### PR TITLE
Polish related-panel tooltip and label format

### DIFF
--- a/docs/superpowers/plans/2026-05-13-group-b-tooltip-and-label.md
+++ b/docs/superpowers/plans/2026-05-13-group-b-tooltip-and-label.md
@@ -1,0 +1,630 @@
+# Group B — Tooltip & Label Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-render `SeeMoreTooltip` in `RelatedStacks.tsx` with a single global cursor-following tooltip primitive, apply the new "N more **Topic**" format in the tooltip and the show-more-link button, and hide both when the topic is missing (with a diagnostic warning).
+
+**Architecture:** A new `HoverTooltip` primitive renders into a `document.body` portal and is driven by an imperative `showTooltip` / `hideTooltip` API backed by a tiny module-level store. The single mounted instance lives in `Shell.tsx`. Existing `<mark>` handlers in `RelatedStacks.tsx` call the imperative API instead of rendering inline tooltip JSX.
+
+**Tech Stack:** Next.js 14 App Router, React 18, TypeScript, Mantine v7, `react-dom`'s `createPortal`. No new dependencies. No test framework available — verification is `pnpm lint`, `pnpm build` (`tsc`), and manual browser walk-through.
+
+**Spec:** [docs/superpowers/specs/2026-05-13-group-b-tooltip-and-label-design.md](../specs/2026-05-13-group-b-tooltip-and-label-design.md) (commit `19dc10c`).
+
+**Branch:** `claude/unruffled-einstein-13834c` (current worktree).
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `src/components/HoverTooltip.tsx` | **Create** | Single-instance portal-mounted tooltip + imperative `showTooltip` / `hideTooltip` + internal store. |
+| `src/app/(shell)/Shell.tsx` | Modify | Mount `<HoverTooltip />` once at the shell root so the portal target exists for all authenticated routes. |
+| `src/components/RelatedStacks.tsx` | Modify | Replace `SeeMoreTooltip` rendering with `showTooltip`/`hideTooltip` calls inside existing `<mark>` handlers; apply bold + category-color format; gate `showMoreLink` and tooltip on `!!anchorTopic`; add missing-topic warning helper. |
+
+No other files touched. No new dependencies.
+
+---
+
+## Task 1: Create the `HoverTooltip` primitive
+
+**Files:**
+- Create: `src/components/HoverTooltip.tsx`
+
+- [ ] **Step 1.1: Create the file with the complete primitive**
+
+Write `src/components/HoverTooltip.tsx`:
+
+```tsx
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+export interface TooltipColors {
+  text: string;
+  border: string;
+}
+
+interface TooltipState {
+  visible: boolean;
+  content: React.ReactNode;
+  colors: TooltipColors;
+  initialX: number;
+  initialY: number;
+}
+
+const DEFAULT_COLORS: TooltipColors = { text: "#334155", border: "#cbd5e1" };
+
+const initialState: TooltipState = {
+  visible: false,
+  content: null,
+  colors: DEFAULT_COLORS,
+  initialX: -9999,
+  initialY: -9999,
+};
+
+type Listener = (state: TooltipState) => void;
+
+const listeners = new Set<Listener>();
+let currentState: TooltipState = initialState;
+
+function setState(partial: Partial<TooltipState>) {
+  currentState = { ...currentState, ...partial };
+  listeners.forEach((l) => l(currentState));
+}
+
+export function showTooltip(opts: {
+  content: React.ReactNode;
+  colors: TooltipColors;
+  x: number;
+  y: number;
+}): void {
+  setState({
+    visible: true,
+    content: opts.content,
+    colors: opts.colors,
+    initialX: opts.x,
+    initialY: opts.y,
+  });
+}
+
+export function hideTooltip(): void {
+  setState({ visible: false, content: null });
+}
+
+export function HoverTooltip(): JSX.Element | null {
+  const [state, setLocalState] = useState<TooltipState>(currentState);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const listener: Listener = (s) => setLocalState(s);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  // Position on initial show + continuous follow while visible.
+  useEffect(() => {
+    if (!state.visible) return;
+
+    const position = (clientX: number, clientY: number) => {
+      const el = nodeRef.current;
+      if (!el) return;
+      const tw = el.offsetWidth;
+      const th = el.offsetHeight;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const offsetX = 14;
+      const offsetY = 18;
+      let x = clientX + offsetX;
+      let y = clientY + offsetY;
+      if (x + tw > vw - 8) x = vw - tw - 8;
+      if (x < 8) x = 8;
+      if (y + th > vh - 8) y = clientY - offsetY - th;
+      if (y < 8) y = 8;
+      el.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+    };
+
+    // Position once with the cursor location captured at show time.
+    position(state.initialX, state.initialY);
+
+    const onMove = (e: MouseEvent) => position(e.clientX, e.clientY);
+    window.addEventListener("mousemove", onMove);
+    return () => window.removeEventListener("mousemove", onMove);
+  }, [state.visible, state.initialX, state.initialY]);
+
+  if (typeof document === "undefined") return null;
+  if (!state.visible) return null;
+
+  return createPortal(
+    <div
+      ref={nodeRef}
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        transform: "translate3d(-9999px, -9999px, 0)",
+        pointerEvents: "none",
+        zIndex: 10000,
+        background: "rgba(255,255,255,0.92)",
+        backdropFilter: "blur(10px)",
+        WebkitBackdropFilter: "blur(10px)",
+        borderRadius: 8,
+        padding: "4px 10px",
+        boxShadow:
+          "0 4px 14px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.05)",
+        border: `1px solid ${state.colors.border}55`,
+        fontSize: 11,
+        fontWeight: 600,
+        color: state.colors.text,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {state.content}
+    </div>,
+    document.body,
+  );
+}
+```
+
+- [ ] **Step 1.2: Verify the file type-checks**
+
+Run: `pnpm build`
+Expected: build completes without errors. The new file should not be referenced anywhere yet, so this only confirms its own types are valid. If `pnpm build` is slow, you can run `pnpm exec tsc --noEmit -p .` for a faster type-only check.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add src/components/HoverTooltip.tsx
+git commit -m "Add HoverTooltip primitive for cursor-following tooltips"
+```
+
+---
+
+## Task 2: Mount `<HoverTooltip />` in the shell
+
+**Files:**
+- Modify: `src/app/(shell)/Shell.tsx`
+
+- [ ] **Step 2.1: Add the import**
+
+In `src/app/(shell)/Shell.tsx`, add this import alongside the existing component imports (after the `RelatedStacksProvider` import on line 8):
+
+```tsx
+import { HoverTooltip } from '../../components/HoverTooltip';
+```
+
+- [ ] **Step 2.2: Render the tooltip once inside the provider**
+
+In `src/app/(shell)/Shell.tsx`, find the line `</AppShell>` (line 77) and add `<HoverTooltip />` immediately after it (still inside `<RelatedStacksProvider>`). The relevant region becomes:
+
+```tsx
+            <AppShell.Main miw={500}>
+                {children}
+            </AppShell.Main>
+        </AppShell>
+        <HoverTooltip />
+        <Burger
+            opened={!navCollapsed}
+            onClick={toggleNav}
+```
+
+(Placement is after `</AppShell>` but before the existing fixed `<Burger>`; both are siblings of the AppShell and live inside `RelatedStacksProvider`.)
+
+- [ ] **Step 2.3: Verify build and lint pass**
+
+Run: `pnpm build && pnpm lint`
+Expected: both succeed. No visible change in the browser yet — nothing calls `showTooltip`.
+
+- [ ] **Step 2.4: Manual sanity check that nothing regressed**
+
+Run `pnpm dev`. Open `http://localhost:3000`, sign in if needed, navigate to a post-detail page (`/posts/[id]`) so the related panel is visible. Confirm:
+- The page loads.
+- Hovering related-post highlights still shows the **old** floating tooltip (since `RelatedStacks.tsx` still renders `SeeMoreTooltip` inline; nothing was migrated yet).
+- No console errors.
+
+This catches a broken mount before any behavioral changes are mixed in.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/app/\(shell\)/Shell.tsx
+git commit -m "Mount HoverTooltip at shell root"
+```
+
+---
+
+## Task 3: Add the missing-topic warning helper and a topic-label renderer in `RelatedStacks.tsx`
+
+**Files:**
+- Modify: `src/components/RelatedStacks.tsx`
+
+This task only adds new helpers — it does not yet touch the existing tooltip render or button text. Keeping the helpers as a separate commit makes the migration commit (Task 4) read cleanly.
+
+- [ ] **Step 3.1: Add the imports at the top of `RelatedStacks.tsx`**
+
+Find the existing imports at the top of `src/components/RelatedStacks.tsx` and add this import alongside them:
+
+```tsx
+import { showTooltip, hideTooltip, type TooltipColors } from './HoverTooltip';
+```
+
+- [ ] **Step 3.2: Add module-level helpers above the `SeeMoreTooltip` definition**
+
+Insert the following block immediately before the existing `// ─── Passive "See more like this" tooltip` comment block (which currently starts at line 109):
+
+```tsx
+// ─── Missing-topic diagnostic (rate-limited) ─────────────────────────────────
+// Surface data-integrity issues (relations with no `topic`) in study logs
+// without spamming the console. One warning per (stackId, rangeIndex) pair
+// per session; the tooltip and "X more" button are suppressed in that case.
+const warnedMissingTopic = new Set<string>();
+function warnMissingTopic(stackId: string, rangeIndex: number): void {
+  const key = `${stackId}:${rangeIndex}`;
+  if (warnedMissingTopic.has(key)) return;
+  warnedMissingTopic.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[stacky] missing topic on relation; tooltip/button suppressed',
+    { stackId, rangeIndex },
+  );
+}
+
+// ─── Tooltip label renderer ───────────────────────────────────────────────────
+// "N more <Topic>" with the topic bolded in the category color. Returns null
+// when topic is absent, so callers can short-circuit without rendering.
+function buildTooltipLabel(
+  topic: string | undefined,
+  otherCount: number | undefined,
+  textColor: string,
+): React.ReactNode | null {
+  if (!topic) return null;
+  const count = otherCount ?? 0;
+  return (
+    <>
+      {count} more <strong style={{ color: textColor }}>{topic}</strong>
+    </>
+  );
+}
+```
+
+- [ ] **Step 3.3: Verify build and lint pass**
+
+Run: `pnpm build && pnpm lint`
+Expected: both succeed. The helpers exist but are not yet called, so they should not change any behavior. If `tsc` complains the helpers are unused, that's fine — they will be wired in Task 4. ESLint may flag the unused functions; if the project's ESLint config errors on `no-unused-vars` at the build step, temporarily proceed without the lint gate here and re-run it after Task 4 wires them up.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add src/components/RelatedStacks.tsx
+git commit -m "Add missing-topic warning and tooltip label helpers"
+```
+
+---
+
+## Task 4: Migrate the highlight tooltip to `HoverTooltip` and remove `SeeMoreTooltip`
+
+**Files:**
+- Modify: `src/components/RelatedStacks.tsx`
+
+This is the behavioral change for the highlight-hover tooltip. After this task, hovering a `<mark>` in a related-post card produces a single cursor-following tooltip via the new primitive.
+
+- [ ] **Step 4.1: Pass `stackId` into `buildMultiHighlightNodes` so the warning helper has context**
+
+The existing `buildMultiHighlightNodes` signature is (lines 227-242 of the current file):
+
+```tsx
+function buildMultiHighlightNodes(
+  plain: string,
+  relations: Relation[] | undefined,
+  primaryColors: CategoryStyle,
+  opts: {
+    isCardHovered: boolean;
+    anyCardHovered: boolean;
+    hoveredRangeIndex: number | null;
+    hoveredCategory: string | null;
+    anchoredRangeIndex: number | null;
+    onRangeHover: (index: number | null) => void;
+    onRangeClick?: (index: number) => void;
+    /** topic → number of OTHER posts (excluding current) that share this topic */
+    otherCountByTopic?: (topic: string) => number;
+  },
+): React.ReactNode[]
+```
+
+Add `stackId: string` to `opts`. Update the call site at line ~1011 (search for `const contentNodes = buildMultiHighlightNodes(`) to pass `stackId: stack.stackId`. Use the variable name already in scope at that call site — confirm by reading 5-10 lines above the call.
+
+- [ ] **Step 4.2: Replace the overlap-segment inline tooltip render with imperative calls**
+
+In `src/components/RelatedStacks.tsx`, lines 343-353 currently render the overlap tooltip:
+
+```tsx
+{hoveredBandContributor && !tooltipRendered.has(hoveredBandContributor.rangeIndex) && (() => {
+  tooltipRendered.add(hoveredBandContributor.rangeIndex);
+  const topic = hoveredBandContributor.topic;
+  return (
+    <SeeMoreTooltip
+      topic={topic}
+      otherCount={topic && opts.otherCountByTopic ? opts.otherCountByTopic(topic) : undefined}
+      categoryColors={getCategoryColors(hoveredBandContributor.category)}
+    />
+  );
+})()}
+```
+
+Remove this entire block (and the wrapping `<span>` is fine to keep around the `<mark>`; only delete the conditional tooltip JSX).
+
+Then update the existing `overlapHover` helper (currently at lines 304-309) to also drive the tooltip. The replacement reads:
+
+```tsx
+const overlapHover = (clientX: number, clientY: number, currentTarget: HTMLElement) => {
+  const rect = currentTarget.getBoundingClientRect();
+  const rel = (clientY - rect.top) / rect.height;
+  const bandIdx = Math.max(0, Math.min(cats.length - 1, Math.floor(rel * cats.length)));
+  const band = cats[bandIdx];
+  opts.onRangeHover(band.rangeIndex);
+
+  if (!band.topic) {
+    warnMissingTopic(opts.stackId, band.rangeIndex);
+    hideTooltip();
+    return;
+  }
+  const count = opts.otherCountByTopic ? opts.otherCountByTopic(band.topic) : undefined;
+  const colors: TooltipColors = { text: band.colors.text, border: band.colors.border };
+  showTooltip({
+    content: buildTooltipLabel(band.topic, count, band.colors.text),
+    colors,
+    x: clientX,
+    y: clientY,
+  });
+};
+```
+
+Note `clientX` is now also passed in. Update the three call sites (lines 316, 318, and the `onClick` at 320-329 — only the move/hover ones; `onClick` does not call `overlapHover`):
+
+- `onMouseMove={(e) => overlapHover(e.clientX, e.clientY, e.currentTarget as HTMLElement)}`
+- `onPointerMove={(e) => { if (e.pointerType === 'mouse') overlapHover(e.clientX, e.clientY, e.currentTarget as HTMLElement); }}`
+
+Update the leave handlers (lines 317 and 319) to also hide the tooltip:
+
+- `onMouseLeave={() => { opts.onRangeHover(null); hideTooltip(); }}`
+- `onPointerLeave={(e) => { if (e.pointerType === 'mouse') { opts.onRangeHover(null); hideTooltip(); } }}`
+
+- [ ] **Step 4.3: Replace the single-contributor segment inline tooltip render with imperative calls**
+
+In `src/components/RelatedStacks.tsx`, lines 428-435 currently render the single-contributor tooltip (verify exact bounds — the rendering uses an IIFE similar to the overlap case). Remove the entire `{isThisRangeHovered && !tooltipRendered.has(c.rangeIndex) && (() => { ... })()}` block.
+
+Then add a tooltip-driving variant to the `<mark>` handlers in the single-contributor branch. The existing handlers (lines 406-414) are:
+
+```tsx
+onMouseEnter={() => opts.onRangeHover(c.rangeIndex)}
+onMouseLeave={() => opts.onRangeHover(null)}
+onPointerEnter={(e) => { if (e.pointerType === 'mouse') opts.onRangeHover(c.rangeIndex); }}
+onPointerLeave={(e) => { if (e.pointerType === 'mouse') opts.onRangeHover(null); }}
+onClick={(e) => { ... }}
+```
+
+Replace them with:
+
+```tsx
+onMouseEnter={(e) => {
+  opts.onRangeHover(c.rangeIndex);
+  if (!c.topic) {
+    warnMissingTopic(opts.stackId, c.rangeIndex);
+    hideTooltip();
+    return;
+  }
+  const count = opts.otherCountByTopic ? opts.otherCountByTopic(c.topic) : undefined;
+  showTooltip({
+    content: buildTooltipLabel(c.topic, count, colors.text),
+    colors: { text: colors.text, border: colors.border },
+    x: e.clientX,
+    y: e.clientY,
+  });
+}}
+onMouseLeave={() => { opts.onRangeHover(null); hideTooltip(); }}
+onPointerEnter={(e) => {
+  if (e.pointerType !== 'mouse') return;
+  opts.onRangeHover(c.rangeIndex);
+  if (!c.topic) {
+    warnMissingTopic(opts.stackId, c.rangeIndex);
+    hideTooltip();
+    return;
+  }
+  const count = opts.otherCountByTopic ? opts.otherCountByTopic(c.topic) : undefined;
+  showTooltip({
+    content: buildTooltipLabel(c.topic, count, colors.text),
+    colors: { text: colors.text, border: colors.border },
+    x: e.clientX,
+    y: e.clientY,
+  });
+}}
+onPointerLeave={(e) => { if (e.pointerType === 'mouse') { opts.onRangeHover(null); hideTooltip(); } }}
+onClick={(e) => {
+  if (!opts.onRangeClick) return;
+  e.stopPropagation();
+  (e.currentTarget as HTMLElement).blur();
+  opts.onRangeClick(c.rangeIndex);
+}}
+```
+
+- [ ] **Step 4.4: Delete the now-unused `SeeMoreTooltip` component and the `tooltipRendered` Set**
+
+Delete lines 109-158 (the `SeeMoreTooltip` function and its comment header). Delete the `const tooltipRendered = new Set<number>();` line (currently line 265) and the comment block immediately above it (lines 263-264). After this, no callers reference `SeeMoreTooltip` and no callers reference `tooltipRendered`.
+
+- [ ] **Step 4.5: Verify build and lint pass**
+
+Run: `pnpm build && pnpm lint`
+Expected: both succeed. Any `unused variable` warnings for `SeeMoreTooltip` should disappear because the function is deleted. If `tsc` errors about a missing `stackId` field, double-check that Step 4.1 was applied at the call site.
+
+- [ ] **Step 4.6: Manual verification of highlight-hover behavior**
+
+Run `pnpm dev` and walk through:
+
+| Check | Expected |
+|---|---|
+| Hover a single-category highlight inside a related card | One tooltip appears at cursor + (14, 18). Content: `N more <Topic>` with topic bolded and tinted with the category color. |
+| Move cursor while still on the highlight | Tooltip follows continuously, smoothly, with no judder. |
+| Move cursor away from the highlight | Tooltip disappears. |
+| Hover an overlap region (two stripes) | Tooltip content changes as cursor moves between bands, reflecting the topic of the band under the cursor. |
+| Hover near the right viewport edge | Tooltip clamps to viewport. |
+| Hover near the bottom of the viewport | Tooltip flips above the cursor instead of overflowing. |
+| Inspect DOM in DevTools while hovering | Exactly one tooltip node exists at any time (a child of `<body>`). |
+| Test with a relation whose `topic` is undefined | No tooltip. `console.warn("[stacky] missing topic ...")` fires once. Second hover of the same range does not re-warn. (Reproduce by editing `src/app/FakeData/mock_related_stacks.json` to clear one `topic` field, OR by adding a temporary `topic = undefined` override in the dev console; revert after.) |
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add src/components/RelatedStacks.tsx
+git commit -m "Migrate related-panel tooltip to single cursor-following primitive"
+```
+
+---
+
+## Task 5: Apply the new format and missing-topic gate to the "X more" button
+
+**Files:**
+- Modify: `src/components/RelatedStacks.tsx`
+
+The show-more-link button at the bottom of a group renders its own text (`{groupRemaining} more {anchorTopic ?? 'related'}`). With the new format and missing-topic policy, this needs two adjustments.
+
+- [ ] **Step 5.1: Gate `showMoreLink` on a present topic**
+
+In `src/components/RelatedStacks.tsx`, find the existing condition at line ~1070:
+
+```tsx
+const showMoreLink = isClaim && isLastInGroup && groupRemaining > 0;
+```
+
+Replace with:
+
+```tsx
+const showMoreLink = isClaim && isLastInGroup && groupRemaining > 0 && !!anchorTopic;
+```
+
+Also add a missing-topic warning when the button would otherwise have rendered. Immediately above the new line, add:
+
+```tsx
+if (isClaim && isLastInGroup && groupRemaining > 0 && !anchorTopic && anchorForThisCard) {
+  warnMissingTopic(anchorForThisCard, anchorRangeIdx ?? -1);
+}
+```
+
+(`anchorForThisCard` is the anchor stack id; `anchorRangeIdx` is in scope from the surrounding loop — confirm both are still in scope by reading 30 lines above the gate.)
+
+- [ ] **Step 5.2: Apply the bold + category color format to the button label**
+
+In `src/components/RelatedStacks.tsx`, the button label is at line ~1104:
+
+```tsx
+{groupRemaining} more {anchorTopic ?? 'related'}
+```
+
+Because the gate now guarantees `anchorTopic` is truthy when this renders, replace with:
+
+```tsx
+{groupRemaining} more <strong style={{ color: anchorColors.text }}>{anchorTopic}</strong>
+```
+
+- [ ] **Step 5.3: Verify build and lint pass**
+
+Run: `pnpm build && pnpm lint`
+Expected: both succeed.
+
+- [ ] **Step 5.4: Manual verification of button behavior**
+
+Run `pnpm dev` and walk through:
+
+| Check | Expected |
+|---|---|
+| Group with `groupRemaining > 0` and a topic | Button shows `N more `**`<Topic>`** with the topic bolded in the anchor's category color. |
+| Group with `groupRemaining > 0` but `anchorTopic` missing | Button does NOT render. `console.warn` fires once. The connector line stub above the button (the `<div aria-hidden>` at lines 1086-1094 of the original file, contained in the same outer `<div>`) also doesn't render because the whole `moreEl` block is gated. |
+| Click the button | Pagination still works (`handleShowMore` runs). |
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/components/RelatedStacks.tsx
+git commit -m "Format show-more-link as bold topic and hide when topic missing"
+```
+
+---
+
+## Task 6: End-to-end verification against the spec
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 6.1: Re-run lint and build cleanly**
+
+```bash
+pnpm lint
+pnpm build
+```
+
+Both should pass. If either reports warnings introduced by Tasks 1-5, fix them before proceeding.
+
+- [ ] **Step 6.2: Walk through the spec's verification checklist**
+
+From [docs/superpowers/specs/2026-05-13-group-b-tooltip-and-label-design.md § 7](../specs/2026-05-13-group-b-tooltip-and-label-design.md), confirm each row:
+
+- [ ] Hover a highlighted span in a related card → exactly one tooltip node in the DOM; content `N more <Topic>`.
+- [ ] Hover the show-more-link button → no second tooltip near the button; the button's own bold-topic text is sufficient.
+- [ ] Hover the topic chip at the top of a group → no second tooltip near the chip (the chip already shows the topic).
+- [ ] Move cursor across viewport while a tooltip is open → tooltip follows smoothly; clamps near right edge; flips above cursor near bottom edge.
+- [ ] Hover a relation whose `otherCount` is 0 → tooltip reads `0 more <Topic>`.
+- [ ] Hover a relation whose `topic` is undefined → no tooltip, no button; one `console.warn` per (stackId, rangeIndex) per session.
+
+- [ ] **Step 6.3: If any check fails, fix the smallest possible diff and re-verify before committing**
+
+For each failure, identify the root cause (rather than papering over with another conditional). Common likely failures and where to look:
+- Tooltip appears in two places after Task 4 → check that the `SeeMoreTooltip` deletion in Step 4.4 was complete, and there is no other call site outside the two render sites in `buildMultiHighlightNodes`.
+- Tooltip lingers after `mouseleave` → ensure both `onMouseLeave` *and* `onPointerLeave` call `hideTooltip()` (Step 4.2 and 4.3).
+- Tooltip doesn't follow → ensure the `useEffect` in Task 1 correctly attaches `mousemove` only while `state.visible`.
+
+Commit any fix:
+
+```bash
+git add src/components/RelatedStacks.tsx src/components/HoverTooltip.tsx
+git commit -m "<one-line summary of the fix>"
+```
+
+- [ ] **Step 6.4: Confirm final git log shows the expected sequence**
+
+```bash
+git log --oneline -7
+```
+
+Expected (in reverse chronological order, after `19dc10c`):
+
+```
+<sha> Format show-more-link as bold topic and hide when topic missing
+<sha> Migrate related-panel tooltip to single cursor-following primitive
+<sha> Add missing-topic warning and tooltip label helpers
+<sha> Mount HoverTooltip at shell root
+<sha> Add HoverTooltip primitive for cursor-following tooltips
+19dc10c Add Group B design spec for tooltip and label polish
+```
+
+(If verification fixes were needed in Step 6.3, an extra commit at the top is expected.)
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- §5.1 Single cursor-following tooltip → Tasks 1, 2, 4.
+- §5.2 "X more Topic" format (tooltip) → Tasks 3, 4 (via `buildTooltipLabel`).
+- §5.2 "X more Topic" format (button) → Task 5.
+- §5.3 Hide tooltip when topic missing → Task 4 (overlap and single-contributor branches).
+- §5.3 Hide button when topic missing → Task 5.
+- §5.3 Diagnostic warning → Task 3 (helper) + Tasks 4 and 5 (call sites).
+- §6 Files touched → matches `HoverTooltip.tsx`, `Shell.tsx`, `RelatedStacks.tsx`.
+- §7 Verification → Task 6.
+
+**Type-consistency:** `TooltipColors` interface defined in Task 1, imported in Task 3, used in Task 4 — names and shapes match. `showTooltip` / `hideTooltip` signatures referenced in Task 4 match the export shapes in Task 1.
+
+**Placeholder scan:** no `TBD`, `TODO`, "implement later", or vague "handle edge cases" left in any task.
+
+**Bite-size:** each step is a single concrete edit, a single command, or a single verification — typically 2-5 minutes.

--- a/docs/superpowers/specs/2026-05-13-group-b-tooltip-and-label-design.md
+++ b/docs/superpowers/specs/2026-05-13-group-b-tooltip-and-label-design.md
@@ -1,0 +1,136 @@
+# Group B — Tooltip & Label Polish (Design Spec)
+
+**Date:** 2026-05-13
+**Status:** Approved by user; ready for implementation plan.
+**Scope:** Polish pass on the related-panel tooltip and the "X more Topic" label format. One sub-project in the broader B → C → D → E → F → G → I → H roadmap.
+**Owner:** tarcode2004
+**Approach selected:** Surgical patch (Approach 1 of 3 considered).
+
+---
+
+## 1. Problem
+
+Three issues in the related panel:
+
+1. **Duplicate tooltip.** When the user hovers a tag inside a related-post group, the "`3 more Trial Results`" tooltip appears in two places at once — one near the tag, one over the highlighted span. The tooltip is also statically positioned above the hovered element rather than following the cursor.
+2. **Unclear label format.** The string "`N more <topic>`" reads ambiguously because the topic word is unstyled and indistinguishable from surrounding text; and the empty-state today renders "`Only <topic>`", which feels truncated.
+3. **Missing-topic data leakage.** When `topic` is undefined in the relation data, the UI silently substitutes `'related'` (button) or `'See more like this'` (tooltip), hiding a real data-integrity problem.
+
+## 2. Goals
+
+- Exactly one tooltip ever in the DOM, regardless of which element triggered the hover.
+- Continuous cursor-following position with viewport clamping.
+- Consistent, scannable `"N more <Topic>"` format with the topic visually emphasized.
+- Missing-topic cases render *nothing* and log a diagnostic warning, so data-integrity issues are visible in study logs rather than papered over.
+
+## 3. Non-Goals (explicit out-of-scope)
+
+- Any change to the focus post's highlight rendering (`renderMultiHighlightHtml` in [src/components/Posts/Post.tsx](src/components/Posts/Post.tsx)). The focus post uses `<mark>` tags via `dangerouslySetInnerHTML` and renders no tooltip; nothing here touches it.
+- Hover-color affordances on filter chips → deferred to **Group C**.
+- Highlight-to-filter interaction on the focus post → deferred to **Group D**.
+- Related-panel visual redesign (option 3 from the meeting; relation indicator placement) → deferred to **Group F**.
+- The simulated-feedback feature on draft replies → deferred to **Group I**.
+
+## 4. Decisions Locked During Brainstorm
+
+| # | Decision | Choice |
+|---|---|---|
+| Q1 | Cursor-following behavior | **Continuous follow** — position updates on every `mousemove`. |
+| Q2 | Topic-name emphasis | **Bold + category color** — `<strong>` styled with `categoryColors.text`. |
+| Q3 | Empty-state phrasing | **Literal `"0 more <Topic>"`** — no special-case branch for count = 0. |
+| Q4 | Missing-topic behavior | **Hide entirely** — tooltip returns `null`; button does not render; `console.warn` logs the case. |
+
+## 5. Behavior Specification
+
+### 5.1 Single Cursor-Following Tooltip
+
+**Single instance, portal-mounted.** A new module exposes an imperative API:
+
+```ts
+showTooltip({ content: React.ReactNode, colors: CategoryStyle }): void
+hideTooltip(): void
+```
+
+A single `<HoverTooltip />` component, mounted near the app root, subscribes to a small internal store. The DOM contains either one tooltip node or zero — never two.
+
+**Continuous follow.** While a tooltip is active, a global `mousemove` listener is attached to `window`. On each event, position updates via `transform: translate3d(x, y, 0)` (GPU-accelerated; avoids layout thrash from `left`/`top` updates). The listener is removed on `hideTooltip()`.
+
+**Cursor offset.** Default: cursor + (14px right, 18px below). The tooltip's `pointerEvents: 'none'` is preserved so it cannot intercept hovers on elements underneath.
+
+**Viewport clamping (recomputed every move):**
+- `x` clamped to `[8, viewportWidth - tooltipWidth - 8]`.
+- If `cursorY + 18 + tooltipHeight > viewportHeight - 8`, flip vertically: render above the cursor at `cursorY - 18 - tooltipHeight`.
+
+**Why this beats a `Set`-based dedupe.** The existing `tooltipRendered: Set<number>` in `RelatedStacks.tsx` line 265 is per-render and shared across two render paths (lines 343 and 428). Single-instance portal removes the dedupe concern *structurally* — there is no second render site to coordinate with.
+
+### 5.2 Label Format
+
+The "X more Topic" string appears in two places. Both render with the new JSX shape:
+
+```tsx
+<>{count} more <strong style={{ color: colors.text }}>{topic}</strong></>
+```
+
+**Tooltip body** ([src/components/RelatedStacks.tsx:111-158](src/components/RelatedStacks.tsx#L111), `SeeMoreTooltip`):
+- The current branch at lines 128-132 (`topic ? (otherCount > 0 ? "${n} more ${topic}" : "Only ${topic}") : 'See more like this'`) is replaced.
+- New behavior: if `topic` is missing, return `null` (do not render). Otherwise always render `"{otherCount ?? 0} more <strong>{topic}</strong>"`.
+
+**Show-more-link button** ([src/components/RelatedStacks.tsx:1095-1106](src/components/RelatedStacks.tsx#L1095)):
+- Same JSX shape inside the existing `<button>`.
+- The `?? 'related'` fallback at line 1104 is removed — see § 5.3 for the gating condition.
+
+**Topic chip at the top of the group** ([src/components/RelatedStacks.tsx:1136-1144](src/components/RelatedStacks.tsx#L1136), `labelEl`):
+- Unchanged. The chip already renders the topic name with category styling and serves as the group header; it carries no "X more" prefix.
+
+### 5.3 Missing-Topic Behavior
+
+**Tooltip.** `SeeMoreTooltip` (or rather its call site that invokes `showTooltip`) checks `!topic` and short-circuits: no `showTooltip` call is made on hover. If somehow called with `!topic`, the component returns `null`.
+
+**Show-more-link button.** `showMoreLink` condition at [src/components/RelatedStacks.tsx:1070](src/components/RelatedStacks.tsx#L1070) becomes:
+
+```ts
+const showMoreLink = isClaim && isLastInGroup && groupRemaining > 0 && !!anchorTopic;
+```
+
+When this is false because of missing topic, the entire `<div>` containing the button and its connector-line stub (lines 1077-1107) does not render.
+
+**Diagnostic warning.** On the first encounter of a missing-topic case per session, `console.warn("[stacky] missing topic on relation; tooltip/button suppressed", { stackId, rangeIndex })` fires once. A module-level `Set<string>` tracks already-warned keys so the warning is rate-limited per (`stackId`, `rangeIndex`) pair.
+
+## 6. Files Touched
+
+| File | Action | Approx LOC |
+|---|---|---|
+| [src/components/HoverTooltip.tsx](src/components/HoverTooltip.tsx) | **New.** Single-instance portal-mounted tooltip + imperative `showTooltip`/`hideTooltip` API + internal store. | ~80 |
+| [src/components/RelatedStacks.tsx](src/components/RelatedStacks.tsx) | Modify. Rewrite `SeeMoreTooltip` to call `showTooltip`/`hideTooltip`. Collapse render sites at lines 343 and 428 to a single hover-state effect. Update label JSX at line 1104. Update `showMoreLink` gating at line 1070. Add missing-topic warning helper. Remove the local `tooltipRendered: Set` (no longer needed). | ~50 |
+| [src/app/(shell)/Shell.tsx](src/app/\(shell\)/Shell.tsx) | Modify. Mount `<HoverTooltip />` once near the app root so its portal target exists in the tree. | ~3 |
+
+No other files are expected to change. No new dependencies.
+
+**On "surgical" plus a new file.** The selected approach is surgical in scope (no library, no refactor of existing call sites beyond the immediate change), but it does introduce one ~80-LOC primitive file. Rationale: the alternative — adding a global `mousemove` listener inside `SeeMoreTooltip` and relying on a per-render `Set` to deduplicate — is the kind of subtle, hope-it-works fix that drifts back into bugs. A small portal-mounted primitive removes the failure mode structurally. Approved during brainstorm.
+
+## 7. Verification
+
+Manual verification (no test framework in this repo per [CLAUDE.md](CLAUDE.md)):
+
+| Check | Expected |
+|---|---|
+| Hover a highlighted span inside a related card | Exactly one tooltip node in the DOM (DevTools Elements); content `"N more <Topic>"`. |
+| Hover the show-more-link button at the bottom of a group | Same tooltip moves to cursor; no second tooltip appears anywhere. |
+| Hover the topic chip at the top of a group | Tooltip near cursor (no second). |
+| Move cursor while hovered | Tooltip follows continuously, smooth (no judder). |
+| Move cursor near right viewport edge | Tooltip clamps; does not overflow. |
+| Move cursor near bottom viewport edge | Tooltip flips above cursor. |
+| Hover a group whose `otherCount` is 0 | Tooltip renders `"0 more <Topic>"`. |
+| Hover a relation with `topic === undefined` | No tooltip. No "X more" button rendered. `console.warn` once per (stackId, rangeIndex). |
+| Run `pnpm lint` and `pnpm build` | Both pass. |
+
+## 8. Risks & Open Questions
+
+- **Mount-site assumption.** `<HoverTooltip />` must be mounted inside the React tree but its portal target is `document.body`. Mounting in [Shell.tsx](src/app/\(shell\)/Shell.tsx) covers all authenticated routes. Unauthenticated routes (`/`, `/callback`) don't render related stacks, so they don't need the tooltip — confirm during implementation that no `RelatedStacks` is rendered outside the shell.
+- **Mousemove cost.** A global `mousemove` listener while a tooltip is active is cheap (one `transform` write per event, no React re-render — done imperatively on the DOM node). The listener is removed on `hideTooltip`. If profiling shows jitter, throttle with `requestAnimationFrame`.
+- **Aside parallel route.** If the related panel is ever rendered in *both* the main area and `@aside/` simultaneously, the single-instance tooltip still holds because both `RelatedStacks` calls dispatch to the same store. No special handling needed.
+- **Duplicate-tooltip root cause not fully diagnosed.** Static analysis didn't isolate which of (dual-render across panels, hover-state race, segment-overlap edge case) is producing the duplicate today. Implementation will diagnose during testing. Design is robust regardless: structural single-instance guarantees the bug cannot recur.
+
+## 9. Next Step
+
+Hand off to the `writing-plans` skill to produce a step-by-step implementation plan.

--- a/src/app/(shell)/Shell.tsx
+++ b/src/app/(shell)/Shell.tsx
@@ -6,6 +6,7 @@ import { ReactNode } from 'react';
 import {Navbar} from "../../components/NavBar/Navbar";
 import StackLogo from '../../utils/StackLogo';
 import { RelatedStacksProvider } from './related-stacks-context';
+import { HoverTooltip } from '../../components/HoverTooltip';
 
 export default function Shell({ children, aside }: {  children: React.ReactNode; aside: React.ReactNode; }) {
     const [opened, { toggle }] = useDisclosure();
@@ -75,6 +76,7 @@ export default function Shell({ children, aside }: {  children: React.ReactNode;
                 {children}
             </AppShell.Main>
         </AppShell>
+        <HoverTooltip />
         <Burger
             opened={!navCollapsed}
             onClick={toggleNav}

--- a/src/components/HoverTooltip.tsx
+++ b/src/components/HoverTooltip.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+export interface TooltipColors {
+  text: string;
+  border: string;
+}
+
+interface TooltipState {
+  visible: boolean;
+  content: React.ReactNode;
+  colors: TooltipColors;
+  initialX: number;
+  initialY: number;
+}
+
+const DEFAULT_COLORS: TooltipColors = { text: "#334155", border: "#cbd5e1" };
+
+const initialState: TooltipState = {
+  visible: false,
+  content: null,
+  colors: DEFAULT_COLORS,
+  initialX: -9999,
+  initialY: -9999,
+};
+
+type Listener = (state: TooltipState) => void;
+
+const listeners = new Set<Listener>();
+let currentState: TooltipState = initialState;
+
+function setState(partial: Partial<TooltipState>) {
+  currentState = { ...currentState, ...partial };
+  listeners.forEach((l) => l(currentState));
+}
+
+export function showTooltip(opts: {
+  content: React.ReactNode;
+  colors: TooltipColors;
+  x: number;
+  y: number;
+}): void {
+  setState({
+    visible: true,
+    content: opts.content,
+    colors: opts.colors,
+    initialX: opts.x,
+    initialY: opts.y,
+  });
+}
+
+export function hideTooltip(): void {
+  setState({ visible: false, content: null });
+}
+
+export function HoverTooltip(): JSX.Element | null {
+  const [state, setLocalState] = useState<TooltipState>(currentState);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const listener: Listener = (s) => setLocalState(s);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  // Position on initial show + continuous follow while visible.
+  useEffect(() => {
+    if (!state.visible) return;
+
+    const position = (clientX: number, clientY: number) => {
+      const el = nodeRef.current;
+      if (!el) return;
+      const tw = el.offsetWidth;
+      const th = el.offsetHeight;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const offsetX = 14;
+      const offsetY = 18;
+      let x = clientX + offsetX;
+      let y = clientY + offsetY;
+      if (x + tw > vw - 8) x = vw - tw - 8;
+      if (x < 8) x = 8;
+      if (y + th > vh - 8) y = clientY - offsetY - th;
+      if (y < 8) y = 8;
+      el.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+    };
+
+    // Position once with the cursor location captured at show time.
+    position(state.initialX, state.initialY);
+
+    const onMove = (e: MouseEvent) => position(e.clientX, e.clientY);
+    window.addEventListener("mousemove", onMove);
+    return () => window.removeEventListener("mousemove", onMove);
+  }, [state.visible, state.initialX, state.initialY]);
+
+  if (typeof document === "undefined") return null;
+  if (!state.visible) return null;
+
+  return createPortal(
+    <div
+      ref={nodeRef}
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        transform: "translate3d(-9999px, -9999px, 0)",
+        pointerEvents: "none",
+        zIndex: 10000,
+        background: "rgba(255,255,255,0.92)",
+        backdropFilter: "blur(10px)",
+        WebkitBackdropFilter: "blur(10px)",
+        borderRadius: 8,
+        padding: "4px 10px",
+        boxShadow:
+          "0 4px 14px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.05)",
+        border: `1px solid ${state.colors.border}55`,
+        fontSize: 11,
+        fontWeight: 600,
+        color: state.colors.text,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {state.content}
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/HoverTooltip.tsx
+++ b/src/components/HoverTooltip.tsx
@@ -30,6 +30,7 @@ type Listener = (state: TooltipState) => void;
 
 const listeners = new Set<Listener>();
 let currentState: TooltipState = initialState;
+let mountCount = 0;
 
 function setState(partial: Partial<TooltipState>) {
   currentState = { ...currentState, ...partial };
@@ -60,10 +61,25 @@ export function HoverTooltip(): JSX.Element | null {
   const nodeRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    // Sync local state with current module state before subscribing
+    // to prevent stale state if showTooltip was called during render.
+    setLocalState(currentState);
+
     const listener: Listener = (s) => setLocalState(s);
     listeners.add(listener);
+
+    // Guard against multi-mount in development.
+    mountCount += 1;
+    if (mountCount > 1 && process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[HoverTooltip] More than one instance is mounted; only one is supported.",
+      );
+    }
+
     return () => {
       listeners.delete(listener);
+      mountCount -= 1;
     };
   }, []);
 

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -571,6 +571,21 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     return Array.from(map.entries()).sort((a, b) => b[1] - a[1]);
   }, [relatedStacks]);
 
+  // Category prevalence — counts stacks that contain ANY relation with the given
+  // category (one stack contributes at most 1 per category, even if it has
+  // multiple relations of the same category). Used for tag-hover tooltips.
+  const categoryStackCount = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const stack of relatedStacks) {
+      const seen = new Set<string>();
+      for (const r of stack.topPost.relations ?? []) {
+        seen.add(r.category);
+      }
+      seen.forEach(c => m.set(c, (m.get(c) ?? 0) + 1));
+    }
+    return m;
+  }, [relatedStacks]);
+
   // Topic prevalence — used by tooltip ("7 more Contract reform") and for pagination.
   const { postTopics, topicTotal } = useMemo(() => {
     const postTopics = new Map<string, Set<string>>();
@@ -1293,11 +1308,23 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                       const tc = getCategoryColors(cat);
                       const anyDirected = hri !== null || hcat !== null;
                       const tagBright = !anyDirected || indices.includes(hri ?? -1) || hcat === cat;
+                      const categoryLabel = CATEGORY_LABELS[cat] ?? cat;
+                      const otherCount = Math.max(0, (categoryStackCount.get(cat) ?? 0) - 1);
+                      const tagHover = (clientX: number, clientY: number) => {
+                        showTooltip({
+                          content: buildTooltipLabel(categoryLabel, otherCount, tc.text),
+                          colors: { text: tc.text, border: tc.border },
+                          x: clientX,
+                          y: clientY,
+                        });
+                      };
                       return (
                         <div
                           key={cat}
-                          onMouseEnter={() => { if (!isTouch) setHoveredCategory(cat); }}
-                          onMouseLeave={() => { if (!isTouch) setHoveredCategory(null); }}
+                          onMouseEnter={(e) => { if (!isTouch) setHoveredCategory(cat); tagHover(e.clientX, e.clientY); }}
+                          onMouseLeave={() => { if (!isTouch) setHoveredCategory(null); hideTooltip(); }}
+                          onPointerEnter={(e) => { if (e.pointerType !== 'mouse') return; tagHover(e.clientX, e.clientY); }}
+                          onPointerLeave={(e) => { if (e.pointerType === 'mouse') hideTooltip(); }}
                           onClick={(e) => {
                             e.stopPropagation();
                             if (isTouch) {

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -1070,10 +1070,11 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
           const groupTotalForThis = anchorForThisCard ? (groupTotal.get(anchorForThisCard) ?? 0) : 0;
           const groupShownForThis = anchorForThisCard ? (groupShown.get(anchorForThisCard) ?? 0) : 0;
           const groupRemaining = Math.max(0, groupTotalForThis - groupShownForThis);
-          if (isClaim && isLastInGroup && groupRemaining > 0 && !anchorTopic && anchorForThisCard) {
+          const canShowMore = isClaim && isLastInGroup && groupRemaining > 0;
+          if (canShowMore && !anchorTopic && anchorForThisCard) {
             warnMissingTopic(anchorForThisCard, anchorRangeIdx ?? -1);
           }
-          const showMoreLink = isClaim && isLastInGroup && groupRemaining > 0 && !!anchorTopic;
+          const showMoreLink = canShowMore && !!anchorTopic;
 
           // "MORE [topic]" pagination — caps the bottom of the group connector
           // line. Rendered inside the last claim's motion.div (below the Paper)

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -1070,7 +1070,10 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
           const groupTotalForThis = anchorForThisCard ? (groupTotal.get(anchorForThisCard) ?? 0) : 0;
           const groupShownForThis = anchorForThisCard ? (groupShown.get(anchorForThisCard) ?? 0) : 0;
           const groupRemaining = Math.max(0, groupTotalForThis - groupShownForThis);
-          const showMoreLink = isClaim && isLastInGroup && groupRemaining > 0;
+          if (isClaim && isLastInGroup && groupRemaining > 0 && !anchorTopic && anchorForThisCard) {
+            warnMissingTopic(anchorForThisCard, anchorRangeIdx ?? -1);
+          }
+          const showMoreLink = isClaim && isLastInGroup && groupRemaining > 0 && !!anchorTopic;
 
           // "MORE [topic]" pagination — caps the bottom of the group connector
           // line. Rendered inside the last claim's motion.div (below the Paper)
@@ -1104,7 +1107,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                 }}
                 style={{ color: anchorColors.text }}
               >
-                {groupRemaining} more {anchorTopic ?? 'related'}
+                {groupRemaining} more <strong style={{ color: anchorColors.text }}>{anchorTopic}</strong>
               </button>
             </div>
           ) : null;

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -140,57 +140,6 @@ function buildTooltipLabel(
   );
 }
 
-// ─── Passive "See more like this" tooltip (no button) ───────────────────────
-
-function SeeMoreTooltip({ topic, otherCount, categoryColors }: { topic?: string; otherCount?: number; categoryColors: CategoryStyle }) {
-  const ref = useRef<HTMLSpanElement>(null);
-  const [nudge, setNudge] = useState(0);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    const pad = 8;
-    let n = 0;
-    if (rect.left < pad) n = -rect.left + pad;
-    else if (rect.right > window.innerWidth - pad) n = window.innerWidth - pad - rect.right;
-    if (n !== nudge) setNudge(n);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // "7 more Contract reform" — prevalence indicator for the topic.
-  const label = topic
-    ? (otherCount !== undefined && otherCount > 0
-        ? `${otherCount} more ${topic}`
-        : `Only ${topic}`)
-    : 'See more like this';
-
-  return (
-    <span
-      style={{
-        position: 'absolute', bottom: '100%', left: '50%',
-        transform: `translateX(calc(-50% + ${nudge}px))`,
-        paddingBottom: 8, whiteSpace: 'nowrap', zIndex: 20, pointerEvents: 'none',
-      }}
-    >
-      <span
-        ref={ref}
-        style={{
-          display: 'inline-flex', alignItems: 'center', gap: 6,
-          background: 'rgba(255,255,255,0.78)',
-          backdropFilter: 'blur(10px)', WebkitBackdropFilter: 'blur(10px)',
-          borderRadius: 8, padding: '4px 10px',
-          boxShadow: '0 4px 14px rgba(0,0,0,0.10), 0 1px 2px rgba(0,0,0,0.05)',
-          border: `1px solid ${categoryColors.border}55`,
-          fontSize: 11, fontWeight: 600, color: categoryColors.text,
-        }}
-      >
-        <span>{label}</span>
-      </span>
-    </span>
-  );
-}
-
 // ─── Filter chip ─────────────────────────────────────────────────────────────
 
 function FilterChip({ category, count, active, onClick }: {
@@ -272,6 +221,7 @@ function buildMultiHighlightNodes(
     onRangeClick?: (index: number) => void;
     /** topic → number of OTHER posts (excluding current) that share this topic */
     otherCountByTopic?: (topic: string) => number;
+    stackId: string;
   },
 ): React.ReactNode[] {
   if (!relations || relations.length === 0) return [plain];
@@ -293,10 +243,6 @@ function buildMultiHighlightNodes(
 
   const nodes: React.ReactNode[] = [];
   let lastEnd = 0;
-
-  // Track which range indices have already rendered a tooltip so we never
-  // show duplicates when the same range is split into multiple segments.
-  const tooltipRendered = new Set<number>();
 
   for (const seg of segments) {
     // Add plain text before this segment
@@ -332,14 +278,28 @@ function buildMultiHighlightNodes(
         return `${rgba} ${pct1}%, ${rgba} ${pct2}%`;
       }).join(', ');
 
-      const hoveredBandContributor = cats.find(c => opts.hoveredRangeIndex === c.rangeIndex);
       // Pointer + mouse handlers run side-by-side so an extension that blocks one
       // event family still leaves the other working (Chrome on Win/Linux hover bug).
-      const overlapHover = (clientY: number, currentTarget: HTMLElement) => {
+      const overlapHover = (clientX: number, clientY: number, currentTarget: HTMLElement) => {
         const rect = currentTarget.getBoundingClientRect();
         const rel = (clientY - rect.top) / rect.height;
         const bandIdx = Math.max(0, Math.min(cats.length - 1, Math.floor(rel * cats.length)));
-        opts.onRangeHover(cats[bandIdx].rangeIndex);
+        const band = cats[bandIdx];
+        opts.onRangeHover(band.rangeIndex);
+
+        if (!band.topic) {
+          warnMissingTopic(opts.stackId, band.rangeIndex);
+          hideTooltip();
+          return;
+        }
+        const count = opts.otherCountByTopic ? opts.otherCountByTopic(band.topic) : undefined;
+        const colors: TooltipColors = { text: band.colors.text, border: band.colors.border };
+        showTooltip({
+          content: buildTooltipLabel(band.topic, count, band.colors.text),
+          colors,
+          x: clientX,
+          y: clientY,
+        });
       };
       nodes.push(
         <span key={`seg-${seg.start}`} style={{ position: 'relative', display: 'inline' }}>
@@ -347,10 +307,10 @@ function buildMultiHighlightNodes(
             data-overlap-bands={cats.length}
             data-overlap-range-ids={cats.map(c => c.rangeIndex).join(',')}
             tabIndex={-1}
-            onMouseMove={(e) => overlapHover(e.clientY, e.currentTarget as HTMLElement)}
-            onMouseLeave={() => opts.onRangeHover(null)}
-            onPointerMove={(e) => { if (e.pointerType === 'mouse') overlapHover(e.clientY, e.currentTarget as HTMLElement); }}
-            onPointerLeave={(e) => { if (e.pointerType === 'mouse') opts.onRangeHover(null); }}
+            onMouseMove={(e) => overlapHover(e.clientX, e.clientY, e.currentTarget as HTMLElement)}
+            onMouseLeave={() => { opts.onRangeHover(null); hideTooltip(); }}
+            onPointerMove={(e) => { if (e.pointerType === 'mouse') overlapHover(e.clientX, e.clientY, e.currentTarget as HTMLElement); }}
+            onPointerLeave={(e) => { if (e.pointerType === 'mouse') { opts.onRangeHover(null); hideTooltip(); } }}
             onClick={(e) => {
               if (!opts.onRangeClick) return;
               const el = e.currentTarget as HTMLElement;
@@ -374,17 +334,6 @@ function buildMultiHighlightNodes(
           >
             {segText}
           </mark>
-          {hoveredBandContributor && !tooltipRendered.has(hoveredBandContributor.rangeIndex) && (() => {
-            tooltipRendered.add(hoveredBandContributor.rangeIndex);
-            const topic = hoveredBandContributor.topic;
-            return (
-              <SeeMoreTooltip
-                topic={topic}
-                otherCount={topic && opts.otherCountByTopic ? opts.otherCountByTopic(topic) : undefined}
-                categoryColors={getCategoryColors(hoveredBandContributor.category)}
-              />
-            );
-          })()}
         </span>
       );
     } else {
@@ -437,10 +386,39 @@ function buildMultiHighlightNodes(
           <mark
             data-range-id={c.rangeIndex}
             tabIndex={-1}
-            onMouseEnter={() => opts.onRangeHover(c.rangeIndex)}
-            onMouseLeave={() => opts.onRangeHover(null)}
-            onPointerEnter={(e) => { if (e.pointerType === 'mouse') opts.onRangeHover(c.rangeIndex); }}
-            onPointerLeave={(e) => { if (e.pointerType === 'mouse') opts.onRangeHover(null); }}
+            onMouseEnter={(e) => {
+              opts.onRangeHover(c.rangeIndex);
+              if (!c.topic) {
+                warnMissingTopic(opts.stackId, c.rangeIndex);
+                hideTooltip();
+                return;
+              }
+              const count = opts.otherCountByTopic ? opts.otherCountByTopic(c.topic) : undefined;
+              showTooltip({
+                content: buildTooltipLabel(c.topic, count, colors.text),
+                colors: { text: colors.text, border: colors.border },
+                x: e.clientX,
+                y: e.clientY,
+              });
+            }}
+            onMouseLeave={() => { opts.onRangeHover(null); hideTooltip(); }}
+            onPointerEnter={(e) => {
+              if (e.pointerType !== 'mouse') return;
+              opts.onRangeHover(c.rangeIndex);
+              if (!c.topic) {
+                warnMissingTopic(opts.stackId, c.rangeIndex);
+                hideTooltip();
+                return;
+              }
+              const count = opts.otherCountByTopic ? opts.otherCountByTopic(c.topic) : undefined;
+              showTooltip({
+                content: buildTooltipLabel(c.topic, count, colors.text),
+                colors: { text: colors.text, border: colors.border },
+                x: e.clientX,
+                y: e.clientY,
+              });
+            }}
+            onPointerLeave={(e) => { if (e.pointerType === 'mouse') { opts.onRangeHover(null); hideTooltip(); } }}
             onClick={(e) => {
               if (!opts.onRangeClick) return;
               e.stopPropagation();
@@ -459,16 +437,6 @@ function buildMultiHighlightNodes(
           >
             {markContent}
           </mark>
-          {isThisRangeHovered && !tooltipRendered.has(c.rangeIndex) && (() => {
-            tooltipRendered.add(c.rangeIndex);
-            return (
-              <SeeMoreTooltip
-                topic={c.topic}
-                otherCount={c.topic && opts.otherCountByTopic ? opts.otherCountByTopic(c.topic) : undefined}
-                categoryColors={colors}
-              />
-            );
-          })()}
         </span>
       );
 
@@ -1057,6 +1025,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                 const hasSelf = postTopics.get(stack.topPost.id)?.has(topic) ? 1 : 0;
                 return Math.max(0, total - hasSelf);
               },
+              stackId: stack.stackId,
             },
           );
 

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -11,6 +11,7 @@ import InteractionControl from './InteractionControl';
 import { toggleFavourite, toggleBookmark } from '../utils/mastoActions';
 import { setHoveredSidebarPost, setHoveredHighlightRangeIndex, setHoveredCategory, setTapped, clearTapped, toggleReRankAnchor, clearReRankAnchors, toggleFilterCategory, useHighlightStore } from '../utils/highlightStore';
 import type { Relation } from '../types/PostType';
+import { showTooltip, hideTooltip, type TooltipColors } from './HoverTooltip';
 import './RelatedStacks.css';
 
 interface PostType {
@@ -105,6 +106,39 @@ const EYE_CURSOR = `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2
 // thread rather than per-card border segments.
 const GROUP_LINE_WIDTH = 2;
 const GROUP_GAP_PX = 12; // matches the parent's `gap: '0.75rem'`
+
+// ─── Missing-topic diagnostic (rate-limited) ─────────────────────────────────
+// Surface data-integrity issues (relations with no `topic`) in study logs
+// without spamming the console. One warning per (stackId, rangeIndex) pair
+// per session; the tooltip and "X more" button are suppressed in that case.
+const warnedMissingTopic = new Set<string>();
+function warnMissingTopic(stackId: string, rangeIndex: number): void {
+  const key = `${stackId}:${rangeIndex}`;
+  if (warnedMissingTopic.has(key)) return;
+  warnedMissingTopic.add(key);
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[stacky] missing topic on relation; tooltip/button suppressed',
+    { stackId, rangeIndex },
+  );
+}
+
+// ─── Tooltip label renderer ───────────────────────────────────────────────────
+// "N more <Topic>" with the topic bolded in the category color. Returns null
+// when topic is absent, so callers can short-circuit without rendering.
+function buildTooltipLabel(
+  topic: string | undefined,
+  otherCount: number | undefined,
+  textColor: string,
+): React.ReactNode | null {
+  if (!topic) return null;
+  const count = otherCount ?? 0;
+  return (
+    <>
+      {count} more <strong style={{ color: textColor }}>{topic}</strong>
+    </>
+  );
+}
 
 // ─── Passive "See more like this" tooltip (no button) ───────────────────────
 

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -868,6 +868,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
   useEffect(() => {
     setHoveredCardIndex(null);
     setHoveredIndex(null);
+    hideTooltip();
     if (rangeHoverTimer.current) clearTimeout(rangeHoverTimer.current);
     clearReRankAnchors();
     clearTapped();
@@ -1081,6 +1082,15 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
           // so its lifecycle is tied to the card. Kept out of the parent
           // AnimatePresence's flatMap because popLayout mode strands such
           // children at opacity:0 forever when their key disappears.
+          const buttonHover = (clientX: number, clientY: number) => {
+            if (!anchorTopic) return;
+            showTooltip({
+              content: buildTooltipLabel(anchorTopic, groupRemaining, anchorColors.text),
+              colors: { text: anchorColors.text, border: anchorColors.border },
+              x: clientX,
+              y: clientY,
+            });
+          };
           const moreEl = showMoreLink && anchorForThisCard ? (
             <div
               style={{
@@ -1106,6 +1116,10 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                   e.stopPropagation();
                   handleShowMore(anchorForThisCard);
                 }}
+                onMouseEnter={(e) => buttonHover(e.clientX, e.clientY)}
+                onMouseLeave={() => hideTooltip()}
+                onPointerEnter={(e) => { if (e.pointerType === 'mouse') buttonHover(e.clientX, e.clientY); }}
+                onPointerLeave={(e) => { if (e.pointerType === 'mouse') hideTooltip(); }}
                 style={{ color: anchorColors.text }}
               >
                 {groupRemaining} more <strong style={{ color: anchorColors.text }}>{anchorTopic}</strong>
@@ -1116,6 +1130,15 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
           // Label (between anchor and first claim) — rendered as its own animated row.
           // The chip + × button cap the top of the connector line; the line itself
           // begins just below the chip and bridges into the gap before the first claim.
+          const chipHover = (clientX: number, clientY: number) => {
+            if (!anchorTopic) return;
+            showTooltip({
+              content: buildTooltipLabel(anchorTopic, groupRemaining, anchorColors.text),
+              colors: { text: anchorColors.text, border: anchorColors.border },
+              x: clientX,
+              y: clientY,
+            });
+          };
           const labelEl = isFirstClaim && anchorForThisCard ? (
             <motion.div
               key={`label-${anchorForThisCard}`}
@@ -1140,13 +1163,19 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                 background: anchorColors.border,
                 borderRadius: GROUP_LINE_WIDTH,
               }} />
-              <span style={{
-                fontSize: '11px', fontWeight: 600, color: anchorColors.text,
-                background: anchorColors.bg, border: `1px solid ${anchorColors.border}55`,
-                borderRadius: '4px', padding: '1px 6px',
-                whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-                maxWidth: '220px',
-              }}>
+              <span
+                onMouseEnter={(e) => chipHover(e.clientX, e.clientY)}
+                onMouseLeave={() => hideTooltip()}
+                onPointerEnter={(e) => { if (e.pointerType === 'mouse') chipHover(e.clientX, e.clientY); }}
+                onPointerLeave={(e) => { if (e.pointerType === 'mouse') hideTooltip(); }}
+                style={{
+                  fontSize: '11px', fontWeight: 600, color: anchorColors.text,
+                  background: anchorColors.bg, border: `1px solid ${anchorColors.border}55`,
+                  borderRadius: '4px', padding: '1px 6px',
+                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                  maxWidth: '220px',
+                }}
+              >
                 {anchorTopic ?? 'Related'}
               </span>
               <button


### PR DESCRIPTION
## Summary

Group B of the related-panel UX overhaul. Replaces the inline-rendered `SeeMoreTooltip` with a single global cursor-following tooltip primitive, applies bold + category color to topic labels, and hides the tooltip/button when topic is missing (with a rate-limited diagnostic warning).

- New `HoverTooltip` primitive (`src/components/HoverTooltip.tsx`) — portal-mounted, single instance, continuous cursor-follow, viewport clamp with bottom-flip.
- Mounted once in `Shell.tsx`.
- `RelatedStacks.tsx` migrated: `<mark>` handlers, show-more-link button, topic chip, and relation-type tags all drive the same tooltip imperatively.
- `"N more <Topic>"` format with topic bolded in category color. `Only Topic` and `'related'` fallbacks removed.
- Missing-topic relations suppress the tooltip and the show-more-link button, log a `console.warn` once per `(stackId, rangeIndex)` per session.

Spec: [docs/superpowers/specs/2026-05-13-group-b-tooltip-and-label-design.md](docs/superpowers/specs/2026-05-13-group-b-tooltip-and-label-design.md)
Plan: [docs/superpowers/plans/2026-05-13-group-b-tooltip-and-label.md](docs/superpowers/plans/2026-05-13-group-b-tooltip-and-label.md)

## Test plan

- [x] Hover highlighted span in related card → exactly one tooltip; content `N more <Topic>`
- [x] Cursor follow + viewport clamp + bottom-flip
- [x] Hover show-more-link button → tooltip follows
- [x] Hover topic chip at top of group → tooltip follows
- [x] Hover relation-type tag (Evidence, Agree, etc.) → tooltip follows with category label
- [x] otherCount = 0 → tooltip reads "0 more <Topic>"
- [x] topic undefined → no tooltip, no button, one console.warn per (stackId, rangeIndex)
- [x] pnpm build clean

No GitHub issue tracks this work — branch was created from the listy-injection feature line as part of an in-flight UX overhaul.