### PR TITLE
Back button, navigation cache, and post UI improvements

### DIFF
--- a/src/app/(shell)/@aside/default.tsx
+++ b/src/app/(shell)/@aside/default.tsx
@@ -1,16 +1,11 @@
 "use client";
-import { usePathname } from 'next/navigation';
 import RelatedStacks from "../../../components/RelatedStacks";
 import { useRelatedStacks } from "../related-stacks-context";
 
 export default function DefaultAside() {
-    const pathname = usePathname();
     const { relatedStacks, showUpdate } = useRelatedStacks();
 
-    const isHome = pathname === '/home' || pathname === '/';
-    const isPost = pathname.startsWith('/posts/');
-
-    if ((!isHome && !isPost) || !relatedStacks || relatedStacks.length === 0) return null;
+    if (!relatedStacks || relatedStacks.length === 0) return null;
 
     return (
         <div style={{ width: "100%" }}>

--- a/src/app/(shell)/posts/[id]/page.tsx
+++ b/src/app/(shell)/posts/[id]/page.tsx
@@ -11,6 +11,7 @@ import Post from "../../../../components/Posts/Post";
 import RelatedStacks from "../../../../components/RelatedStacks";
 import RepliesStack from "../../../../components/RepliesStack";
 import ReplySection from "../../../../components/ReplySection";
+import BackButton from "../../../../components/BackButton";
 import { useRelatedStacks } from "../../related-stacks-context";
 
 // -------------------- Types --------------------
@@ -464,6 +465,7 @@ export default function PostView({ params }: { params: { id: string } }) {
 
   return (
     <div ref={mainRef} style={{ position: "relative" }}>
+      <BackButton />
       <div>
         <div style={{ position: "relative" }}>
           {/* Ancestors */}

--- a/src/app/(shell)/tag/[tag]/page.tsx
+++ b/src/app/(shell)/tag/[tag]/page.tsx
@@ -20,12 +20,17 @@ interface TagData {
   following: boolean;
 }
 
+// Module-level cache for tag data so back navigation is instant
+const tagDataCache = new Map<string, TagData>();
+
 export default function TagPage() {
   const params = useParams();
   const tagName = Array.isArray(params.tag) ? params.tag[0] : params.tag;
-  const [tagData, setTagData] = useState<TagData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [isFollowing, setIsFollowing] = useState(false);
+
+  const cached = tagName ? tagDataCache.get(tagName) : undefined;
+  const [tagData, setTagData] = useState<TagData | null>(cached ?? null);
+  const [loading, setLoading] = useState(!cached);
+  const [isFollowing, setIsFollowing] = useState(cached?.following ?? false);
 
   useEffect(() => {
     if (tagName) {
@@ -34,6 +39,7 @@ export default function TagPage() {
   }, [tagName]);
 
   const fetchTagData = async (tag: string) => {
+    if (!loading) setLoading(false); // don't flash if we have cached data
     try {
       const accessToken = localStorage.getItem('accessToken');
       const response = await axios.get(`${MastodonInstanceUrl}/api/v1/tags/${tag}`, {
@@ -43,6 +49,7 @@ export default function TagPage() {
       });
       setTagData(response.data);
       setIsFollowing(response.data.following);
+      tagDataCache.set(tag, response.data);
     } catch (error) {
       console.error('Error fetching tag data:', error);
     } finally {
@@ -52,7 +59,6 @@ export default function TagPage() {
 
   const handleFollowToggle = async () => {
     try {
-      setLoading(true);
       const accessToken = localStorage.getItem('accessToken');
       const url = isFollowing
         ? `${MastodonInstanceUrl}/api/v1/tags/${tagName}/unfollow`
@@ -65,10 +71,12 @@ export default function TagPage() {
       });
 
       setIsFollowing(!isFollowing);
+      // Update cache with new following state
+      if (tagData && tagName) {
+        tagDataCache.set(tagName, { ...tagData, following: !isFollowing });
+      }
     } catch (error) {
       console.error('Error toggling follow status:', error);
-    } finally {
-      setLoading(false);
     }
   };
 

--- a/src/app/(shell)/tag/[tag]/page.tsx
+++ b/src/app/(shell)/tag/[tag]/page.tsx
@@ -21,16 +21,20 @@ interface TagData {
 }
 
 // Module-level cache for tag data so back navigation is instant
-const tagDataCache = new Map<string, TagData>();
+const tagDataCache = new Map<string, TagData & { _ts: number }>();
+const TAG_CACHE_TTL = 5 * 60 * 1000;
+const MAX_TAG_CACHE = 20;
 
 export default function TagPage() {
   const params = useParams();
   const tagName = Array.isArray(params.tag) ? params.tag[0] : params.tag;
 
-  const cached = tagName ? tagDataCache.get(tagName) : undefined;
+  const rawCached = tagName ? tagDataCache.get(tagName) : undefined;
+  const cached = rawCached && Date.now() - rawCached._ts < TAG_CACHE_TTL ? rawCached : undefined;
   const [tagData, setTagData] = useState<TagData | null>(cached ?? null);
   const [loading, setLoading] = useState(!cached);
   const [isFollowing, setIsFollowing] = useState(cached?.following ?? false);
+  const [toggling, setToggling] = useState(false);
 
   useEffect(() => {
     if (tagName) {
@@ -39,7 +43,6 @@ export default function TagPage() {
   }, [tagName]);
 
   const fetchTagData = async (tag: string) => {
-    if (!loading) setLoading(false); // don't flash if we have cached data
     try {
       const accessToken = localStorage.getItem('accessToken');
       const response = await axios.get(`${MastodonInstanceUrl}/api/v1/tags/${tag}`, {
@@ -49,7 +52,11 @@ export default function TagPage() {
       });
       setTagData(response.data);
       setIsFollowing(response.data.following);
-      tagDataCache.set(tag, response.data);
+      tagDataCache.set(tag, { ...response.data, _ts: Date.now() });
+      if (tagDataCache.size > MAX_TAG_CACHE) {
+        const oldest = tagDataCache.keys().next().value;
+        if (oldest !== undefined) tagDataCache.delete(oldest);
+      }
     } catch (error) {
       console.error('Error fetching tag data:', error);
     } finally {
@@ -58,6 +65,8 @@ export default function TagPage() {
   };
 
   const handleFollowToggle = async () => {
+    if (toggling) return;
+    setToggling(true);
     try {
       const accessToken = localStorage.getItem('accessToken');
       const url = isFollowing
@@ -73,10 +82,12 @@ export default function TagPage() {
       setIsFollowing(!isFollowing);
       // Update cache with new following state
       if (tagData && tagName) {
-        tagDataCache.set(tagName, { ...tagData, following: !isFollowing });
+        tagDataCache.set(tagName, { ...tagData, following: !isFollowing, _ts: Date.now() });
       }
     } catch (error) {
       console.error('Error toggling follow status:', error);
+    } finally {
+      setToggling(false);
     }
   };
 
@@ -100,9 +111,9 @@ export default function TagPage() {
           <Button
             color={isFollowing ? 'red' : 'blue'}
             onClick={handleFollowToggle}
-            disabled={loading}
+            disabled={toggling}
           >
-            {loading ? 'Loading...' : (isFollowing ? 'Unfollow hashtag' : 'Follow hashtag')}
+            {toggling ? 'Loading...' : (isFollowing ? 'Unfollow hashtag' : 'Follow hashtag')}
           </Button>
         </Group>
         <Divider my="md" />

--- a/src/app/(shell)/tag/[tag]/page.tsx
+++ b/src/app/(shell)/tag/[tag]/page.tsx
@@ -26,7 +26,6 @@ export default function TagPage() {
   const [tagData, setTagData] = useState<TagData | null>(null);
   const [loading, setLoading] = useState(true);
   const [isFollowing, setIsFollowing] = useState(false);
-  const accessToken = localStorage.getItem('accessToken');
 
   useEffect(() => {
     if (tagName) {
@@ -36,6 +35,7 @@ export default function TagPage() {
 
   const fetchTagData = async (tag: string) => {
     try {
+      const accessToken = localStorage.getItem('accessToken');
       const response = await axios.get(`${MastodonInstanceUrl}/api/v1/tags/${tag}`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -53,6 +53,7 @@ export default function TagPage() {
   const handleFollowToggle = async () => {
     try {
       setLoading(true);
+      const accessToken = localStorage.getItem('accessToken');
       const url = isFollowing
         ? `${MastodonInstanceUrl}/api/v1/tags/${tagName}/unfollow`
         : `${MastodonInstanceUrl}/api/v1/tags/${tagName}/follow`;

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -20,7 +20,7 @@ export default function BackButton() {
   const [label, setLabel] = useState<string | null | undefined>(undefined);
 
   useEffect(() => {
-    const prev = sessionStorage.getItem('previousPath');
+    const prev = sessionStorage.getItem(`previousPath:${window.location.pathname}`);
     if (prev) {
       setLabel(labelFromPath(prev));
     } else {

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -15,21 +15,26 @@ function labelFromPath(path: string): string | null {
   return null;
 }
 
+// 'unchecked' = haven't read sessionStorage yet, 'none' = checked but no previous path
+type BackButtonState = 'unchecked' | 'none' | { label: string | null };
+
 export default function BackButton() {
   const router = useRouter();
-  const [label, setLabel] = useState<string | null | undefined>(undefined);
+  const [state, setState] = useState<BackButtonState>('unchecked');
 
   useEffect(() => {
     const prev = sessionStorage.getItem(`previousPath:${window.location.pathname}`);
     if (prev) {
-      setLabel(labelFromPath(prev));
+      setState({ label: labelFromPath(prev) });
     } else {
-      setLabel(undefined);
+      setState('none');
     }
   }, []);
 
-  // undefined = still loading, don't render yet
-  if (label === undefined) return null;
+  // Haven't checked yet or no previous path — don't render
+  if (state === 'unchecked' || state === 'none') return null;
+
+  const displayLabel = state.label;
 
   return (
     <UnstyledButton
@@ -39,7 +44,7 @@ export default function BackButton() {
       <Group gap={6}>
         <IconArrowLeft size={18} color="#324e93" />
         <Text size="sm" fw={600} c="#324e93">
-          {label ? `Back to ${label}` : 'Back'}
+          {displayLabel ? `Back to ${displayLabel}` : 'Back'}
         </Text>
       </Group>
     </UnstyledButton>

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { UnstyledButton, Text, Group } from '@mantine/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+
+function labelFromPath(path: string): string | null {
+  if (path.startsWith('/tag/')) {
+    const tag = decodeURIComponent(path.replace('/tag/', ''));
+    return `#${tag}`;
+  }
+  if (path === '/' || path === '/home') return 'Home';
+  if (path.startsWith('/user/')) return 'Profile';
+  return null;
+}
+
+export default function BackButton() {
+  const router = useRouter();
+  const [label, setLabel] = useState<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    const prev = sessionStorage.getItem('previousPath');
+    if (prev) {
+      setLabel(labelFromPath(prev));
+    } else {
+      setLabel(undefined);
+    }
+  }, []);
+
+  // undefined = still loading, don't render yet
+  if (label === undefined) return null;
+
+  return (
+    <UnstyledButton
+      onClick={() => router.back()}
+      style={{ marginBottom: '1rem' }}
+    >
+      <Group gap={6}>
+        <IconArrowLeft size={18} color="#324e93" />
+        <Text size="sm" fw={600} c="#324e93">
+          {label ? `Back to ${label}` : 'Back'}
+        </Text>
+      </Group>
+    </UnstyledButton>
+  );
+}

--- a/src/components/InteractionControl.tsx
+++ b/src/components/InteractionControl.tsx
@@ -1,5 +1,5 @@
 import React, { useState, ReactElement } from 'react';
-import { ActionIcon, Text, UnstyledButton } from '@mantine/core';
+import { ActionIcon, Text } from '@mantine/core';
 
 interface InteractionControlProps {
   icon: React.ReactNode;
@@ -18,7 +18,9 @@ export default function InteractionControl({ icon, label, ariaLabel, onClick, ac
   const isActive = hovered || active;
 
   return (
-    <UnstyledButton
+    <div
+      role="button"
+      tabIndex={0}
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -35,7 +37,7 @@ export default function InteractionControl({ icon, label, ariaLabel, onClick, ac
         e.preventDefault();
         e.stopPropagation();
       }}
-      style={{ display: 'flex', alignItems: 'center' }}
+      style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', background: 'none', border: 'none' }}
     >
       <ActionIcon
         variant="subtle"
@@ -45,6 +47,7 @@ export default function InteractionControl({ icon, label, ariaLabel, onClick, ac
         style={{
           backgroundColor: hovered ? 'rgba(75, 116, 220, 0.06)' : 'transparent',
           transition: 'background-color 230ms 60ms ease-in-out, color 230ms 60ms ease-in-out, transform 230ms 60ms ease-in-out',
+          pointerEvents: 'none',
         }}
         styles={{
           root: {
@@ -75,7 +78,7 @@ export default function InteractionControl({ icon, label, ariaLabel, onClick, ac
           {label}
         </Text>
       )}
-    </UnstyledButton>
+    </div>
   );
 }
 

--- a/src/components/InteractionControl.tsx
+++ b/src/components/InteractionControl.tsx
@@ -26,6 +26,13 @@ export default function InteractionControl({ icon, label, ariaLabel, onClick, ac
         e.stopPropagation();
         onClick();
       }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          e.stopPropagation();
+          onClick();
+        }
+      }}
       aria-label={ariaLabel}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -16,6 +16,19 @@ interface PostListCache {
 }
 const postListCacheMap = new Map<string, PostListCache>();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const MAX_CACHE_ENTRIES = 20;
+
+/** Evict expired entries and cap total size */
+function pruneCache<V extends { timestamp: number }>(cache: Map<string, V>, max: number) {
+    const now = Date.now();
+    cache.forEach((value, key) => {
+        if (now - value.timestamp > CACHE_TTL) cache.delete(key);
+    });
+    while (cache.size > max) {
+        const oldest = cache.keys().next().value;
+        if (oldest !== undefined) cache.delete(oldest);
+    }
+}
 
 interface PostListProps {
     apiUrl: string;
@@ -42,15 +55,20 @@ const PostList: React.FC<PostListProps> = ({
     showLoadMore = false,
     ready,
 }) => {
-    // Check cache synchronously during initialization to avoid a loading flash
-    const initialCache = postListCacheMap.get(apiUrl);
-    const hasCachedData = !!initialCache && Date.now() - initialCache.timestamp < CACHE_TTL;
+    // Check cache synchronously during initialization to avoid a loading flash.
+    // Stored in a ref so subsequent renders don't re-evaluate the cache check.
+    const initialCacheRef = useRef(() => {
+        const cached = postListCacheMap.get(apiUrl);
+        return cached && Date.now() - cached.timestamp < CACHE_TTL ? cached : null;
+    });
+    const cachedSnapshot = useRef(initialCacheRef.current());
+    const hasCachedData = !!cachedSnapshot.current;
 
-    const [posts, setPosts] = useState<PostType[]>(() => hasCachedData ? initialCache.posts : []);
+    const [posts, setPosts] = useState<PostType[]>(() => cachedSnapshot.current?.posts ?? []);
     const [loading, setLoading] = useState(() => !hasCachedData);
     const [loadingMore, setLoadingMore] = useState(false);
     const postRefs = useRef<Array<HTMLDivElement | null>>([]);
-    const [maxId, setMaxId] = useState<string | null>(() => hasCachedData ? initialCache.maxId : null);
+    const [maxId, setMaxId] = useState<string | null>(() => cachedSnapshot.current?.maxId ?? null);
     const hasAutoHighlightedFirstPostRef = useRef(false);
     const hasPublishedFirstPostStacksRef = useRef(false);
     const scrollStopTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -311,6 +329,7 @@ const PostList: React.FC<PostListProps> = ({
             maxId,
             timestamp: Date.now(),
         });
+        pruneCache(postListCacheMap, MAX_CACHE_ENTRIES);
     }, [posts, loading, apiUrl, maxId]);
 
     const postElements = posts.map((post: PostType, index) => (

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -7,6 +7,16 @@ import axios from 'axios';
 
 const MastodonInstanceUrl = 'https://beta.stacky.social:3002';
 
+// Module-level cache survives component remounts during SPA navigation
+// without the size limits of sessionStorage
+interface PostListCache {
+    posts: PostType[];
+    maxId: string | null;
+    timestamp: number;
+}
+const postListCacheMap = new Map<string, PostListCache>();
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
 interface PostListProps {
     apiUrl: string;
     handleStackIconClick: (relatedStacks: any[], postId: string, position: { top: number, height: number }) => void;
@@ -50,6 +60,26 @@ const PostList: React.FC<PostListProps> = ({
         const key = `${apiUrl}|${loadStackInfo}|${accessToken}`;
         if (fetchKeyRef.current === key) return; // dedupe in Strict Mode
         fetchKeyRef.current = key;
+
+        // Try to restore from in-memory cache
+        const cached = postListCacheMap.get(apiUrl);
+        if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+            setPosts(cached.posts);
+            setMaxId(cached.maxId);
+            setLoading(false);
+
+            // Restore scroll position
+            const savedY = sessionStorage.getItem(`scrollY:${window.location.pathname}`);
+            if (savedY) {
+                requestAnimationFrame(() => {
+                    window.scrollTo(0, parseInt(savedY, 10));
+                });
+                sessionStorage.removeItem(`scrollY:${window.location.pathname}`);
+            }
+            return;
+        }
+
+        postListCacheMap.delete(apiUrl);
         fetchPosts();
     }, [apiUrl, accessToken, loadStackInfo, ready]);
 
@@ -95,7 +125,9 @@ const PostList: React.FC<PostListProps> = ({
             }));
 
             setPosts((prevPosts) => isLoadMore ? [...prevPosts, ...data] : data);
-            setMaxId(data[data.length - 1].postId);
+            if (data.length > 0) {
+                setMaxId(data[data.length - 1].postId);
+            }
 
             if (loadStackInfo) {
                 await loadStackDataInBatches(data, 2);
@@ -267,6 +299,16 @@ const PostList: React.FC<PostListProps> = ({
             }));
         }
     };
+
+    // Save to in-memory cache whenever posts update (even partially loaded stacks)
+    useEffect(() => {
+        if (loading || posts.length === 0) return;
+        postListCacheMap.set(apiUrl, {
+            posts,
+            maxId,
+            timestamp: Date.now(),
+        });
+    }, [posts, loading, apiUrl, maxId]);
 
     const postElements = posts.map((post: PostType, index) => (
         <div

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -13,6 +13,7 @@ interface PostListCache {
     posts: PostType[];
     maxId: string | null;
     timestamp: number;
+    fetchedAt: number;
 }
 const postListCacheMap = new Map<string, PostListCache>();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -59,7 +60,7 @@ const PostList: React.FC<PostListProps> = ({
     // Stored in a ref so subsequent renders don't re-evaluate the cache check.
     const initialCacheRef = useRef(() => {
         const cached = postListCacheMap.get(apiUrl);
-        return cached && Date.now() - cached.timestamp < CACHE_TTL ? cached : null;
+        return cached ?? null;
     });
     const cachedSnapshot = useRef(initialCacheRef.current());
     const hasCachedData = !!cachedSnapshot.current;
@@ -97,12 +98,39 @@ const PostList: React.FC<PostListProps> = ({
         if (fetchKeyRef.current === key) return; // dedupe in Strict Mode
         fetchKeyRef.current = key;
 
-        // If initialized from cache, skip fetching
-        if (hasCachedData) return;
+        if (hasCachedData) {
+            // Serve cache instantly, revalidate in background
+            revalidate();
+            return;
+        }
 
         postListCacheMap.delete(apiUrl);
         fetchPosts();
     }, [apiUrl, accessToken, loadStackInfo, ready]);
+
+    const mapResponseToPosts = (data: any[]): PostType[] =>
+        data.map((post: any) => ({
+            postId: post.id,
+            text: post.content,
+            author: post.account.username,
+            account: post.account.acct,
+            avatar: post.account.avatar,
+            createdAt: post.created_at,
+            replies: post.replies_count,
+            replies_count: post.replies_count,
+            stackCount: loadStackInfo ? null : -1,
+            favouritesCount: post.favourites_count,
+            favourited: post.favourited,
+            bookmarked: post.bookmarked,
+            mediaAttachments: post.media_attachments,
+            relatedStacks: [],
+            previewCard: post.card ? {
+                title: post.card.title,
+                description: post.card.description,
+                image: post.card.image || undefined,
+                url: post.card.url,
+            } : null
+        }));
 
     const fetchPosts = async (isLoadMore = false) => {
         try {
@@ -123,27 +151,7 @@ const PostList: React.FC<PostListProps> = ({
                 }
             });
 
-            const data: PostType[] = response.data.map((post: any) => ({
-                postId: post.id,
-                text: post.content,
-                author: post.account.username,
-                account: post.account.acct,
-                avatar: post.account.avatar,
-                createdAt: post.created_at,
-                replies: post.replies_count,
-                stackCount: loadStackInfo ? null : -1,
-                favouritesCount: post.favourites_count,
-                favourited: post.favourited,
-                bookmarked: post.bookmarked,
-                mediaAttachments: post.media_attachments,
-                relatedStacks: [],
-                previewCard: post.card ? {
-                    title: post.card.title,
-                    description: post.card.description,
-                    image: post.card.image || undefined,
-                    url: post.card.url,
-                } : null
-            }));
+            const data: PostType[] = mapResponseToPosts(response.data);
 
             setPosts((prevPosts) => isLoadMore ? [...prevPosts, ...data] : data);
             if (data.length > 0) {
@@ -168,6 +176,98 @@ const PostList: React.FC<PostListProps> = ({
 
     const handleLoadMore = () => {
         fetchPosts(true);
+    };
+
+    const getScrollAnchor = (): { postId: string; offsetFromViewport: number } | null => {
+        const els = Array.from(document.querySelectorAll('[data-post-id]'));
+        for (const el of els) {
+            const rect = el.getBoundingClientRect();
+            if (rect.top >= 0 && rect.top < window.innerHeight) {
+                return {
+                    postId: el.getAttribute('data-post-id')!,
+                    offsetFromViewport: rect.top,
+                };
+            }
+        }
+        return null;
+    };
+
+    const revalidate = async () => {
+        try {
+            const headers: Record<string, string> = {};
+            if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+
+            const response = await axios.get(apiUrl, {
+                headers,
+                params: { limit: 40 },
+            });
+
+            const freshPosts: PostType[] = mapResponseToPosts(response.data);
+
+            // Capture scroll anchor before updating state
+            const anchor = getScrollAnchor();
+
+            setPosts((prev) => {
+                const prevMap = new Map(prev.map(p => [p.postId, p]));
+                const merged: PostType[] = [];
+
+                for (const fp of freshPosts) {
+                    const existing = prevMap.get(fp.postId);
+                    if (existing) {
+                        // Keep loaded stack data from cache, update everything else
+                        merged.push({
+                            ...fp,
+                            stackCount: existing.stackCount !== null ? existing.stackCount : fp.stackCount,
+                            relatedStacks: existing.relatedStacks.length > 0 ? existing.relatedStacks : fp.relatedStacks,
+                        });
+                        prevMap.delete(fp.postId);
+                    } else {
+                        merged.push(fp);
+                    }
+                }
+
+                // Append any remaining old posts (from Load More) that weren't in the fresh page
+                prevMap.forEach((p) => merged.push(p));
+
+                return merged;
+            });
+
+            // Update maxId for Load More continuity
+            if (freshPosts.length > 0) {
+                setMaxId(freshPosts[freshPosts.length - 1].postId);
+            }
+
+            // Restore scroll position after merge
+            if (anchor) {
+                requestAnimationFrame(() => {
+                    const el = document.querySelector(`[data-post-id="${anchor.postId}"]`);
+                    if (el) {
+                        const newTop = el.getBoundingClientRect().top;
+                        const drift = newTop - anchor.offsetFromViewport;
+                        if (Math.abs(drift) > 1) {
+                            window.scrollBy(0, drift);
+                        }
+                    }
+                });
+            }
+
+            // Update fetchedAt in cache
+            const cached = postListCacheMap.get(apiUrl);
+            if (cached) {
+                cached.fetchedAt = Date.now();
+            }
+
+            // Reload stack data for new posts that don't have it yet
+            if (loadStackInfo) {
+                const postsNeedingStacks = freshPosts.filter(p => p.stackCount === null);
+                if (postsNeedingStacks.length > 0) {
+                    await loadStackDataInBatches(postsNeedingStacks, 2);
+                }
+            }
+        } catch {
+            // Silent failure — user already has cached content
+            console.warn('Background revalidation failed');
+        }
     };
 
     useEffect(() => {
@@ -311,11 +411,11 @@ const PostList: React.FC<PostListProps> = ({
                     );
                 } catch (error) {
                     console.error(`Error fetching stack data for post ${post.postId}:`, error);
-                    notifications.show({
-                        color: 'red',
-                        title: 'Failed to load stacks',
-                        message: `Post ${post.postId}: please try again later.`,
-                    });
+                    // notifications.show({
+                    //     color: 'red',
+                    //     title: 'Failed to load stacks',
+                    //     message: `Post ${post.postId}: please try again later.`,
+                    // });
                 }
             }));
         }
@@ -328,6 +428,7 @@ const PostList: React.FC<PostListProps> = ({
             posts,
             maxId,
             timestamp: Date.now(),
+            fetchedAt: Date.now(),
         });
         pruneCache(postListCacheMap, MAX_CACHE_ENTRIES);
     }, [posts, loading, apiUrl, maxId]);
@@ -335,6 +436,7 @@ const PostList: React.FC<PostListProps> = ({
     const postElements = posts.map((post: PostType, index) => (
         <div
             key={post.postId}
+            data-post-id={post.postId}
             ref={(el) => {
                 postRefs.current[index] = el;
             }}

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -42,11 +42,15 @@ const PostList: React.FC<PostListProps> = ({
     showLoadMore = false,
     ready,
 }) => {
-    const [posts, setPosts] = useState<PostType[]>([]);
-    const [loading, setLoading] = useState(true);
+    // Check cache synchronously during initialization to avoid a loading flash
+    const initialCache = postListCacheMap.get(apiUrl);
+    const hasCachedData = !!initialCache && Date.now() - initialCache.timestamp < CACHE_TTL;
+
+    const [posts, setPosts] = useState<PostType[]>(() => hasCachedData ? initialCache.posts : []);
+    const [loading, setLoading] = useState(() => !hasCachedData);
     const [loadingMore, setLoadingMore] = useState(false);
     const postRefs = useRef<Array<HTMLDivElement | null>>([]);
-    const [maxId, setMaxId] = useState<string | null>(null);
+    const [maxId, setMaxId] = useState<string | null>(() => hasCachedData ? initialCache.maxId : null);
     const hasAutoHighlightedFirstPostRef = useRef(false);
     const hasPublishedFirstPostStacksRef = useRef(false);
     const scrollStopTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -54,6 +58,20 @@ const PostList: React.FC<PostListProps> = ({
     const manualActiveIdRef = useRef<string | null>(null);
     const manualLockRef = useRef(false);
     const fetchKeyRef = useRef<string | null>(null);
+    const restoredScrollRef = useRef(false);
+
+    // Restore scroll position after first paint when using cached data
+    useEffect(() => {
+        if (!hasCachedData || restoredScrollRef.current) return;
+        restoredScrollRef.current = true;
+        const savedY = sessionStorage.getItem(`scrollY:${window.location.pathname}`);
+        if (savedY) {
+            requestAnimationFrame(() => {
+                window.scrollTo(0, parseInt(savedY, 10));
+            });
+            sessionStorage.removeItem(`scrollY:${window.location.pathname}`);
+        }
+    }, []);
 
     useEffect(() => {
         if (!ready) return; // wait for token check
@@ -61,23 +79,8 @@ const PostList: React.FC<PostListProps> = ({
         if (fetchKeyRef.current === key) return; // dedupe in Strict Mode
         fetchKeyRef.current = key;
 
-        // Try to restore from in-memory cache
-        const cached = postListCacheMap.get(apiUrl);
-        if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-            setPosts(cached.posts);
-            setMaxId(cached.maxId);
-            setLoading(false);
-
-            // Restore scroll position
-            const savedY = sessionStorage.getItem(`scrollY:${window.location.pathname}`);
-            if (savedY) {
-                requestAnimationFrame(() => {
-                    window.scrollTo(0, parseInt(savedY, 10));
-                });
-                sessionStorage.removeItem(`scrollY:${window.location.pathname}`);
-            }
-            return;
-        }
+        // If initialized from cache, skip fetching
+        if (hasCachedData) return;
 
         postListCacheMap.delete(apiUrl);
         fetchPosts();

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -2,8 +2,8 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Text, Avatar, Group, Paper, UnstyledButton, Divider, Anchor } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { IconHeart, IconBookmark, IconNote, IconMessageCircle, IconHeartFilled, IconBookmarkFilled, IconLink } from '@tabler/icons-react';
-import { formatDistanceToNow } from 'date-fns';
+import { IconHeart, IconBookmark, IconNote, IconMessageCircle, IconHeartFilled, IconBookmarkFilled, IconLink, IconCheck } from '@tabler/icons-react';
+import { format, formatDistanceToNow } from 'date-fns';
 import StackCount from '../StackCount';
 import axios from 'axios';
 import AnnotationModal from '../AnnotationModal';
@@ -121,8 +121,10 @@ export default function Post({
   const handleNavigate = () => {
     const url = `/posts/${id}`;
     localStorage.setItem('relatedStacks', JSON.stringify(tempRelatedStacks));
- 
+
     localStorage.setItem('relatedStacksSize', JSON.stringify(stackCount));
+    sessionStorage.setItem('previousPath', window.location.pathname);
+    sessionStorage.setItem(`scrollY:${window.location.pathname}`, String(window.scrollY));
     router.push(url);
   };
 
@@ -361,9 +363,11 @@ export default function Post({
   </UnstyledButton>
 )}
 
-        <UnstyledButton
+        <div
           onClick={handleSingleClick}
-          style={{ width: '100%' }}
+          role="button"
+          tabIndex={0}
+          style={{ width: '100%', cursor: 'pointer' }}
         >
           <Group>
             <UnstyledButton onClick={handleNavigateToUser} className="avatarHoverDim">
@@ -384,7 +388,7 @@ export default function Post({
               <Text size="xs" c="dimmed">{formatDistanceToNow(new Date(createdAt))} ago</Text>
             </div>
           </Group>
-        </UnstyledButton>
+        </div>
 
         <div
           style={{ paddingLeft: '3rem', paddingRight:'3rem', cursor: 'pointer'}}

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -169,7 +169,10 @@ export default function Post({
   };
 
   const handleReply = () => {
-    router.push(`/posts/${id}`);
+    const url = `/posts/${id}`;
+    sessionStorage.setItem(`previousPath:${url}`, window.location.pathname);
+    sessionStorage.setItem(`scrollY:${window.location.pathname}`, String(window.scrollY));
+    router.push(url);
   };
 
   const getAccessToken = () => {

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -407,6 +407,12 @@ export default function Post({
 
         <div
           onClick={handleSingleClick}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleNavigate();
+            }
+          }}
           role="button"
           tabIndex={0}
           style={{ width: '100%', cursor: 'pointer' }}

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -2,18 +2,57 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Text, Avatar, Group, Paper, UnstyledButton, Divider, Anchor } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { IconHeart, IconBookmark, IconNote, IconMessageCircle, IconHeartFilled, IconBookmarkFilled, IconLink, IconCheck } from '@tabler/icons-react';
+import { IconHeart, IconBookmark, IconNote, IconMessageCircle, IconHeartFilled, IconBookmarkFilled, IconLink } from '@tabler/icons-react';
 import { format, formatDistanceToNow } from 'date-fns';
 import StackCount from '../StackCount';
 import axios from 'axios';
 import AnnotationModal from '../AnnotationModal';
-import LinkPreviewCard from '../LinkPreviewCard';
 import { PreviewCardType } from '../../types/PostType';
 import InteractionControl from '../InteractionControl';
 
 type PreviewCard = PreviewCardType;
 
 const MastodonInstanceUrl = 'https://beta.stacky.social';
+
+interface CleanedPost {
+  html: string;
+  publishedDate: string | null;
+  articleUrl: string | null;
+}
+
+/** Strip external URLs and extract "Published" date from post HTML */
+function cleanPostHtml(html: string, card: PreviewCard | null | undefined): CleanedPost {
+  let cleaned = html;
+
+  // Remove all <a> tags linking to external URLs (entire tag + contents)
+  cleaned = cleaned.replace(/<a[^>]*href=["']https?:\/\/[^"']+["'][^>]*>[\s\S]*?<\/a>/gi, '');
+
+  // Remove bare URLs in text (not inside tags)
+  cleaned = cleaned.replace(/https?:\/\/[^\s<]+/g, '');
+
+  // Extract "Published: DATE" and remove from text
+  let publishedDate: string | null = null;
+  cleaned = cleaned.replace(/Published:\s*(\d{4}-\d{2}-\d{2}T[\d:.]+Z?)/g, (_match, iso) => {
+    try {
+      publishedDate = format(new Date(iso), 'MMM d, yyyy');
+    } catch {
+      publishedDate = iso;
+    }
+    return '';
+  });
+  // Also handle already-formatted "Published: Mon DD, YYYY"
+  if (!publishedDate) {
+    cleaned = cleaned.replace(/Published:\s*([A-Z][a-z]+ \d{1,2}, \d{4})/g, (_match, date) => {
+      publishedDate = date;
+      return '';
+    });
+  }
+
+  // Collapse leftover empty <p></p> tags
+  cleaned = cleaned.replace(/<p>\s*<\/p>/g, '');
+
+  return { html: cleaned, publishedDate, articleUrl: card?.url ?? null };
+}
 
 
 
@@ -77,6 +116,7 @@ export default function Post({
 
   const [previewCards, setPreviewCards] = useState<PreviewCard[]>(initialCard ? [initialCard] : []);
   const [tempRelatedStacks, setTempRelatedStacks] = useState<any[]>(relatedStacks);
+  const { html: displayText, publishedDate, articleUrl } = cleanPostHtml(text, previewCards[0]);
 
   const [isOverflowing, setIsOverflowing] = useState(false);
   const textRef = useRef<HTMLDivElement>(null);
@@ -123,7 +163,7 @@ export default function Post({
     localStorage.setItem('relatedStacks', JSON.stringify(tempRelatedStacks));
 
     localStorage.setItem('relatedStacksSize', JSON.stringify(stackCount));
-    sessionStorage.setItem('previousPath', window.location.pathname);
+    sessionStorage.setItem(`previousPath:${url}`, window.location.pathname);
     sessionStorage.setItem(`scrollY:${window.location.pathname}`, String(window.scrollY));
     router.push(url);
   };
@@ -230,13 +270,9 @@ export default function Post({
     setAnnotationModalOpen(true);
   };
 
-  const handleCopyLink = () => {
-    const url = `${window.location.origin}/posts/${id}`;
-    navigator.clipboard.writeText(url).then(() => {
-
-    }).catch((error) => {
-      console.error('Error copying link:', error);
-    });
+  const handleOpenInNewTab = () => {
+    const url = articleUrl || `${window.location.origin}/posts/${id}`;
+    window.open(url, '_blank');
   };
 
   const handleStackCountClick = async () => {
@@ -407,7 +443,7 @@ export default function Post({
           lineHeight: '1.5',
           color: '#011445'
         }}
-        dangerouslySetInnerHTML={{ __html: text }}
+        dangerouslySetInnerHTML={{ __html: displayText }}
       />
       {isOverflowing && (
         <Anchor
@@ -443,15 +479,30 @@ export default function Post({
             </div>
           )}
 
-          {previewCards.slice(0, 1).map((card, index) => (
-            <LinkPreviewCard
-              key={index}
-              url={card.url}
-              title={card.title}
-              description={card.description}
-              imageUrl={card.image}
-            />
-          ))}
+          {previewCards.slice(0, 1).map((card, index) =>
+            card.image ? (
+              <a
+                key={index}
+                href={card.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                onMouseUp={(e) => e.stopPropagation()}
+                style={{ display: 'block', marginTop: '0.5rem', marginRight: '0.5rem' }}
+              >
+                <img
+                  src={card.image}
+                  alt={card.title}
+                  style={{ width: '100%', borderRadius: '8px', display: 'block' }}
+                />
+              </a>
+            ) : null
+          )}
+          {publishedDate && (
+            <Text size="xs" c="dimmed" style={{ marginTop: '0.5rem' }}>
+              Published: {publishedDate}
+            </Text>
+          )}
         </div>
 
         <Divider style={{ marginTop:'1.5rem'}}/>
@@ -483,8 +534,8 @@ export default function Post({
             />
             <InteractionControl
               icon={<IconLink size={20} />}
-              ariaLabel="Copy link"
-              onClick={handleCopyLink}
+              ariaLabel="Open in new tab"
+              onClick={handleOpenInNewTab}
             />
           </Group>
         </div>

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -20,18 +20,21 @@ interface CleanedPost {
   articleUrl: string | null;
 }
 
-/** Strip external URLs and extract "Published" date from post HTML */
+/** Strip external URLs and extract "Published" date from post HTML.
+ *  Only strips URLs when a preview card exists to preserve legitimate links in conversational posts. */
 function cleanPostHtml(html: string, card: PreviewCard | null | undefined): CleanedPost {
   let cleaned = html;
+  let publishedDate: string | null = null;
 
-  // Remove all <a> tags linking to external URLs (entire tag + contents)
-  cleaned = cleaned.replace(/<a[^>]*href=["']https?:\/\/[^"']+["'][^>]*>[\s\S]*?<\/a>/gi, '');
+  if (card) {
+    // Remove all <a> tags linking to external URLs (entire tag + contents)
+    cleaned = cleaned.replace(/<a[^>]*href=["']https?:\/\/[^"']+["'][^>]*>[\s\S]*?<\/a>/gi, '');
 
-  // Remove bare URLs in text (not inside tags)
-  cleaned = cleaned.replace(/https?:\/\/[^\s<]+/g, '');
+    // Remove bare URLs in text (not inside tags)
+    cleaned = cleaned.replace(/https?:\/\/[^\s<]+/g, '');
+  }
 
   // Extract "Published: DATE" and remove from text
-  let publishedDate: string | null = null;
   cleaned = cleaned.replace(/Published:\s*(\d{4}-\d{2}-\d{2}T[\d:.]+Z?)/g, (_match, iso) => {
     try {
       publishedDate = format(new Date(iso), 'MMM d, yyyy');

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -201,7 +201,9 @@ function mergeHighlight(contentHighlight: string, rewriteContent: string) {
   const parsed2 = parseHighlight(rewriteContent, 'blue');
 
   if (parsed1.plainText !== parsed2.plainText) {
-    console.warn('Warning: highlight plain texts not matching!');
+    // Plain texts diverged — merging highlights would produce garbled output.
+    // Return empty so callers fall back to plain formatted content.
+    return '';
   }
 
   const merged = mergeHighlights(parsed1.plainText, parsed1.highlights, parsed2.highlights);
@@ -293,7 +295,7 @@ function mergeHighlight(contentHighlight: string, rewriteContent: string) {
         // 优先使用开关状态；若未开启开关，维持原有 hover 合并高亮的体验
         const contentToDisplay = (showOriginalContent[index] === true)
           ? (stack.topPost.content_highlight && stack.topPost.rewrite?.content
-              ? mergeHighlight(stack.topPost.content_highlight, stack.topPost.rewrite.content)
+              ? (mergeHighlight(stack.topPost.content_highlight, stack.topPost.rewrite.content) || formatContent(stack.topPost.content ?? '').__html)
               : formatContent(stack.topPost.content ?? '').__html)
           : (stack.topPost.rewrite.significant && (showAIRewrite[index] !== false)
               ? formatContent(stack.topPost.rewrite.content ?? '').__html

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -213,6 +213,8 @@ function mergeHighlight(contentHighlight: string, rewriteContent: string) {
 
   const handleNavigate = (postId: string, newStackId: string) => {
     const url = `/posts/${postId}?stackId=${newStackId || ''}`;
+    sessionStorage.setItem('previousPath', window.location.pathname);
+    sessionStorage.setItem(`scrollY:${window.location.pathname}`, String(window.scrollY));
     router.push(url);
   };
 

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -213,7 +213,7 @@ function mergeHighlight(contentHighlight: string, rewriteContent: string) {
 
   const handleNavigate = (postId: string, newStackId: string) => {
     const url = `/posts/${postId}?stackId=${newStackId || ''}`;
-    sessionStorage.setItem('previousPath', window.location.pathname);
+    sessionStorage.setItem(`previousPath:/posts/${postId}`, window.location.pathname);
     sessionStorage.setItem(`scrollY:${window.location.pathname}`, String(window.scrollY));
     router.push(url);
   };

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -79,9 +79,10 @@ export default function SearchBar() {
       return;
     }
 
+    if (!searchQuery.trim()) return;
     try {
       const response = await axios.get(`${MastodonInstanceUrl}/api/v2/search`, {
-        params: { q: searchQuery, limit: 10 },
+        params: { q: searchQuery, limit: 10, resolve: true },
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -102,7 +103,10 @@ export default function SearchBar() {
     setLoadingRelatedStacks(true);
 
     try {
-      const response = await axios.get(`${MastodonInstanceUrl}:3002/stacks/${post.id}/related`);
+      const headers: Record<string, string> = {};
+      if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+
+      const response = await axios.get(`${MastodonInstanceUrl}:3002/stacks/${post.id}/related`, { headers });
       console.log('Related stacks:', response.data);
       const stackData = response.data.relatedStacks || [];
       const stackCount = response.data.size;
@@ -121,14 +125,13 @@ export default function SearchBar() {
 
     } catch (error) {
       console.error('Error fetching related stacks:', error);
-      notifications.show({ color: 'red', title: 'Failed to load stacks', message: 'Please try again later.' });
     } finally {
       setLoadingRelatedStacks(false);
     }
   };
 
   useEffect(() => {
-    console.log('ResultPosts:', ResultPosts);
+    // console.log('ResultPosts:', ResultPosts);
   }, [ResultPosts]);
 
   const handleSearch = () => {

--- a/src/components/StackPostsModal.tsx
+++ b/src/components/StackPostsModal.tsx
@@ -280,6 +280,7 @@ function StackPostsModal({ isOpen, onClose, apiUrl, stackId }: StackPostsModalPr
                 handleStackIconClick={handleStackIconClick}
                 loadStackInfo={false}
                 accessToken={accessToken}
+                ready={true}
                 setIsModalOpen={() => { }}
                 setIsExpandModalOpen={() => { }}
                 activePostId={null}


### PR DESCRIPTION
## Summary
- **Back button** on post detail pages with contextual labels ("Back to #tagname", "Back to Home", or plain "Back") that persists correctly across multi-level navigation
- **Navigation cache** using module-level Maps for both PostList data and tag page metadata — back navigation renders instantly with no loading flash and restores scroll position
- **Stale-while-revalidate (SWR)** — cached posts are always served instantly on mount, then silently revalidated in the background. No more loading spinner when cache TTL expires; content updates seamlessly with scroll anchoring to prevent layout shifts
- **Post UI cleanup** — external URLs and "Published" dates are extracted from post body text (no more duplication with embed), card embeds show just the image, link button opens the article source in a new tab
- **Highlight mismatch fix** — RelatedStacks gracefully falls back to plain content when highlight plain texts diverge, instead of producing garbled output
- **Quieter error handling** — stack load failure toasts disabled (console logging preserved)

## Test plan
- [x] Navigate to `/tag/[tag]`, click a post, verify back button shows "Back to #tagname"
- [x] Click back — page loads instantly from cache at the same scroll position
- [x] From a post, click another post — back button shows "Back", then going back again shows "Back to #tagname"
- [x] Verify link button opens the article URL in a new tab
- [x] Verify post text no longer shows duplicate URLs or titles from embedded links
- [x] Verify "Published" date appears below the image, formatted nicely
- [x] Direct URL entry to a post — no back button shown
- [x] Navigate back after cache exists — posts appear instantly, background revalidation updates silently (no spinner)
- [x] If new posts were added since last visit, they appear at top without scroll jump
- [x] Load More still works after revalidation merges fresh first page
- [ ] Stack counts/related stacks from cache are preserved during revalidation
- [ ] No error toasts on stack load failure (only console logs)
- [ ] RelatedStacks highlight mismatch shows plain content instead of garbled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)