### PR TITLE
Group D: Highlight-to-Filter interaction on focus post

### DIFF
--- a/docs/superpowers/plans/2026-05-13-group-d-highlight-to-filter.md
+++ b/docs/superpowers/plans/2026-05-13-group-d-highlight-to-filter.md
@@ -1,0 +1,353 @@
+# Group D — Highlight-to-Filter Implementation Plan
+
+**Date:** 2026-05-13
+**Status:** Ready
+**Spec:** `docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md`
+
+---
+
+## Step 1 — highlightStore: add filterFocusSpan field + actions
+
+**File:** `src/utils/highlightStore.ts`
+
+### 1.1 Add type + field to HighlightState
+
+Add to the `HighlightState` interface:
+```ts
+/** D2: focus-post mark clicked — filter sidebar to spans overlapping this range */
+filterFocusSpan: { start: number; end: number; text: string } | null;
+```
+
+### 1.2 Update INITIAL constant
+
+Add `filterFocusSpan: null` to `INITIAL`.
+
+### 1.3 Add SERVER_SNAPSHOT update
+
+Add `filterFocusSpan: null` to the `SERVER_SNAPSHOT` object.
+
+### 1.4 Add actions
+
+```ts
+export function setFilterFocusSpan(span: { start: number; end: number; text: string }): void {
+  state = { ...state, filterFocusSpan: span };
+  notify();
+}
+
+export function clearFilterFocusSpan(): void {
+  if (state.filterFocusSpan === null) return;
+  state = { ...state, filterFocusSpan: null };
+  notify();
+}
+```
+
+### 1.5 Update resetHighlightStore
+
+Add `filterFocusSpan: null` to the reset state.
+
+**Verification:** `pnpm build` — no errors.
+
+---
+
+## Step 2 — Post.tsx: add data-range-id to renderMultiHighlightHtml marks
+
+**File:** `src/components/Posts/Post.tsx`
+
+### 2.1 In `renderMultiHighlightHtml`
+
+Change the `markHtml` construction at line ~94:
+```ts
+const markHtml = `<mark data-range-id="${entry.index}" style="background:${entry.bgColor};padding:1px 0;color:inherit;border-radius:3px;transition:background 200ms ease">${innerHtml}</mark>`;
+```
+
+**Verification:** `pnpm build` — no errors.
+
+---
+
+## Step 3 — Post.tsx: event delegation + D1 neutral hover + D2 click filter
+
+**File:** `src/components/Posts/Post.tsx`
+
+### 3.1 Import new store actions
+
+Add to imports from `../../utils/highlightStore`:
+```ts
+import { useHighlightStore, setFilterFocusSpan, clearFilterFocusSpan } from '../../utils/highlightStore';
+```
+
+### 3.2 Add state + unique ID in `ActiveHighlightedContent`
+
+Add inside the component, after existing state:
+```ts
+const { filterFocusSpan } = useHighlightStore();  // already has hoveredPostId, etc.
+const [hoveredFocusMarkIndex, setHoveredFocusMarkIndex] = useState<number | null>(null);
+const containerIdRef = useRef<string>(`ahc-${Math.random().toString(36).slice(2)}`);
+```
+
+### 3.3 Event delegation via useEffect
+
+After the existing `useLayoutEffect` and `useEffect` blocks, add:
+
+```ts
+// D1/D2: event delegation on container for focus-post mark hover + click
+useEffect(() => {
+  const el = innerRef.current;
+  if (!el) return;
+
+  const handleMouseOver = (e: MouseEvent) => {
+    if (showCrossHighlight) return; // D1 suppressed during cross-highlight
+    const target = (e.target as HTMLElement).closest('mark');
+    if (!target) return;
+    const rid = target.getAttribute('data-range-id');
+    if (rid !== null) setHoveredFocusMarkIndex(parseInt(rid, 10));
+  };
+  const handleMouseOut = (e: MouseEvent) => {
+    const target = (e.target as HTMLElement).closest('mark');
+    if (!target) return;
+    const related = e.relatedTarget as HTMLElement | null;
+    if (related && target.contains(related)) return;
+    setHoveredFocusMarkIndex(null);
+  };
+  const handleClick = (e: MouseEvent) => {
+    const target = (e.target as HTMLElement).closest('mark');
+    if (!target) return;
+    const rid = target.getAttribute('data-range-id');
+    if (rid === null) return;
+    const idx = parseInt(rid, 10);
+    const rels = hoveredRelations;
+    if (!rels || idx >= rels.length) return;
+    const rel = rels[idx];
+    e.stopPropagation();
+    // Toggle: same span clears, different span sets
+    if (
+      filterFocusSpan !== null &&
+      filterFocusSpan.start === rel.focusStart &&
+      filterFocusSpan.end === rel.focusEnd
+    ) {
+      clearFilterFocusSpan();
+    } else {
+      const plainText = stripHtml(rawText);
+      setFilterFocusSpan({
+        start: rel.focusStart,
+        end: rel.focusEnd,
+        text: plainText.slice(rel.focusStart, rel.focusEnd),
+      });
+    }
+  };
+
+  el.addEventListener('mouseover', handleMouseOver);
+  el.addEventListener('mouseout', handleMouseOut);
+  el.addEventListener('click', handleClick, true); // capture to beat card navigation click
+  return () => {
+    el.removeEventListener('mouseover', handleMouseOver);
+    el.removeEventListener('mouseout', handleMouseOut);
+    el.removeEventListener('click', handleClick, true);
+  };
+}, [showCrossHighlight, hoveredRelations, filterFocusSpan, rawText]);
+```
+
+### 3.4 Inject scoped CSS for D1 neutral hover
+
+After the effect above, add:
+
+```ts
+// D1: inject scoped style to override mark background on hover
+useEffect(() => {
+  const id = containerIdRef.current;
+  const styleId = `d1-hover-${id}`;
+  let styleEl = document.getElementById(styleId) as HTMLStyleElement | null;
+  if (!styleEl) {
+    styleEl = document.createElement('style');
+    styleEl.id = styleId;
+    document.head.appendChild(styleEl);
+  }
+  if (hoveredFocusMarkIndex !== null && !showCrossHighlight) {
+    styleEl.textContent = `#${id} mark[data-range-id="${hoveredFocusMarkIndex}"] { background: rgba(100,116,139,0.30) !important; cursor: pointer; }`;
+  } else {
+    styleEl.textContent = `#${id} mark { cursor: ${showCrossHighlight ? 'default' : 'pointer'}; }`;
+  }
+  return () => {
+    // cleanup only on unmount
+  };
+}, [hoveredFocusMarkIndex, showCrossHighlight]);
+
+// Cleanup style on unmount
+useEffect(() => {
+  const id = containerIdRef.current;
+  return () => {
+    const el = document.getElementById(`d1-hover-${id}`);
+    if (el) el.remove();
+  };
+}, []);
+```
+
+### 3.5 Add id attribute to the container div
+
+Change the return statement in `ActiveHighlightedContent`:
+```tsx
+return <div ref={setRefs} id={containerIdRef.current} className={className} style={mergedStyle} dangerouslySetInnerHTML={{ __html: html }} />;
+```
+
+**Verification:** `pnpm build` — no errors.
+
+---
+
+## Step 4 — RelatedStacks.tsx: span filter + D3 label
+
+**File:** `src/components/RelatedStacks.tsx`
+
+### 4.1 Destructure filterFocusSpan from store
+
+In line ~595 where `useHighlightStore()` is destructured:
+```ts
+const { filterCategories, filterFocusSpan, hoveredHighlightRangeIndex, hoveredCategory, tappedCardPostId, tappedRangeIndex, reRankAnchorIds, anchoredRangeByPost } = useHighlightStore();
+```
+
+### 4.2 Import clearFilterFocusSpan
+
+Add to the import from `../utils/highlightStore`:
+```ts
+import { ..., clearFilterFocusSpan } from '../utils/highlightStore';
+```
+
+### 4.3 Add span filter clause to displayStacks useMemo
+
+After the existing category filter block (around line 776):
+```ts
+// D2: span filter — keep only stacks whose relations overlap the clicked focus-post span
+if (filterFocusSpan !== null) {
+  result = result.filter(s =>
+    (s.topPost.relations ?? []).some(r =>
+      r.focusStart < filterFocusSpan.end && filterFocusSpan.start < r.focusEnd
+    )
+  );
+}
+```
+
+Also add `filterFocusSpan` to the useMemo dependency array.
+
+### 4.4 Add clearFilterFocusSpan to relatedStacks change effect
+
+In the `useEffect` that runs on `relatedStacks` change (around line 960):
+```ts
+useEffect(() => {
+  setHoveredCardIndex(null);
+  setHoveredIndex(null);
+  if (rangeHoverTimer.current) clearTimeout(rangeHoverTimer.current);
+  clearReRankAnchors();
+  clearTapped();
+  clearFilterFocusSpan(); // D2: clear span filter when focus post changes
+}, [relatedStacks]);
+```
+
+### 4.5 Compute shortestCommonText
+
+After `displayStacks` is computed, add a useMemo:
+```ts
+/** D3: shortest common related text for span filter label. Null when filterFocusSpan is null. */
+const shortestCommonText = useMemo<string | null>(() => {
+  if (!filterFocusSpan) return null;
+  if (displayStacks.length === 0) return null;
+
+  let maxStart = filterFocusSpan.start;
+  let minEnd = filterFocusSpan.end;
+
+  for (const s of displayStacks) {
+    const rels = (s.topPost.relations ?? []).filter(r =>
+      filterCategories.size === 0 || filterCategories.has(r.category)
+    );
+    for (const r of rels) {
+      if (r.focusStart > maxStart) maxStart = r.focusStart;
+      if (r.focusEnd < minEnd) minEnd = r.focusEnd;
+    }
+  }
+
+  let text: string;
+  if (maxStart < minEnd && maxStart >= filterFocusSpan.start && minEnd <= filterFocusSpan.end) {
+    text = filterFocusSpan.text.slice(maxStart - filterFocusSpan.start, minEnd - filterFocusSpan.start);
+  } else {
+    text = filterFocusSpan.text; // fallback: entire clicked span
+  }
+
+  return text.length > 60 ? text.slice(0, 60) + '…' : text;
+}, [displayStacks, filterFocusSpan, filterCategories]);
+```
+
+### 4.6 Update sticky header count label
+
+Replace the existing count text (around line 1019):
+```tsx
+<Text size="xs" c="dimmed" mb={4}>
+  {filterCategories.size > 0 && filterFocusSpan !== null
+    ? `${displayStacks.length} post${displayStacks.length !== 1 ? 's' : ''} (category + span filter)`
+    : filterFocusSpan !== null
+    ? `${displayStacks.length} post${displayStacks.length !== 1 ? 's' : ''} (span filter active)`
+    : filterCategories.size > 0
+    ? `${displayStacks.length} ${Array.from(filterCategories).map(c => CATEGORY_LABELS[c] ?? c).join(' + ')} post${displayStacks.length !== 1 ? 's' : ''}`
+    : `${displayStacks.length} posts across all categories`}
+</Text>
+```
+
+And add an indicator chip for the active span filter after that text:
+```tsx
+{filterFocusSpan !== null && (
+  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '0.5rem', flexWrap: 'wrap' }}>
+    <Text size="xs" c="#5a71a8" fw={600} style={{ fontSize: '11px' }}>Span filter:</Text>
+    <span style={{
+      background: '#f1f5f9', border: '1px solid #cbd5e1', color: '#64748b',
+      borderRadius: '4px', padding: '1px 8px', fontSize: '10px', fontWeight: 600,
+      maxWidth: '180px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+    }}>
+      "{filterFocusSpan.text.length > 40 ? filterFocusSpan.text.slice(0, 40) + '…' : filterFocusSpan.text}"
+    </span>
+    <button
+      type="button"
+      onClick={() => clearFilterFocusSpan()}
+      style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: '14px', lineHeight: 1, padding: '0 2px' }}
+      aria-label="Clear span filter"
+    >×</button>
+  </div>
+)}
+```
+
+### 4.7 Render D3 label in each card
+
+Inside the `displayStacks.flatMap` loop, inside the card `<Paper>`, after the category tags div and before the avatar/content:
+
+Find where `contentNodes` is rendered (inside the `<div onClick={handleCardClick}>`) and add above the `<Text component="p">`:
+```tsx
+{/* D3: shortest common related text label */}
+{shortestCommonText !== null && (
+  <div style={{
+    display: 'inline-flex', alignItems: 'center', gap: '4px',
+    background: '#f1f5f9', border: '1px solid #cbd5e1',
+    borderRadius: '4px', padding: '1px 6px', marginBottom: '4px',
+    maxWidth: '100%',
+  }}>
+    <Text size="xs" c="#64748b" style={{ fontSize: '10px', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+      "{shortestCommonText}"
+    </Text>
+  </div>
+)}
+```
+
+**Verification:** `pnpm build` — no errors.
+
+---
+
+## Step 5 — Final build verification
+
+Run `pnpm build` from the worktree root. Confirm:
+- Zero TypeScript errors.
+- Zero Next.js build errors.
+- Bundle sizes not dramatically increased.
+
+---
+
+## Commit sequence
+
+1. `Add filterFocusSpan field and actions to highlightStore (#N)`
+2. `Add data-range-id to focus-post marks for event delegation (#N)`
+3. `Add D1 neutral hover and D2 click-to-filter on focus post (#N)`
+4. `Add D2 span filter and D3 label in RelatedStacks (#N)`
+5. `Add Group D design spec and implementation plan (#N)`

--- a/docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md
+++ b/docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md
@@ -50,7 +50,7 @@ Three missing interaction layers:
 | JC1 | How to attach handlers to `<mark>` elements in `dangerouslySetInnerHTML` output? | Event delegation on the container div in `ActiveHighlightedContent`. Listen for `mouseover`/`mouseout`/`click` on the container; check `e.target.closest('mark')`. | Less invasive than rebuilding `renderMultiHighlightHtml` as JSX. The marks already use inline style; we just need to identify which one was interacted with. |
 | JC2 | How to identify which mark/relation was clicked? | Add `data-range-id="{i}"` attribute to each `<mark>` in `renderMultiHighlightHtml`. The `index` variable is already in scope at construction time. | Zero additional state; deterministic; mirrors RelatedStacks.tsx pattern. |
 | JC3 | D1: hover neutral color | `rgba(100, 116, 139, 0.30)` (slate-500 at 30%) as background override. Applied via React state `hoveredFocusMarkIndex: number | null` in `ActiveHighlightedContent`, which injects a `<style>` scoped to a CSS class. | Can't do per-element style override because the `<mark>` is inside `dangerouslySetInnerHTML`. A CSS class + `useEffect` injects the override rule. |
-| JC4 | D1 + cross-highlight layering | Focus-post marks are **always visible** (dimmed default state at ~0.25 alpha) when the post has relations, even before any sidebar card is hovered. D1 hover fires regardless of cross-highlight state — the neutral grey (`rgba(100,116,139,0.30) !important`) overrides whichever color is currently showing. Cross-highlight (bright colors) layers on top of the dimmed default when a sidebar card is hovered; D1 hover layers on top of cross-highlight if the user simultaneously hovers a mark. The original "JC4 suppression" (`if (showCrossHighlight) return`) has been removed. | Makes marks always legible as interactive affordances. The original suppression was dead code: marks only existed during cross-highlight, so D1 could never fire. Always-on dimmed marks are the intended baseline. |
+| JC4 | D1 + cross-highlight layering | Focus-post marks are **invisible by default**. They appear only when: a sidebar card is hovered (cross-highlight, full brightness), the user has dwelled over the focus-post text area for ≥1500ms (dimmed ~0.25 alpha), or a span filter is active (dimmed). D1 hover (neutral grey `!important`) fires whenever a mark is present in the DOM. Cross-highlight produces bright marks; dwell and filter produce dimmed marks. The dwell timer (`FOCUS_HOVER_DWELL_MS = 1500`) is a named constant. | Avoids always-on visual noise while keeping marks discoverable. The dwell threshold is long enough to distinguish deliberate exploration from accidental hover. A named constant makes it easy to tune without touching logic. |
 | JC5 | `filterFocusSpan` storage location | New field in `highlightStore.ts`, same module as `filterCategories`. Type: `{ start: number; end: number } | null`. | Keeps all filter state co-located; both RelatedStacks and Post.tsx can subscribe via `useHighlightStore`. |
 | JC6 | D2: "same mark again" detection | Clicking a mark whose `focusStart === filterFocusSpan.start && focusEnd === filterFocusSpan.end` clears the filter. | Toggle semantics — consistent with how C's category filter toggles. |
 | JC7 | D2: what offsets does a mark carry? | `data-range-id` lets us index into the active relations array to get `focusStart`/`focusEnd`. When cross-highlight is active (`showCrossHighlight` is true), the active array is `hoveredRelations`. Otherwise it is `focusRelations` (the focus post's own relations passed as a prop). The D2 click handler resolves the same way as the HTML useMemo: `const rels = showCrossHighlight && hoveredRelations ? hoveredRelations : focusRelations`. | Marks are now always present (dimmed or bright), so D2 must work in both states. `focusRelations` is the merged list of all related posts' relation arrays, wired in `toPostData` and passed as a prop. |
@@ -62,19 +62,36 @@ Three missing interaction layers:
 | JC13 | D3: one stack visible | If exactly one stack passes the filter, the "shortest common" is just that stack's focus range text (same as if all stacks have the same range). Fall through normally — the intersection of one span is itself. | No special case needed. |
 | JC14 | Clearing filterFocusSpan | Clear on: same-mark click (D2 toggle), `resetHighlightStore()` call (navigating away), when `relatedStacks` changes (new focus post). RelatedStacks already calls `clearReRankAnchors()` and `clearTapped()` on `relatedStacks` change — add `clearFilterFocusSpan()` to that effect. | Prevents stale filter from persisting across focus post changes. |
 
-### Always-Visible Dimmed Marks (Option B — Locked)
+### Dwell-Triggered Mark Visibility (Option B — Revised)
 
-The original implementation rendered marks only when `showCrossHighlight` was true (a sidebar card was being hovered). This made D1 hover dead code: D1 was suppressed during cross-highlight, and marks didn't exist otherwise.
+The original Option B implementation rendered marks in a **permanently dimmed state** (~0.25 alpha) whenever the focus post had relations. User feedback found this too noisy — the always-on tinting was visually distracting.
 
-**Option B**, now implemented: marks render in a **dimmed default state** (~0.25 alpha per category color) at all times when the focus post has relations. States stack:
+**Current behavior:** Marks on the focus post are **invisible by default** (absent from the DOM). They become visible only under three conditions, computed as `marksVisible`:
 
-| State | Mark appearance |
+```
+marksVisible = showCrossHighlight || focusHoverShowMarks || filterFocusSpan !== null
+```
+
+- **`showCrossHighlight`** — the user is hovering a sidebar card (existing cross-highlight path). Marks appear at full category brightness.
+- **`focusHoverShowMarks`** — the user has held the cursor inside the focus-post text area continuously for ≥ **1500ms** (`FOCUS_HOVER_DWELL_MS`, a named constant). Marks appear dimmed (~0.25 alpha).
+- **`filterFocusSpan !== null`** — a span filter is active (D2 click was used). Marks stay visible so the user can see which span is filtered and toggle it off.
+
+The dwell timer is managed via `focusHoverTimerRef` (a `useRef<ReturnType<typeof setTimeout> | null>`). `onMouseEnter` starts the timer; `onMouseLeave` cancels it and immediately clears `focusHoverShowMarks`. A `useEffect` cleanup on unmount prevents timer leaks.
+
+The constant `FOCUS_HOVER_DWELL_MS = 1500` is declared at module level and can be tuned without touching component logic.
+
+Mark states when `marksVisible` is true:
+
+| Trigger | Mark appearance |
 |---|---|
-| Default (no hover anywhere) | Dimmed category color (~0.25 alpha) |
-| Cross-highlight (sidebar card hovered) | Bright category colors (alpha 1.0 for relevant ranges, 0.2 for others) |
-| D1 hover (mark directly hovered on focus post) | Neutral grey `rgba(100,116,139,0.30)` overrides current color via `!important` |
+| Cross-highlight (`showCrossHighlight`) | Bright category colors (alpha 1.0 for hovered range, 0.2 for others) |
+| Dwell (`focusHoverShowMarks`) | Dimmed category colors (~0.25 alpha) |
+| Span filter active (`filterFocusSpan !== null`) | Dimmed category colors (~0.25 alpha) |
+| D1 hover (mark directly hovered on focus post) | Neutral grey `rgba(100,116,139,0.30)` via `!important` scoped style |
 
-The expand-to-reveal animation **only fires when cross-highlight activates** (not on initial dimmed render), preserving the animation's purpose: smoothly revealing marks that would otherwise be hidden under the 5-line clamp when a sidebar card is first hovered.
+When `marksVisible` is false, no `<mark>` elements are present in the DOM.
+
+The expand-to-reveal animation now triggers on **any** `marksVisible → true` transition (cross-highlight OR dwell). The collapse animation fires when `marksVisible` becomes false. This ensures dwell-revealed marks that fall below the 5-line clamp are also expanded to view.
 
 ---
 
@@ -83,8 +100,8 @@ The expand-to-reveal animation **only fires when cross-highlight activates** (no
 ### D1 — Neutral highlight on focus-post hover
 
 - Applies ONLY in `ActiveHighlightedContent` (the component rendered for the active/focus post).
-- Marks are **always present** when the focus post has relations (dimmed default ~0.25 alpha).
-- D1 activates when the user moves mouse over a `<mark>` — regardless of whether `showCrossHighlight` is true or false.
+- Marks are **invisible by default** (absent from DOM). They become visible only when `marksVisible` is true: cross-highlight active, dwell threshold (1500ms) reached, or span filter active.
+- D1 activates when the user moves the mouse over a `<mark>` element that is currently in the DOM — regardless of which trigger made `marksVisible` true.
 - While active: the hovered mark's background becomes `rgba(100, 116, 139, 0.30)` — overrides the current category color (whether dimmed or bright) via a dynamically injected `<style>` block scoped to a unique ID using `!important`.
 - On `mouseout` from a `<mark>`, `hoveredFocusMarkIndex` resets to null, removing the override.
 - Cursor over all `<mark>` elements: `pointer` (always indicates clickability).
@@ -151,12 +168,16 @@ if (filterFocusSpan !== null) {
 1. `pnpm build` must produce zero TypeScript errors and zero build warnings related to changed files.
 2. Manual test (documented in PR test plan):
    - Open a post with related stacks.
-   - Hover a sidebar card → focus post marks appear in category colors.
-   - While sidebar card is hovered, move mouse to a focus-post mark → NO neutral color (cross-highlight takes priority, JC4).
-   - Un-hover sidebar card → marks disappear. Now hover directly over the focus-post text area where a mark was → neutral grey appears.
-   - Click the mark → sidebar filters to only posts relating to that span. Count label updates.
+   - Hover briefly over the focus post text — marks should NOT appear (under 1500ms).
+   - Hover and hold over the focus post text for 1.5s → marks fade in at dimmed category colors.
+   - Move mouse away → marks disappear immediately.
+   - Hover a sidebar card → focus post marks appear in full category colors (cross-highlight).
+   - While sidebar card is hovered, move mouse to a focus-post mark → neutral grey (D1) overrides.
+   - Un-hover sidebar card → marks disappear. Now dwell (1.5s) on focus post → dimmed marks appear.
+   - Click a mark during dwell-visible state → sidebar filters to only posts relating to that span. Count label updates.
    - Click same mark again → filter clears, all sidebar posts return.
    - Click a different mark → span filter switches.
+   - With span filter active, leave focus post — marks stay visible (filter keeps `marksVisible` true).
    - With span filter active, each sidebar card shows the intersection label chip.
    - Apply a category filter (Group C chips) → AND: only stacks matching both span and category show.
    - Navigate away → no stale span filter on next post.
@@ -192,7 +213,7 @@ if (filterFocusSpan !== null) {
 
 3. **JC3 — Neutral hover via scoped `<style>` injection.** Cannot override per-element inline style inside `dangerouslySetInnerHTML` from outside. Inject a `<style>` block with a class selector that overrides the mark's background, scoped to a stable unique ID on the container.
 
-4. **JC4 — Always-visible dimmed marks; D1 fires regardless of cross-highlight.** Focus-post marks render at ~0.25 alpha in their category colors at all times when the post has relations. D1 (neutral grey hover) fires on direct mark hover regardless of whether cross-highlight is active. The original suppression (`if (showCrossHighlight) return`) was removed because it made D1 dead code — marks only existed during cross-highlight, so D1 could never fire. Option B fixes this by making marks always present.
+4. **JC4 — Dwell-triggered marks; D1 fires whenever marks are present.** Focus-post marks are invisible by default (absent from DOM). They appear only when `marksVisible = showCrossHighlight || focusHoverShowMarks || filterFocusSpan !== null`. `focusHoverShowMarks` becomes true after 1500ms of continuous cursor presence over the focus-post text area (`FOCUS_HOVER_DWELL_MS`, tunable constant). D1 (neutral grey hover) fires on direct mark hover regardless of which trigger made marks visible. The always-on dimmed state (original Option B) was replaced because it produced constant visual noise; the dwell threshold filters out accidental hover while keeping marks discoverable on deliberate inspection.
 
 5. **JC5 — filterFocusSpan in highlightStore.** Co-locates all filter state. Both Post.tsx (writer) and RelatedStacks.tsx (reader) access it through the same store hook.
 

--- a/docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md
+++ b/docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md
@@ -62,49 +62,48 @@ Three missing interaction layers:
 | JC13 | D3: one stack visible | If exactly one stack passes the filter, the "shortest common" is just that stack's focus range text (same as if all stacks have the same range). Fall through normally — the intersection of one span is itself. | No special case needed. |
 | JC14 | Clearing filterFocusSpan | Clear on: same-mark click (D2 toggle), `resetHighlightStore()` call (navigating away), when `relatedStacks` changes (new focus post). RelatedStacks already calls `clearReRankAnchors()` and `clearTapped()` on `relatedStacks` change — add `clearFilterFocusSpan()` to that effect. | Prevents stale filter from persisting across focus post changes. |
 
-### Dwell-Triggered Mark Visibility (Option B — Revised)
+### Dwell-Triggered Mark Visibility (Option B — Per-Mark Dwell)
 
-The original Option B implementation rendered marks in a **permanently dimmed state** (~0.25 alpha) whenever the focus post had relations. User feedback found this too noisy — the always-on tinting was visually distracting.
+The original Option B implementation rendered marks in a **permanently dimmed state** (~0.25 alpha) whenever the focus post had relations. An intermediate revision made all marks appear after 1500ms of cursor presence anywhere inside the focus-post container. Both were found too noisy. The current model targets **individual marks**: only the specific mark the cursor dwells on becomes visible.
 
-**Current behavior:** Marks on the focus post are **invisible by default** (absent from the DOM). They become visible only under three conditions, computed as `marksVisible`:
+**Current behavior:** `<mark>` elements are **always present in the DOM** (so cursor-over-mark events fire reliably), but they are **visually invisible by default** (`background: transparent !important` via scoped `<style>`). A mark becomes visible only under one of three conditions:
 
-```
-marksVisible = showCrossHighlight || focusHoverShowMarks || filterFocusSpan !== null
-```
+- **`showCrossHighlight`** — the user is hovering a sidebar card. The scoped style rule is cleared; inline category colors on each `<mark>` take over (full brightness for the hovered range, 0.2 alpha for others). All marks are visible.
+- **`dwellOnMarkIndex !== null`** — the user has held the cursor on a specific `<mark>` for ≥ **1500ms** (`FOCUS_HOVER_DWELL_MS`, a named constant). Only that one mark becomes visible in **neutral grey** (`rgba(100,116,139,0.30)`). Moving the cursor to a different mark cancels the timer, immediately hides the previously-shown mark, and starts a fresh 1500ms timer on the new mark. Leaving a mark with no incoming mark cancels the timer and hides the mark.
+- **`filterFocusSpan !== null` (and matching relation found)** — a span filter is active (D2 click was used). The matching mark stays visible in neutral grey so the user can see which span is filtered and toggle it off.
 
-- **`showCrossHighlight`** — the user is hovering a sidebar card (existing cross-highlight path). Marks appear at full category brightness.
-- **`focusHoverShowMarks`** — the user has held the cursor inside the focus-post text area continuously for ≥ **1500ms** (`FOCUS_HOVER_DWELL_MS`, a named constant). Marks appear dimmed (~0.25 alpha).
-- **`filterFocusSpan !== null`** — a span filter is active (D2 click was used). Marks stay visible so the user can see which span is filtered and toggle it off.
-
-The dwell timer is managed via `focusHoverTimerRef` (a `useRef<ReturnType<typeof setTimeout> | null>`). `onMouseEnter` starts the timer; `onMouseLeave` cancels it and immediately clears `focusHoverShowMarks`. A `useEffect` cleanup on unmount prevents timer leaks.
+The state is `dwellOnMarkIndex: number | null` (React state). The timer is `dwellTimerRef` (`useRef<ReturnType<typeof setTimeout> | null>`). Both `mouseover` and `mouseout` are handled via event delegation on the container element (same `useEffect` that handles D2 click). A `useEffect` cleanup on unmount prevents timer leaks.
 
 The constant `FOCUS_HOVER_DWELL_MS = 1500` is declared at module level and can be tuned without touching component logic.
 
-Mark states when `marksVisible` is true:
+A derived value `visibleMarkIdx` combines dwell and filter into a single index (dwell wins over filter if both are active). A second derived value `anyMarkVisuallyActive` replaces the old `marksVisible` flag for expand/collapse gating.
+
+Mark states summary:
 
 | Trigger | Mark appearance |
 |---|---|
 | Cross-highlight (`showCrossHighlight`) | Bright category colors (alpha 1.0 for hovered range, 0.2 for others) |
-| Dwell (`focusHoverShowMarks`) | Dimmed category colors (~0.25 alpha) |
-| Span filter active (`filterFocusSpan !== null`) | Dimmed category colors (~0.25 alpha) |
-| D1 hover (mark directly hovered on focus post) | Neutral grey `rgba(100,116,139,0.30)` via `!important` scoped style |
+| Per-mark dwell (`dwellOnMarkIndex`) | One mark: neutral grey `rgba(100,116,139,0.30)`. All others: invisible. |
+| Span filter active (`filterFocusSpan` matched) | Matching mark: neutral grey. All others: invisible. |
+| Default | All marks invisible (but present in DOM for event handling). |
 
-When `marksVisible` is false, no `<mark>` elements are present in the DOM.
+The D1 neutral-hover affordance is now unified with dwell: hovering a mark IS the dwell trigger. There is no separate "D1 hover immediate" effect — the 1500ms threshold acts as the intentionality gate.
 
-The expand-to-reveal animation now triggers on **any** `marksVisible → true` transition (cross-highlight OR dwell). The collapse animation fires when `marksVisible` becomes false. This ensures dwell-revealed marks that fall below the 5-line clamp are also expanded to view.
+The expand-to-reveal animation triggers on any `anyMarkVisuallyActive → true` transition. The collapse animation fires when `anyMarkVisuallyActive` becomes false. This ensures dwell-revealed marks that fall below the 5-line clamp are expanded to view.
 
 ---
 
 ## 5. Behavior Specification
 
-### D1 — Neutral highlight on focus-post hover
+### D1 — Neutral highlight on focus-post hover (per-mark dwell)
 
 - Applies ONLY in `ActiveHighlightedContent` (the component rendered for the active/focus post).
-- Marks are **invisible by default** (absent from DOM). They become visible only when `marksVisible` is true: cross-highlight active, dwell threshold (1500ms) reached, or span filter active.
-- D1 activates when the user moves the mouse over a `<mark>` element that is currently in the DOM — regardless of which trigger made `marksVisible` true.
-- While active: the hovered mark's background becomes `rgba(100, 116, 139, 0.30)` — overrides the current category color (whether dimmed or bright) via a dynamically injected `<style>` block scoped to a unique ID using `!important`.
-- On `mouseout` from a `<mark>`, `hoveredFocusMarkIndex` resets to null, removing the override.
-- Cursor over all `<mark>` elements: `pointer` (always indicates clickability).
+- Marks are **always present in the DOM** but visually invisible (`background: transparent !important` via scoped `<style>`).
+- D1 is unified with the dwell mechanism: hovering a `<mark>` starts a 1500ms (`FOCUS_HOVER_DWELL_MS`) timer for that specific mark. After 1500ms, that mark's background becomes `rgba(100, 116, 139, 0.30)` (neutral grey) via a `!important` rule in the scoped style block. All other marks remain invisible.
+- Moving the cursor to a different mark: timer is cancelled, the previously-shown mark immediately reverts to invisible, and a fresh 1500ms timer starts for the new mark.
+- On `mouseout` from a mark (with no incoming mark): timer is cancelled, `dwellOnMarkIndex` resets to null, mark becomes invisible. A 200ms CSS transition (`transition: background 200ms ease`) softens the fade-out.
+- When cross-highlight is active: the scoped style block only sets `cursor: pointer`; inline category colors on each `<mark>` take over. The dwell timer still tracks state but the CSS override for neutral grey is not applied.
+- Cursor over all `<mark>` elements: `pointer` (always indicates clickability, even when invisible).
 
 ### D2 — Click → filter related panel by span
 

--- a/docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md
+++ b/docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md
@@ -50,10 +50,10 @@ Three missing interaction layers:
 | JC1 | How to attach handlers to `<mark>` elements in `dangerouslySetInnerHTML` output? | Event delegation on the container div in `ActiveHighlightedContent`. Listen for `mouseover`/`mouseout`/`click` on the container; check `e.target.closest('mark')`. | Less invasive than rebuilding `renderMultiHighlightHtml` as JSX. The marks already use inline style; we just need to identify which one was interacted with. |
 | JC2 | How to identify which mark/relation was clicked? | Add `data-range-id="{i}"` attribute to each `<mark>` in `renderMultiHighlightHtml`. The `index` variable is already in scope at construction time. | Zero additional state; deterministic; mirrors RelatedStacks.tsx pattern. |
 | JC3 | D1: hover neutral color | `rgba(100, 116, 139, 0.30)` (slate-500 at 30%) as background override. Applied via React state `hoveredFocusMarkIndex: number | null` in `ActiveHighlightedContent`, which injects a `<style>` scoped to a CSS class. | Can't do per-element style override because the `<mark>` is inside `dangerouslySetInnerHTML`. A CSS class + `useEffect` injects the override rule. |
-| JC4 | D1 + cross-highlight conflict | When `hoveredFocusMarkIndex` is set, the neutral style takes priority over the category color. When a sidebar card is being hovered (cross-highlight is active), the cross-highlight colors take priority over D1. Concretely: if `showCrossHighlight` is true, D1 hover state is suppressed (not shown, not stored). | Avoids confusing interaction where the user hovers a sidebar card AND hovers a focus mark simultaneously. Cross-highlight is the higher-signal event. |
+| JC4 | D1 + cross-highlight layering | Focus-post marks are **always visible** (dimmed default state at ~0.25 alpha) when the post has relations, even before any sidebar card is hovered. D1 hover fires regardless of cross-highlight state — the neutral grey (`rgba(100,116,139,0.30) !important`) overrides whichever color is currently showing. Cross-highlight (bright colors) layers on top of the dimmed default when a sidebar card is hovered; D1 hover layers on top of cross-highlight if the user simultaneously hovers a mark. The original "JC4 suppression" (`if (showCrossHighlight) return`) has been removed. | Makes marks always legible as interactive affordances. The original suppression was dead code: marks only existed during cross-highlight, so D1 could never fire. Always-on dimmed marks are the intended baseline. |
 | JC5 | `filterFocusSpan` storage location | New field in `highlightStore.ts`, same module as `filterCategories`. Type: `{ start: number; end: number } | null`. | Keeps all filter state co-located; both RelatedStacks and Post.tsx can subscribe via `useHighlightStore`. |
 | JC6 | D2: "same mark again" detection | Clicking a mark whose `focusStart === filterFocusSpan.start && focusEnd === filterFocusSpan.end` clears the filter. | Toggle semantics — consistent with how C's category filter toggles. |
-| JC7 | D2: what offsets does a mark carry? | `data-range-id` lets us index into `hoveredRelations[i]` to get `focusStart`/`focusEnd`. `hoveredRelations` is already in the store (set when a sidebar card was most recently hovered). If no sidebar card has been hovered yet (`hoveredRelations === null`), clicks on marks do nothing (marks only appear when `showCrossHighlight` is true — i.e., when `hoveredRelations` is set). So this is always safe. | The relations context is always available when marks are visible. |
+| JC7 | D2: what offsets does a mark carry? | `data-range-id` lets us index into the active relations array to get `focusStart`/`focusEnd`. When cross-highlight is active (`showCrossHighlight` is true), the active array is `hoveredRelations`. Otherwise it is `focusRelations` (the focus post's own relations passed as a prop). The D2 click handler resolves the same way as the HTML useMemo: `const rels = showCrossHighlight && hoveredRelations ? hoveredRelations : focusRelations`. | Marks are now always present (dimmed or bright), so D2 must work in both states. `focusRelations` is the merged list of all related posts' relation arrays, wired in `toPostData` and passed as a prop. |
 | JC8 | D3: "relevant relations" for shortest-common computation | Use ALL of a stack's relations (not just the active-category-filtered ones), since the user may have no category filter active. If `filterCategories` is non-empty, restrict to relations whose category is in `filterCategories`. | Consistent with how the category filter behaves in the display pipeline. |
 | JC9 | D3: intersection empty → fallback | When `maxStart >= minEnd` across visible stacks, fall back to rendering the text of `filterFocusSpan` itself (the clicked span). This covers the case where different stacks respond to non-overlapping parts of the focus post. | Graceful degradation; still informative. |
 | JC10 | D3: zero visible stacks | When no stacks pass the combined filter, the label is not rendered (there are no cards to label). | No label needed with no cards. |
@@ -62,6 +62,20 @@ Three missing interaction layers:
 | JC13 | D3: one stack visible | If exactly one stack passes the filter, the "shortest common" is just that stack's focus range text (same as if all stacks have the same range). Fall through normally — the intersection of one span is itself. | No special case needed. |
 | JC14 | Clearing filterFocusSpan | Clear on: same-mark click (D2 toggle), `resetHighlightStore()` call (navigating away), when `relatedStacks` changes (new focus post). RelatedStacks already calls `clearReRankAnchors()` and `clearTapped()` on `relatedStacks` change — add `clearFilterFocusSpan()` to that effect. | Prevents stale filter from persisting across focus post changes. |
 
+### Always-Visible Dimmed Marks (Option B — Locked)
+
+The original implementation rendered marks only when `showCrossHighlight` was true (a sidebar card was being hovered). This made D1 hover dead code: D1 was suppressed during cross-highlight, and marks didn't exist otherwise.
+
+**Option B**, now implemented: marks render in a **dimmed default state** (~0.25 alpha per category color) at all times when the focus post has relations. States stack:
+
+| State | Mark appearance |
+|---|---|
+| Default (no hover anywhere) | Dimmed category color (~0.25 alpha) |
+| Cross-highlight (sidebar card hovered) | Bright category colors (alpha 1.0 for relevant ranges, 0.2 for others) |
+| D1 hover (mark directly hovered on focus post) | Neutral grey `rgba(100,116,139,0.30)` overrides current color via `!important` |
+
+The expand-to-reveal animation **only fires when cross-highlight activates** (not on initial dimmed render), preserving the animation's purpose: smoothly revealing marks that would otherwise be hidden under the 5-line clamp when a sidebar card is first hovered.
+
 ---
 
 ## 5. Behavior Specification
@@ -69,16 +83,16 @@ Three missing interaction layers:
 ### D1 — Neutral highlight on focus-post hover
 
 - Applies ONLY in `ActiveHighlightedContent` (the component rendered for the active/focus post).
-- Activates when `showCrossHighlight` is false (no sidebar card hover in progress) AND user moves mouse over a `<mark>`.
-- While active: the hovered mark's background becomes `rgba(100, 116, 139, 0.30)` — overrides the normal category color via a dynamically injected `<style>` block scoped to a unique ID.
-- When `showCrossHighlight` is true, D1 is suppressed entirely — category colors take over as before.
+- Marks are **always present** when the focus post has relations (dimmed default ~0.25 alpha).
+- D1 activates when the user moves mouse over a `<mark>` — regardless of whether `showCrossHighlight` is true or false.
+- While active: the hovered mark's background becomes `rgba(100, 116, 139, 0.30)` — overrides the current category color (whether dimmed or bright) via a dynamically injected `<style>` block scoped to a unique ID using `!important`.
 - On `mouseout` from a `<mark>`, `hoveredFocusMarkIndex` resets to null, removing the override.
-- Cursor over `<mark>` elements when cross-highlight is inactive: `pointer` (indicates clickability).
+- Cursor over all `<mark>` elements: `pointer` (always indicates clickability).
 
 ### D2 — Click → filter related panel by span
 
-- Activates when user clicks a `<mark>` on the focus post while `showCrossHighlight` could be true or false. (The mark is only visible when `showCrossHighlight` is true, but technically the user could click very quickly — the guard is: only process if a mark is clicked AND `hoveredRelations` is non-null.)
-- On click: extract `data-range-id` → index into `hoveredRelations[i]` → get `focusStart`, `focusEnd`. Compute `focusPlainText.slice(focusStart, focusEnd)` as the text snippet.
+- Activates when user clicks a `<mark>` on the focus post (marks are always visible, so this works in any state).
+- On click: extract `data-range-id` → index into the active relations array (`hoveredRelations` during cross-highlight, `focusRelations` otherwise) → get `focusStart`, `focusEnd`. Compute `focusPlainText.slice(focusStart, focusEnd)` as the text snippet.
 - Call `setFilterFocusSpan({ start: focusStart, end: focusEnd, text: snippet })`.
 - Toggle: if `filterFocusSpan.start === focusStart && filterFocusSpan.end === focusEnd`, call `clearFilterFocusSpan()`.
 - In `RelatedStacks.tsx`, in the `displayStacks` useMemo filter pipeline (after the category filter clause):
@@ -178,13 +192,13 @@ if (filterFocusSpan !== null) {
 
 3. **JC3 — Neutral hover via scoped `<style>` injection.** Cannot override per-element inline style inside `dangerouslySetInnerHTML` from outside. Inject a `<style>` block with a class selector that overrides the mark's background, scoped to a stable unique ID on the container.
 
-4. **JC4 — Cross-highlight suppresses D1.** When a sidebar card is hovered and marks are in category colors, D1 neutral hover is disabled. Cross-highlight is the higher-intent signal. D1 only activates when no sidebar card is being hovered.
+4. **JC4 — Always-visible dimmed marks; D1 fires regardless of cross-highlight.** Focus-post marks render at ~0.25 alpha in their category colors at all times when the post has relations. D1 (neutral grey hover) fires on direct mark hover regardless of whether cross-highlight is active. The original suppression (`if (showCrossHighlight) return`) was removed because it made D1 dead code — marks only existed during cross-highlight, so D1 could never fire. Option B fixes this by making marks always present.
 
 5. **JC5 — filterFocusSpan in highlightStore.** Co-locates all filter state. Both Post.tsx (writer) and RelatedStacks.tsx (reader) access it through the same store hook.
 
 6. **JC6 — Click same mark toggles filter off.** Consistent with C's category filter toggle semantics.
 
-7. **JC7 — Marks only visible when hoveredRelations is set.** D2 is safe: marks only exist during cross-highlight, so `hoveredRelations` is always non-null when a mark can be clicked.
+7. **JC7 — D2 resolves relations from active state.** Marks are always present. The click handler resolves relations as `showCrossHighlight && hoveredRelations ? hoveredRelations : focusRelations`, the same logic as the HTML useMemo. `focusRelations` is the merged flat list of all related posts' relation arrays, provided via the new `focusRelations` prop on `Post`.
 
 8. **JC8 — D3 uses category-filtered relations when filter is active.** If the user has both a category filter and a span filter active, the intersection label only considers the filtered relation categories.
 

--- a/docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md
+++ b/docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md
@@ -1,0 +1,203 @@
+# Group D — Highlight-to-Filter Interaction (Design Spec)
+
+**Date:** 2026-05-13
+**Status:** Ready for implementation
+**Scope:** Focus-post highlight hover (neutral), click-to-filter-by-span, shortest-common-related-text label in sidebar cards.
+**Owner:** tarcode2004
+**Approach:** Event delegation on focus post container; new `filterFocusSpan` store field; surgical filter clause in RelatedStacks; label injected in card UI.
+
+---
+
+## 1. Problem
+
+The focus post shows colorful `<mark>` elements when a sidebar card is hovered (cross-highlighting). These marks are inert — no hover feedback, no click behavior, no way for the user to say "filter the sidebar to posts that relate to THIS phrase."
+
+Three missing interaction layers:
+
+1. **No hover feedback on focus-post marks.** The user cannot tell that marks are interactive.
+2. **No span-click-to-filter.** Clicking a focus-post mark does nothing — no bridge from "this phrase caught my eye" to "show me only posts that respond to this phrase."
+3. **No "what phrase connects these?" label in the sidebar.** When a span filter is active, users cannot easily see which substring all visible sidebar posts share.
+
+---
+
+## 2. Goals
+
+- **D1.** Hovering a `<mark>` on the focus post applies a neutral grey highlight to that span only (hover visual). Releasing hover restores the category color. No tooltip.
+- **D2.** Clicking a `<mark>` on the focus post filters the sidebar panel to stacks whose `relations[i].focusStart..focusEnd` overlaps the clicked span. The span filter ANDs with C's category filter. Clicking the same mark again clears the span filter.
+- **D3.** When `filterFocusSpan` is active, each sidebar card shows a small label: the shortest substring of the focus post's plain text that all currently-visible stacks' relevant spans collectively cover (intersection). If the intersection is empty (non-overlapping spans), fall back to `filterFocusSpan` itself. Truncate at 60 chars + `…`.
+
+---
+
+## 3. Non-Goals
+
+- No tooltip text when hovering focus-post marks (Group B owns tooltips).
+- No change to the cross-highlighting behavior when hovering sidebar cards — D1 only activates when the user hovers directly on the focus post.
+- No change to HoverTooltip.tsx.
+- No change to Shell.tsx.
+- No change to ThreadedReplyList.tsx (Group G).
+- No change to ReplySection.tsx (Group I).
+- No visual redesign of cards (Group F).
+- No reordering logic (Group E).
+- No URL persistence of filter state.
+- No mobile/touch handling beyond what already exists for the span filter clear.
+
+---
+
+## 4. Decisions Locked (Judgment Calls Made Without User Input)
+
+| # | Question | Decision | Rationale |
+|---|---|---|---|
+| JC1 | How to attach handlers to `<mark>` elements in `dangerouslySetInnerHTML` output? | Event delegation on the container div in `ActiveHighlightedContent`. Listen for `mouseover`/`mouseout`/`click` on the container; check `e.target.closest('mark')`. | Less invasive than rebuilding `renderMultiHighlightHtml` as JSX. The marks already use inline style; we just need to identify which one was interacted with. |
+| JC2 | How to identify which mark/relation was clicked? | Add `data-range-id="{i}"` attribute to each `<mark>` in `renderMultiHighlightHtml`. The `index` variable is already in scope at construction time. | Zero additional state; deterministic; mirrors RelatedStacks.tsx pattern. |
+| JC3 | D1: hover neutral color | `rgba(100, 116, 139, 0.30)` (slate-500 at 30%) as background override. Applied via React state `hoveredFocusMarkIndex: number | null` in `ActiveHighlightedContent`, which injects a `<style>` scoped to a CSS class. | Can't do per-element style override because the `<mark>` is inside `dangerouslySetInnerHTML`. A CSS class + `useEffect` injects the override rule. |
+| JC4 | D1 + cross-highlight conflict | When `hoveredFocusMarkIndex` is set, the neutral style takes priority over the category color. When a sidebar card is being hovered (cross-highlight is active), the cross-highlight colors take priority over D1. Concretely: if `showCrossHighlight` is true, D1 hover state is suppressed (not shown, not stored). | Avoids confusing interaction where the user hovers a sidebar card AND hovers a focus mark simultaneously. Cross-highlight is the higher-signal event. |
+| JC5 | `filterFocusSpan` storage location | New field in `highlightStore.ts`, same module as `filterCategories`. Type: `{ start: number; end: number } | null`. | Keeps all filter state co-located; both RelatedStacks and Post.tsx can subscribe via `useHighlightStore`. |
+| JC6 | D2: "same mark again" detection | Clicking a mark whose `focusStart === filterFocusSpan.start && focusEnd === filterFocusSpan.end` clears the filter. | Toggle semantics — consistent with how C's category filter toggles. |
+| JC7 | D2: what offsets does a mark carry? | `data-range-id` lets us index into `hoveredRelations[i]` to get `focusStart`/`focusEnd`. `hoveredRelations` is already in the store (set when a sidebar card was most recently hovered). If no sidebar card has been hovered yet (`hoveredRelations === null`), clicks on marks do nothing (marks only appear when `showCrossHighlight` is true — i.e., when `hoveredRelations` is set). So this is always safe. | The relations context is always available when marks are visible. |
+| JC8 | D3: "relevant relations" for shortest-common computation | Use ALL of a stack's relations (not just the active-category-filtered ones), since the user may have no category filter active. If `filterCategories` is non-empty, restrict to relations whose category is in `filterCategories`. | Consistent with how the category filter behaves in the display pipeline. |
+| JC9 | D3: intersection empty → fallback | When `maxStart >= minEnd` across visible stacks, fall back to rendering the text of `filterFocusSpan` itself (the clicked span). This covers the case where different stacks respond to non-overlapping parts of the focus post. | Graceful degradation; still informative. |
+| JC10 | D3: zero visible stacks | When no stacks pass the combined filter, the label is not rendered (there are no cards to label). | No label needed with no cards. |
+| JC11 | D3: label placement | Below the category tag row (absolute top-left area), inside the card's content `div`, before `contentNodes`. A small dim chip: `font-size: 10px`, slate background `#f1f5f9`, border `#cbd5e1`, color `#64748b`. | Unobtrusive; consistent with existing chip aesthetics in the panel. |
+| JC12 | D3: focus post plain text | `hoveredRelations[i].focusStart..focusEnd` points into `stripHtml(rawText)` (the plain text). But `RelatedStacks` does not have the focus post's plain text. The `filterFocusSpan` store field needs to also carry the relevant text snippet for D3 to render without the panel needing access to the full focus post text. | Store `{ start, end, text }` in `filterFocusSpan` where `text = focusPlainText.slice(start, end)`. |
+| JC13 | D3: one stack visible | If exactly one stack passes the filter, the "shortest common" is just that stack's focus range text (same as if all stacks have the same range). Fall through normally — the intersection of one span is itself. | No special case needed. |
+| JC14 | Clearing filterFocusSpan | Clear on: same-mark click (D2 toggle), `resetHighlightStore()` call (navigating away), when `relatedStacks` changes (new focus post). RelatedStacks already calls `clearReRankAnchors()` and `clearTapped()` on `relatedStacks` change — add `clearFilterFocusSpan()` to that effect. | Prevents stale filter from persisting across focus post changes. |
+
+---
+
+## 5. Behavior Specification
+
+### D1 — Neutral highlight on focus-post hover
+
+- Applies ONLY in `ActiveHighlightedContent` (the component rendered for the active/focus post).
+- Activates when `showCrossHighlight` is false (no sidebar card hover in progress) AND user moves mouse over a `<mark>`.
+- While active: the hovered mark's background becomes `rgba(100, 116, 139, 0.30)` — overrides the normal category color via a dynamically injected `<style>` block scoped to a unique ID.
+- When `showCrossHighlight` is true, D1 is suppressed entirely — category colors take over as before.
+- On `mouseout` from a `<mark>`, `hoveredFocusMarkIndex` resets to null, removing the override.
+- Cursor over `<mark>` elements when cross-highlight is inactive: `pointer` (indicates clickability).
+
+### D2 — Click → filter related panel by span
+
+- Activates when user clicks a `<mark>` on the focus post while `showCrossHighlight` could be true or false. (The mark is only visible when `showCrossHighlight` is true, but technically the user could click very quickly — the guard is: only process if a mark is clicked AND `hoveredRelations` is non-null.)
+- On click: extract `data-range-id` → index into `hoveredRelations[i]` → get `focusStart`, `focusEnd`. Compute `focusPlainText.slice(focusStart, focusEnd)` as the text snippet.
+- Call `setFilterFocusSpan({ start: focusStart, end: focusEnd, text: snippet })`.
+- Toggle: if `filterFocusSpan.start === focusStart && filterFocusSpan.end === focusEnd`, call `clearFilterFocusSpan()`.
+- In `RelatedStacks.tsx`, in the `displayStacks` useMemo filter pipeline (after the category filter clause):
+
+```
+if (filterFocusSpan !== null) {
+  result = result.filter(s =>
+    (s.topPost.relations ?? []).some(r =>
+      r.focusStart < filterFocusSpan.end && filterFocusSpan.start < r.focusEnd
+    )
+  );
+}
+```
+
+- The category filter runs first, then the span filter, resulting in AND semantics.
+
+### D3 — Shortest common related text label
+
+- Only rendered when `filterFocusSpan !== null`.
+- For each visible stack (post-filter), collect its relevant relations:
+  - If `filterCategories.size > 0`: only relations whose `category` is in `filterCategories`.
+  - Otherwise: all relations.
+- From those relations, collect all `(focusStart, focusEnd)` pairs.
+- Compute `maxStart = max(all focusStart)` and `minEnd = min(all focusEnd)`.
+- If `maxStart < minEnd`: intersection text = `filterFocusSpan.text` trimmed at [maxStart - filterFocusSpan.start, minEnd - filterFocusSpan.start] relative offsets within the snippet.
+  - Actually simpler: intersection is `focusPlainText.slice(maxStart, minEnd)`. Since we stored the snippet text and we know `filterFocusSpan.start`, we can compute `snippet.slice(maxStart - filterFocusSpan.start, minEnd - filterFocusSpan.start)` — but this requires knowing the full plain text. Instead, store full snippet of the filterFocusSpan but also compute the intersection against a reconstructed plain text slice stored in the store.
+  - **Simplification (JC15):** Store `focusPlainText` as a module-level variable in `highlightStore.ts` set when `setFilterFocusSpan` is called. OR pass the intersected text directly. The cleanest approach: store only the clicked span's text in `filterFocusSpan.text` and in RelatedStacks compute the narrowed intersection by string search within that snippet.
+
+  **Practical D3 computation in `RelatedStacks`:**
+  Given `filterFocusSpan = { start, end, text }` and `visibleStacks`:
+  1. Collect all `(r.focusStart, r.focusEnd)` from each visible stack's relevant relations.
+  2. `maxStart = Math.max(...all focusStart values)`.
+  3. `minEnd = Math.min(...all focusEnd values)`.
+  4. If `maxStart < minEnd && maxStart >= filterFocusSpan.start && minEnd <= filterFocusSpan.end`:
+     - `intersectionText = filterFocusSpan.text.slice(maxStart - filterFocusSpan.start, minEnd - filterFocusSpan.start)`.
+  5. Else: `intersectionText = filterFocusSpan.text` (fallback).
+  6. Truncate to 60 chars + `…` if longer.
+  7. Display as a small chip above the content in each card.
+
+- Label chip styling: `background: #f1f5f9`, `border: 1px solid #cbd5e1`, `color: #64748b`, `font-size: 10px`, `border-radius: 4px`, `padding: 1px 6px`, `max-width: 100%`, overflow hidden + ellipsis.
+
+---
+
+## 6. Files Touched
+
+| File | Change |
+|---|---|
+| `src/utils/highlightStore.ts` | Add `filterFocusSpan: { start: number; end: number; text: string } \| null` to `HighlightState`. Add `setFilterFocusSpan`, `clearFilterFocusSpan` actions. Export both. |
+| `src/components/Posts/Post.tsx` | In `renderMultiHighlightHtml`: add `data-range-id="${entry.index}"` to each `<mark>`. In `ActiveHighlightedContent`: add `hoveredFocusMarkIndex` state, event delegation via `useEffect` on the container div's `addEventListener`. Add pointer cursor CSS when cross-highlight is inactive. Handle click → `setFilterFocusSpan`. |
+| `src/components/RelatedStacks.tsx` | 1. Destructure `filterFocusSpan` from `useHighlightStore`. 2. Add span filter clause to `displayStacks` useMemo. 3. Add `clearFilterFocusSpan()` call in the `relatedStacks` change `useEffect`. 4. Compute `shortestCommonText` for visible stacks when `filterFocusSpan` is active. 5. Render the label chip in the card UI. 6. Update count label in sticky header to mention span filter. |
+
+---
+
+## 7. Verification
+
+1. `pnpm build` must produce zero TypeScript errors and zero build warnings related to changed files.
+2. Manual test (documented in PR test plan):
+   - Open a post with related stacks.
+   - Hover a sidebar card → focus post marks appear in category colors.
+   - While sidebar card is hovered, move mouse to a focus-post mark → NO neutral color (cross-highlight takes priority, JC4).
+   - Un-hover sidebar card → marks disappear. Now hover directly over the focus-post text area where a mark was → neutral grey appears.
+   - Click the mark → sidebar filters to only posts relating to that span. Count label updates.
+   - Click same mark again → filter clears, all sidebar posts return.
+   - Click a different mark → span filter switches.
+   - With span filter active, each sidebar card shows the intersection label chip.
+   - Apply a category filter (Group C chips) → AND: only stacks matching both span and category show.
+   - Navigate away → no stale span filter on next post.
+
+---
+
+## 8. Risks
+
+- **R1: Mark position drift.** `renderMultiHighlightHtml` uses text replacement in HTML strings, not offset-based injection. If the plain text extraction (`stripHtml`) doesn't perfectly align with actual HTML positions, `data-range-id` might point to wrong offsets. Mitigation: `data-range-id` maps to an index in `hoveredRelations` array — the `focusStart/End` are read from the already-correct `hoveredRelations[i]` not re-computed.
+- **R2: Multiple marks for same relation.** If `renderMultiHighlightHtml` creates multiple `<mark>` elements for the same relation (unlikely but possible if the snippet appears twice), clicking either one should work — they share the same `data-range-id`.
+- **R3: D1 style injection SSR.** The `<style>` element injection needs to happen only in `useEffect` (client-side), not during SSR. Standard guard: `useEffect` already runs only client-side.
+- **R4: Clearing span filter on stack change.** If `relatedStacks` changes (navigating to a new focus post) while `filterFocusSpan` is set, the sidebar would briefly show 0 results. The `useEffect` on `relatedStacks` change clears it synchronously.
+- **R5: Non-overlapping spans across stacks.** D3 intersection may be empty (maxStart >= minEnd). Fallback to `filterFocusSpan.text` handles this gracefully per JC9.
+- **R6: Hover conflict when user moves from sidebar card to focus post rapidly.** Event delegation fires on the focus post container. If `showCrossHighlight` is still true (mouseleave of sidebar card fires after mouseover of focus post mark), D1 is suppressed. The 150ms-ish debounce on `setHoveredSidebarPost(null)` means D1 takes a moment to activate. This is acceptable behavior and is not perceptible in normal use.
+
+---
+
+## 9. Next Steps
+
+- Group E: reordering (independent of D).
+- Group F: visual redesign of cards (reads D3 label placement as a stable anchor).
+- Group H: URL persistence of `filterFocusSpan` (could serialize `start` and `end` in the URL).
+
+---
+
+## Judgment Calls Made Without User Input
+
+(Verbatim for PR description)
+
+1. **JC1 — Event delegation over JSX rebuild.** Rather than rewriting `renderMultiHighlightHtml` to return React nodes (invasive), we use event delegation on the wrapper div. Simpler, less risk to the existing cross-highlight rendering.
+
+2. **JC2 — data-range-id identifies relation index.** Each `<mark>` gets `data-range-id="{i}"` where `i` is its position in the `hoveredRelations` array. Relation's `focusStart/End` read from the store array.
+
+3. **JC3 — Neutral hover via scoped `<style>` injection.** Cannot override per-element inline style inside `dangerouslySetInnerHTML` from outside. Inject a `<style>` block with a class selector that overrides the mark's background, scoped to a stable unique ID on the container.
+
+4. **JC4 — Cross-highlight suppresses D1.** When a sidebar card is hovered and marks are in category colors, D1 neutral hover is disabled. Cross-highlight is the higher-intent signal. D1 only activates when no sidebar card is being hovered.
+
+5. **JC5 — filterFocusSpan in highlightStore.** Co-locates all filter state. Both Post.tsx (writer) and RelatedStacks.tsx (reader) access it through the same store hook.
+
+6. **JC6 — Click same mark toggles filter off.** Consistent with C's category filter toggle semantics.
+
+7. **JC7 — Marks only visible when hoveredRelations is set.** D2 is safe: marks only exist during cross-highlight, so `hoveredRelations` is always non-null when a mark can be clicked.
+
+8. **JC8 — D3 uses category-filtered relations when filter is active.** If the user has both a category filter and a span filter active, the intersection label only considers the filtered relation categories.
+
+9. **JC9 — Empty intersection falls back to filterFocusSpan.text.** When stacks respond to non-overlapping parts of the span, we display the original clicked-span text.
+
+10. **JC10 — No label when zero visible stacks.** Nothing to display.
+
+11. **JC11 — Label placement: above content, below tags.** Placed as a chip between category tags and the post content text. Stays out of the way of the action bar.
+
+12. **JC12 — Store carries text snippet.** `filterFocusSpan = { start, end, text }` where `text = plainText.slice(start, end)`. This means `RelatedStacks` doesn't need access to the full focus post's plain text to compute D3.
+
+13. **JC13 — One visible stack: no special case.** Intersection of one span is itself.
+
+14. **JC14 — Clear span filter on relatedStacks change.** Added to the existing cleanup effect in `RelatedStacks`.
+
+15. **JC15 — Intersection computed in RelatedStacks from relation offsets + stored snippet.** RelatedStacks knows `filterFocusSpan.start` (base offset) and the `text` snippet. Each relation's `focusStart/End` are absolute offsets in the focus post's plain text. The intersection `[maxStart, minEnd]` can be sliced from the snippet as `text.slice(maxStart - start, minEnd - start)` when both offsets fall within `[start, end]`.

--- a/src/app/(shell)/listy-injection/page.tsx
+++ b/src/app/(shell)/listy-injection/page.tsx
@@ -49,6 +49,8 @@ function toPostData(entry: ListyInjectionEntry) {
   const aggregatedStacks = Array.from(categoryMap.entries()).map(([cat, { count, topPost }]) => ({
     stackId: `agg-${entry.focusPost.id}-${cat}`, rel: cat, size: count, topPost,
   }));
+  // All focus-post relations from every related post (for dimmed always-visible marks)
+  const focusRelations = entry.relatedPosts.flatMap((rp) => rp.relations ?? []);
   return {
     postId: entry.focusPost.id,
     text: entry.focusPost.content,
@@ -66,6 +68,7 @@ function toPostData(entry: ListyInjectionEntry) {
     aggregatedStacks,
     previewCard: null,
     replies: entry.replies ?? [],
+    focusRelations,
   };
 }
 
@@ -183,6 +186,7 @@ function replyToPostData(reply: FocusPostMock) {
     aggregatedStacks: [] as ReturnType<typeof toPostData>["aggregatedStacks"],
     previewCard: null,
     replies: [] as FocusPostMock[],
+    focusRelations: [] as ReturnType<typeof toPostData>["focusRelations"],
   };
 }
 
@@ -473,6 +477,7 @@ export default function ListyInjectionPage() {
         }}
         initialCard={null}
         onNavigate={opts?.isAncestor ? opts.onAncestorClick ? () => opts.onAncestorClick!() : undefined : navigateToPost}
+        focusRelations={opts?.isAncestor ? [] : postData.focusRelations}
       />
     );
   }

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -153,6 +153,9 @@ function cleanPostHtml(html: string, card: PreviewCard | null | undefined): Clea
 
 
 
+// Dwell duration (ms) before focus-post marks become visible on hover.
+const FOCUS_HOVER_DWELL_MS = 1500;
+
 // Subscribes to the highlight store — only mounted for the *active* post so
 // inactive posts don't re-render on every sidebar hover.
 const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
@@ -165,9 +168,25 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
 }>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded, focusRelations = [] }, ref) {
   const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, filterFocusSpan } = useHighlightStore();
   const showCrossHighlight = !!hoveredPostId && !!hoveredRelations;
+
+  // Dwell-triggered mark visibility: true after FOCUS_HOVER_DWELL_MS of continuous hover
+  const [focusHoverShowMarks, setFocusHoverShowMarks] = useState<boolean>(false);
+  const focusHoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cleanup timer on unmount to avoid memory leaks
+  useEffect(() => {
+    return () => {
+      if (focusHoverTimerRef.current) clearTimeout(focusHoverTimerRef.current);
+    };
+  }, []);
+
+  // Marks are visible when: cross-highlight active, dwell triggered, or a span filter is active
+  const marksVisible = showCrossHighlight || focusHoverShowMarks || filterFocusSpan !== null;
+
   const html = useMemo(() => {
+    if (!marksVisible) return displayText;
     // Prefer cross-highlight relations when active (brightened state).
-    // Otherwise render the post's own relations in a dimmed default state.
+    // Otherwise render the post's own relations in a dimmed state.
     const relations = showCrossHighlight && hoveredRelations ? hoveredRelations : focusRelations;
     if (!relations || relations.length === 0) return displayText;
     return renderMultiHighlightHtml(
@@ -177,7 +196,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       showCrossHighlight ? hoveredHighlightRangeIndex : null,
       /* dimmed */ !showCrossHighlight,
     );
-  }, [displayText, rawText, showCrossHighlight, hoveredRelations, focusRelations, hoveredHighlightRangeIndex]);
+  }, [displayText, rawText, marksVisible, showCrossHighlight, hoveredRelations, focusRelations, hoveredHighlightRangeIndex]);
 
   const innerRef = useRef<HTMLDivElement | null>(null);
   const setRefs = (el: HTMLDivElement | null) => {
@@ -193,7 +212,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
 
   // ── Expand-to-reveal ──────────────────────────────────────────────────────
   // When a mark is below the 5-line clamp, smoothly grow the box downward.
-  // Collapses with a matching animation when hover ends.
+  // Collapses with a matching animation when marks become invisible.
   //
   // Phase: 'normal' → 'expanded' → 'collapsing' → 'normal'
   //   expanded:   display:block, maxHeight = revealHeight  (large)
@@ -204,10 +223,10 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // EXPAND: useLayoutEffect fires synchronously when html changes (marks appear).
-  // Only runs when showCrossHighlight is true — does NOT touch state on unhover.
+  // Triggers on any marksVisible → true transition (cross-highlight OR dwell).
   useLayoutEffect(() => {
     const el = innerRef.current;
-    if (!el || isTextExpanded || !showCrossHighlight) return;
+    if (!el || isTextExpanded || !marksVisible) return;
 
     const marks = Array.from(el.querySelectorAll('mark'));
     if (marks.length === 0) return;
@@ -230,13 +249,13 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       setCollapsing(false);
       setRevealHeight(Math.min(needed, el.scrollHeight));
     }
-  }, [html, isTextExpanded, showCrossHighlight]);
+  }, [html, isTextExpanded, marksVisible]);
 
-  // COLLAPSE: when hover ends, start the collapse animation.
+  // COLLAPSE: when marks become invisible, start the collapse animation.
   // revealHeight stays set (keeping display:block) while CSS transition plays.
   // After 320ms, clear everything → snap to normal -webkit-box style.
   useEffect(() => {
-    if (!showCrossHighlight && revealHeight !== null) {
+    if (!marksVisible && revealHeight !== null) {
       setCollapsing(true);
       collapseTimerRef.current = setTimeout(() => {
         setCollapsing(false);
@@ -247,7 +266,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     return () => {
       if (collapseTimerRef.current) { clearTimeout(collapseTimerRef.current); collapseTimerRef.current = null; }
     };
-  }, [showCrossHighlight]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [marksVisible]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // D1/D2: event delegation on the container div — hover neutral highlight + click span filter
   useEffect(() => {
@@ -304,7 +323,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       el.removeEventListener('mouseout', handleMouseOut);
       el.removeEventListener('click', handleClick, true);
     };
-  }, [showCrossHighlight, hoveredRelations, focusRelations, filterFocusSpan, rawText]);
+  }, [showCrossHighlight, hoveredRelations, focusRelations, filterFocusSpan, rawText, focusHoverShowMarks, marksVisible]);
 
   // D1: inject a scoped <style> to apply neutral background to the hovered mark
   useEffect(() => {
@@ -367,7 +386,28 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     mergedStyle = style;
   }
 
-  return <div ref={setRefs} id={containerIdRef.current} className={className} style={mergedStyle} dangerouslySetInnerHTML={{ __html: html }} />;
+  return (
+    <div
+      ref={setRefs}
+      id={containerIdRef.current}
+      className={className}
+      style={mergedStyle}
+      dangerouslySetInnerHTML={{ __html: html }}
+      onMouseEnter={() => {
+        if (focusHoverTimerRef.current) clearTimeout(focusHoverTimerRef.current);
+        focusHoverTimerRef.current = setTimeout(() => {
+          setFocusHoverShowMarks(true);
+        }, FOCUS_HOVER_DWELL_MS);
+      }}
+      onMouseLeave={() => {
+        if (focusHoverTimerRef.current) {
+          clearTimeout(focusHoverTimerRef.current);
+          focusHoverTimerRef.current = null;
+        }
+        setFocusHoverShowMarks(false);
+      }}
+    />
+  );
 });
 
 interface PostProps {

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -314,7 +314,10 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       const rels = showCrossHighlight && hoveredRelations ? hoveredRelations : focusRelations;
       if (!rels || idx >= rels.length) return;
       const rel = rels[idx];
+      // Belt-and-suspenders: stop all further propagation and default browser actions
+      e.preventDefault();
       e.stopPropagation();
+      e.stopImmediatePropagation();
       // Toggle: clicking the same span clears the filter; different span sets it
       if (
         filterFocusSpan !== null &&
@@ -711,11 +714,16 @@ export default function Post({
   };
 
   const handleSingleClick = (e: React.MouseEvent) => {
+    // If the click originated from a highlighted mark, let the mark's own
+    // capture-phase handler deal with it — do not navigate.
+    if ((e.target as HTMLElement).closest('mark')) return;
     e.stopPropagation();
     handleNavigate();
   };
 
-  const handleMouseUp = () => {
+  const handleMouseUp = (e: React.MouseEvent) => {
+    // If the mouseup came from a highlighted mark, do not navigate.
+    if ((e.target as HTMLElement).closest('mark')) return;
     const selection = window.getSelection();
     if (selection && selection.toString().length === 0) {
       handleNavigate();
@@ -798,7 +806,7 @@ export default function Post({
 
         <div
           style={{ paddingLeft: '3rem', paddingRight:'3rem', cursor: 'pointer'}}
-          onMouseUp={handleMouseUp}
+          onMouseUp={(e) => handleMouseUp(e)}
         >
           <div>
       {isActive ? (

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -169,24 +169,29 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, filterFocusSpan } = useHighlightStore();
   const showCrossHighlight = !!hoveredPostId && !!hoveredRelations;
 
-  // Dwell-triggered mark visibility: true after FOCUS_HOVER_DWELL_MS of continuous hover
-  const [focusHoverShowMarks, setFocusHoverShowMarks] = useState<boolean>(false);
-  const focusHoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Per-mark dwell: index of the mark that has become visible via 1500ms dwell
+  const [dwellOnMarkIndex, setDwellOnMarkIndex] = useState<number | null>(null);
+  const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Cleanup timer on unmount to avoid memory leaks
+  // Cleanup dwell timer on unmount
   useEffect(() => {
     return () => {
-      if (focusHoverTimerRef.current) clearTimeout(focusHoverTimerRef.current);
+      if (dwellTimerRef.current) clearTimeout(dwellTimerRef.current);
     };
   }, []);
 
-  // Marks are visible when: cross-highlight active, dwell triggered, or a span filter is active
-  const marksVisible = showCrossHighlight || focusHoverShowMarks || filterFocusSpan !== null;
+  // Compute which mark index (if any) should be visible in neutral grey
+  const filterIdx = filterFocusSpan
+    ? focusRelations.findIndex(r => r.focusStart === filterFocusSpan.start && r.focusEnd === filterFocusSpan.end)
+    : -1;
+  const visibleMarkIdx = dwellOnMarkIndex !== null ? dwellOnMarkIndex : (filterIdx >= 0 ? filterIdx : null);
+
+  // Marks are visually active when: cross-highlight, per-mark dwell, or filter active
+  const anyMarkVisuallyActive = showCrossHighlight || dwellOnMarkIndex !== null || (filterFocusSpan !== null && filterIdx >= 0);
 
   const html = useMemo(() => {
-    if (!marksVisible) return displayText;
-    // Prefer cross-highlight relations when active (brightened state).
-    // Otherwise render the post's own relations in a dimmed state.
+    // Always render marks in DOM when focusRelations exist so cursor events fire on them.
+    // CSS overrides control visibility — not DOM presence.
     const relations = showCrossHighlight && hoveredRelations ? hoveredRelations : focusRelations;
     if (!relations || relations.length === 0) return displayText;
     return renderMultiHighlightHtml(
@@ -194,9 +199,9 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       stripHtml(rawText),
       relations,
       showCrossHighlight ? hoveredHighlightRangeIndex : null,
-      /* dimmed */ !showCrossHighlight,
+      /* dimmed */ false,
     );
-  }, [displayText, rawText, marksVisible, showCrossHighlight, hoveredRelations, focusRelations, hoveredHighlightRangeIndex]);
+  }, [displayText, rawText, showCrossHighlight, hoveredRelations, focusRelations, hoveredHighlightRangeIndex]);
 
   const innerRef = useRef<HTMLDivElement | null>(null);
   const setRefs = (el: HTMLDivElement | null) => {
@@ -207,8 +212,6 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
 
   // D1/D2: stable container ID for scoped CSS and event delegation
   const containerIdRef = useRef<string>(`ahc-${Math.random().toString(36).slice(2)}`);
-  // D1: index of the mark currently hovered directly on the focus post
-  const [hoveredFocusMarkIndex, setHoveredFocusMarkIndex] = useState<number | null>(null);
 
   // ── Expand-to-reveal ──────────────────────────────────────────────────────
   // When a mark is below the 5-line clamp, smoothly grow the box downward.
@@ -223,10 +226,10 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // EXPAND: useLayoutEffect fires synchronously when html changes (marks appear).
-  // Triggers on any marksVisible → true transition (cross-highlight OR dwell).
+  // Triggers on any anyMarkVisuallyActive → true transition (cross-highlight OR dwell OR filter).
   useLayoutEffect(() => {
     const el = innerRef.current;
-    if (!el || isTextExpanded || !marksVisible) return;
+    if (!el || isTextExpanded || !anyMarkVisuallyActive) return;
 
     const marks = Array.from(el.querySelectorAll('mark'));
     if (marks.length === 0) return;
@@ -249,13 +252,13 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       setCollapsing(false);
       setRevealHeight(Math.min(needed, el.scrollHeight));
     }
-  }, [html, isTextExpanded, marksVisible]);
+  }, [html, isTextExpanded, anyMarkVisuallyActive]);
 
   // COLLAPSE: when marks become invisible, start the collapse animation.
   // revealHeight stays set (keeping display:block) while CSS transition plays.
   // After 320ms, clear everything → snap to normal -webkit-box style.
   useEffect(() => {
-    if (!marksVisible && revealHeight !== null) {
+    if (!anyMarkVisuallyActive && revealHeight !== null) {
       setCollapsing(true);
       collapseTimerRef.current = setTimeout(() => {
         setCollapsing(false);
@@ -266,9 +269,9 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     return () => {
       if (collapseTimerRef.current) { clearTimeout(collapseTimerRef.current); collapseTimerRef.current = null; }
     };
-  }, [marksVisible]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [anyMarkVisuallyActive]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // D1/D2: event delegation on the container div — hover neutral highlight + click span filter
+  // D1/D2: event delegation on the container div — per-mark dwell + click span filter
   useEffect(() => {
     const el = innerRef.current;
     if (!el) return;
@@ -277,15 +280,30 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       const target = (e.target as HTMLElement).closest('mark');
       if (!target) return;
       const rid = target.getAttribute('data-range-id');
-      if (rid !== null) setHoveredFocusMarkIndex(parseInt(rid, 10));
+      if (rid === null) return;
+      const idx = parseInt(rid, 10);
+
+      // Start a fresh dwell timer for this specific mark
+      if (dwellTimerRef.current) clearTimeout(dwellTimerRef.current);
+      // If we were showing a different mark, hide it immediately
+      setDwellOnMarkIndex(prev => (prev === idx ? prev : null));
+      dwellTimerRef.current = setTimeout(() => {
+        setDwellOnMarkIndex(idx);
+        dwellTimerRef.current = null;
+      }, FOCUS_HOVER_DWELL_MS);
     };
     const handleMouseOut = (e: MouseEvent) => {
       const target = (e.target as HTMLElement).closest('mark');
       if (!target) return;
-      // Don't clear if the mouse is moving to a child of the same mark
+      // Allow cursor moving within the same mark (e.g., over a child span)
       const related = e.relatedTarget as HTMLElement | null;
       if (related && target.contains(related)) return;
-      setHoveredFocusMarkIndex(null);
+      // Cancel any pending dwell, hide the shown mark
+      if (dwellTimerRef.current) {
+        clearTimeout(dwellTimerRef.current);
+        dwellTimerRef.current = null;
+      }
+      setDwellOnMarkIndex(null);
     };
     const handleClick = (e: MouseEvent) => {
       const target = (e.target as HTMLElement).closest('mark');
@@ -323,9 +341,11 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       el.removeEventListener('mouseout', handleMouseOut);
       el.removeEventListener('click', handleClick, true);
     };
-  }, [showCrossHighlight, hoveredRelations, focusRelations, filterFocusSpan, rawText, focusHoverShowMarks, marksVisible]);
+  }, [showCrossHighlight, hoveredRelations, focusRelations, filterFocusSpan, rawText]);
 
-  // D1: inject a scoped <style> to apply neutral background to the hovered mark
+  // D1: inject a scoped <style> to control mark visibility
+  // Default: all marks hidden (transparent). Override: dwell/filter mark visible in neutral grey.
+  // Cross-highlight: clear overrides so inline category colors win.
   useEffect(() => {
     const id = containerIdRef.current;
     const styleId = `d1-hover-${id}`;
@@ -335,13 +355,18 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       styleEl.id = styleId;
       document.head.appendChild(styleEl);
     }
-    if (hoveredFocusMarkIndex !== null) {
-      styleEl.textContent = `#${id} mark[data-range-id="${hoveredFocusMarkIndex}"] { background: rgba(100,116,139,0.30) !important; cursor: pointer; }
-#${id} mark { cursor: pointer; }`;
-    } else {
+
+    if (showCrossHighlight) {
+      // Cross-highlight inline styles win — only ensure cursor is set
       styleEl.textContent = `#${id} mark { cursor: pointer; }`;
+    } else {
+      // Default: hide all marks. Show one in neutral grey if dwell or filter active.
+      const visibleRule = visibleMarkIdx !== null
+        ? `#${id} mark[data-range-id="${visibleMarkIdx}"] { background: rgba(100,116,139,0.30) !important; }`
+        : '';
+      styleEl.textContent = `#${id} mark { background: transparent !important; cursor: pointer; transition: background 200ms ease; } ${visibleRule}`;
     }
-  }, [hoveredFocusMarkIndex, showCrossHighlight]);
+  }, [showCrossHighlight, visibleMarkIdx]);
 
   // Cleanup scoped style on unmount
   useEffect(() => {
@@ -393,19 +418,6 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       className={className}
       style={mergedStyle}
       dangerouslySetInnerHTML={{ __html: html }}
-      onMouseEnter={() => {
-        if (focusHoverTimerRef.current) clearTimeout(focusHoverTimerRef.current);
-        focusHoverTimerRef.current = setTimeout(() => {
-          setFocusHoverShowMarks(true);
-        }, FOCUS_HOVER_DWELL_MS);
-      }}
-      onMouseLeave={() => {
-        if (focusHoverTimerRef.current) {
-          clearTimeout(focusHoverTimerRef.current);
-          focusHoverTimerRef.current = null;
-        }
-        setFocusHoverShowMarks(false);
-      }}
     />
   );
 });

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -9,7 +9,7 @@ import axios from 'axios';
 import AnnotationModal from '../AnnotationModal';
 import { PreviewCardType } from '../../types/PostType';
 import InteractionControl from '../InteractionControl';
-import { useHighlightStore } from '../../utils/highlightStore';
+import { useHighlightStore, setFilterFocusSpan, clearFilterFocusSpan } from '../../utils/highlightStore';
 import type { Relation } from '../../types/PostType';
 
 // ─── Focus post cross-highlight helpers ──────────────────────────────────────
@@ -91,7 +91,7 @@ function renderMultiHighlightHtml(
           const after = entry.snippet.slice(ci + entry.focusComment.length);
           innerHtml = before + bold + after;
         }
-        const markHtml = `<mark style="background:${entry.bgColor};padding:1px 0;color:inherit;border-radius:3px;transition:background 200ms ease">${innerHtml}</mark>`;
+        const markHtml = `<mark data-range-id="${entry.index}" style="background:${entry.bgColor};padding:1px 0;color:inherit;border-radius:3px;transition:background 200ms ease">${innerHtml}</mark>`;
         result = result.slice(0, match.index) + markHtml + result.slice(match.index + entry.snippet.length);
         break;
       }
@@ -159,7 +159,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   className?: string;
   isTextExpanded: boolean;
 }>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded }, ref) {
-  const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex } = useHighlightStore();
+  const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, filterFocusSpan } = useHighlightStore();
   const showCrossHighlight = !!hoveredPostId && !!hoveredRelations;
   const html = useMemo(() => {
     if (!showCrossHighlight || !hoveredRelations) return displayText;
@@ -177,6 +177,11 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     if (typeof ref === 'function') ref(el);
     else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
   };
+
+  // D1/D2: stable container ID for scoped CSS and event delegation
+  const containerIdRef = useRef<string>(`ahc-${Math.random().toString(36).slice(2)}`);
+  // D1: index of the mark currently hovered directly on the focus post
+  const [hoveredFocusMarkIndex, setHoveredFocusMarkIndex] = useState<number | null>(null);
 
   // ── Expand-to-reveal ──────────────────────────────────────────────────────
   // When a mark is below the 5-line clamp, smoothly grow the box downward.
@@ -236,6 +241,93 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     };
   }, [showCrossHighlight]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // D1/D2: event delegation on the container div — hover neutral highlight + click span filter
+  useEffect(() => {
+    const el = innerRef.current;
+    if (!el) return;
+
+    const handleMouseOver = (e: MouseEvent) => {
+      // D1 suppressed while cross-highlight is active (sidebar card hovered)
+      if (showCrossHighlight) return;
+      const target = (e.target as HTMLElement).closest('mark');
+      if (!target) return;
+      const rid = target.getAttribute('data-range-id');
+      if (rid !== null) setHoveredFocusMarkIndex(parseInt(rid, 10));
+    };
+    const handleMouseOut = (e: MouseEvent) => {
+      const target = (e.target as HTMLElement).closest('mark');
+      if (!target) return;
+      // Don't clear if the mouse is moving to a child of the same mark
+      const related = e.relatedTarget as HTMLElement | null;
+      if (related && target.contains(related)) return;
+      setHoveredFocusMarkIndex(null);
+    };
+    const handleClick = (e: MouseEvent) => {
+      const target = (e.target as HTMLElement).closest('mark');
+      if (!target) return;
+      const rid = target.getAttribute('data-range-id');
+      if (rid === null) return;
+      const idx = parseInt(rid, 10);
+      const rels = hoveredRelations;
+      if (!rels || idx >= rels.length) return;
+      const rel = rels[idx];
+      e.stopPropagation();
+      // Toggle: clicking the same span clears the filter; different span sets it
+      if (
+        filterFocusSpan !== null &&
+        filterFocusSpan.start === rel.focusStart &&
+        filterFocusSpan.end === rel.focusEnd
+      ) {
+        clearFilterFocusSpan();
+      } else {
+        const plainText = stripHtml(rawText);
+        setFilterFocusSpan({
+          start: rel.focusStart,
+          end: rel.focusEnd,
+          text: plainText.slice(rel.focusStart, rel.focusEnd),
+        });
+      }
+    };
+
+    el.addEventListener('mouseover', handleMouseOver);
+    el.addEventListener('mouseout', handleMouseOut);
+    // Capture phase so our handler fires before the card navigation handler
+    el.addEventListener('click', handleClick, true);
+    return () => {
+      el.removeEventListener('mouseover', handleMouseOver);
+      el.removeEventListener('mouseout', handleMouseOut);
+      el.removeEventListener('click', handleClick, true);
+    };
+  }, [showCrossHighlight, hoveredRelations, filterFocusSpan, rawText]);
+
+  // D1: inject a scoped <style> to apply neutral background to the hovered mark
+  useEffect(() => {
+    const id = containerIdRef.current;
+    const styleId = `d1-hover-${id}`;
+    let styleEl = document.getElementById(styleId) as HTMLStyleElement | null;
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = styleId;
+      document.head.appendChild(styleEl);
+    }
+    if (hoveredFocusMarkIndex !== null && !showCrossHighlight) {
+      styleEl.textContent = `#${id} mark[data-range-id="${hoveredFocusMarkIndex}"] { background: rgba(100,116,139,0.30) !important; cursor: pointer; }
+#${id} mark { cursor: pointer; }`;
+    } else {
+      // When cross-highlight active, marks are presentational; pointer only when inactive
+      styleEl.textContent = `#${id} mark { cursor: ${showCrossHighlight ? 'pointer' : 'pointer'}; }`;
+    }
+  }, [hoveredFocusMarkIndex, showCrossHighlight]);
+
+  // Cleanup scoped style on unmount
+  useEffect(() => {
+    const id = containerIdRef.current;
+    return () => {
+      const el = document.getElementById(`d1-hover-${id}`);
+      if (el) el.remove();
+    };
+  }, []);
+
   // Build the merged style
   const TRANSITION = 'max-height 300ms ease';
   let mergedStyle: React.CSSProperties;
@@ -270,7 +362,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     mergedStyle = style;
   }
 
-  return <div ref={setRefs} className={className} style={mergedStyle} dangerouslySetInnerHTML={{ __html: html }} />;
+  return <div ref={setRefs} id={containerIdRef.current} className={className} style={mergedStyle} dangerouslySetInnerHTML={{ __html: html }} />;
 });
 
 interface PostProps {

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -44,12 +44,14 @@ function hexToRgba(hex: string, alpha: number): string {
 
 /** Render multi-range focus highlights into HTML using offset-based Relations.
  *  Each relation's focus range gets its category color.
- *  Level 2: when hoveredRangeIndex is set, non-active highlights dim their BACKGROUND only. */
+ *  Level 2: when hoveredRangeIndex is set, non-active highlights dim their BACKGROUND only.
+ *  When dimmed=true, all marks render at low alpha (always-visible default state). */
 function renderMultiHighlightHtml(
   displayHtml: string,
   focusPlainText: string,
   relations: Relation[],
   hoveredRangeIndex: number | null,
+  dimmed?: boolean,
 ): string {
   if (relations.length === 0) return displayHtml;
 
@@ -58,7 +60,8 @@ function renderMultiHighlightHtml(
     if (!catColors) return null;
 
     const snippet = focusPlainText.slice(r.focusStart, r.focusEnd);
-    const bgAlpha = (hoveredRangeIndex === null || hoveredRangeIndex === i) ? 1 : 0.2;
+    let bgAlpha = (hoveredRangeIndex === null || hoveredRangeIndex === i) ? 1 : 0.2;
+    if (dimmed) bgAlpha = 0.25;
     const bgColor = bgAlpha < 1 ? hexToRgba(catColors.bg, bgAlpha) : catColors.bg;
 
     // focusComment substring to bold — only when this specific highlight is hovered (Level 2)
@@ -158,18 +161,23 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   style: React.CSSProperties;
   className?: string;
   isTextExpanded: boolean;
-}>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded }, ref) {
+  focusRelations?: Relation[];
+}>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded, focusRelations = [] }, ref) {
   const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, filterFocusSpan } = useHighlightStore();
   const showCrossHighlight = !!hoveredPostId && !!hoveredRelations;
   const html = useMemo(() => {
-    if (!showCrossHighlight || !hoveredRelations) return displayText;
+    // Prefer cross-highlight relations when active (brightened state).
+    // Otherwise render the post's own relations in a dimmed default state.
+    const relations = showCrossHighlight && hoveredRelations ? hoveredRelations : focusRelations;
+    if (!relations || relations.length === 0) return displayText;
     return renderMultiHighlightHtml(
       displayText,
       stripHtml(rawText),
-      hoveredRelations,
-      hoveredHighlightRangeIndex,
+      relations,
+      showCrossHighlight ? hoveredHighlightRangeIndex : null,
+      /* dimmed */ !showCrossHighlight,
     );
-  }, [displayText, rawText, showCrossHighlight, hoveredRelations, hoveredHighlightRangeIndex]);
+  }, [displayText, rawText, showCrossHighlight, hoveredRelations, focusRelations, hoveredHighlightRangeIndex]);
 
   const innerRef = useRef<HTMLDivElement | null>(null);
   const setRefs = (el: HTMLDivElement | null) => {
@@ -247,8 +255,6 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     if (!el) return;
 
     const handleMouseOver = (e: MouseEvent) => {
-      // D1 suppressed while cross-highlight is active (sidebar card hovered)
-      if (showCrossHighlight) return;
       const target = (e.target as HTMLElement).closest('mark');
       if (!target) return;
       const rid = target.getAttribute('data-range-id');
@@ -268,7 +274,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       const rid = target.getAttribute('data-range-id');
       if (rid === null) return;
       const idx = parseInt(rid, 10);
-      const rels = hoveredRelations;
+      const rels = showCrossHighlight && hoveredRelations ? hoveredRelations : focusRelations;
       if (!rels || idx >= rels.length) return;
       const rel = rels[idx];
       e.stopPropagation();
@@ -298,7 +304,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       el.removeEventListener('mouseout', handleMouseOut);
       el.removeEventListener('click', handleClick, true);
     };
-  }, [showCrossHighlight, hoveredRelations, filterFocusSpan, rawText]);
+  }, [showCrossHighlight, hoveredRelations, focusRelations, filterFocusSpan, rawText]);
 
   // D1: inject a scoped <style> to apply neutral background to the hovered mark
   useEffect(() => {
@@ -310,12 +316,11 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       styleEl.id = styleId;
       document.head.appendChild(styleEl);
     }
-    if (hoveredFocusMarkIndex !== null && !showCrossHighlight) {
+    if (hoveredFocusMarkIndex !== null) {
       styleEl.textContent = `#${id} mark[data-range-id="${hoveredFocusMarkIndex}"] { background: rgba(100,116,139,0.30) !important; cursor: pointer; }
 #${id} mark { cursor: pointer; }`;
     } else {
-      // When cross-highlight active, marks are presentational; pointer only when inactive
-      styleEl.textContent = `#${id} mark { cursor: ${showCrossHighlight ? 'pointer' : 'pointer'}; }`;
+      styleEl.textContent = `#${id} mark { cursor: pointer; }`;
     }
   }, [hoveredFocusMarkIndex, showCrossHighlight]);
 
@@ -387,6 +392,8 @@ interface PostProps {
   initialCard?: PreviewCard | null;
   /** When provided, intercepts post navigation instead of routing to /posts/{id} */
   onNavigate?: (postId: string) => void;
+  /** Relations for the focus post's own text spans — used to render dimmed marks in the default state */
+  focusRelations?: Relation[];
 }
 
 export default function Post({
@@ -407,6 +414,7 @@ export default function Post({
   setActivePostId,
   initialCard,
   onNavigate,
+  focusRelations = [],
 }: PostProps) {
   const router = useRouter();
   const [cardHeight, setCardHeight] = useState(0);
@@ -747,6 +755,7 @@ export default function Post({
           displayText={displayText}
           rawText={text}
           isTextExpanded={isTextExpanded}
+          focusRelations={focusRelations}
           className={isTextExpanded ? undefined : 'postClampedText'}
           style={{
             display: isTextExpanded ? 'block' : '-webkit-box',

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -9,7 +9,7 @@ import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import StackPostsModal from './StackPostsModal';
 import InteractionControl from './InteractionControl';
 import { toggleFavourite, toggleBookmark } from '../utils/mastoActions';
-import { setHoveredSidebarPost, setHoveredHighlightRangeIndex, setHoveredCategory, setTapped, clearTapped, toggleReRankAnchor, clearReRankAnchors, setFilterCategories, useHighlightStore } from '../utils/highlightStore';
+import { setHoveredSidebarPost, setHoveredHighlightRangeIndex, setHoveredCategory, setTapped, clearTapped, toggleReRankAnchor, clearReRankAnchors, setFilterCategories, clearFilterFocusSpan, useHighlightStore } from '../utils/highlightStore';
 import type { Relation } from '../types/PostType';
 import './RelatedStacks.css';
 
@@ -592,7 +592,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
   const [favouritedOverride, setFavouritedOverride] = useState<Record<string, boolean>>({});
   const [bookmarkedOverride, setBookmarkedOverride] = useState<Record<string, boolean>>({});
   const [favouritesCountOverride, setFavouritesCountOverride] = useState<Record<string, number>>({});
-  const { filterCategories, hoveredHighlightRangeIndex, hoveredCategory, tappedCardPostId, tappedRangeIndex, reRankAnchorIds, anchoredRangeByPost } = useHighlightStore();
+  const { filterCategories, filterFocusSpan, hoveredHighlightRangeIndex, hoveredCategory, tappedCardPostId, tappedRangeIndex, reRankAnchorIds, anchoredRangeByPost } = useHighlightStore();
   // C2: hover preview state for filter chips
   const [chipHovered, setChipHovered] = useState<string | null>(null);
   // C3: panel hover state for neutral-until-hover tag coloring
@@ -775,8 +775,17 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
       });
     }
 
+    // D2: span filter — keep only stacks whose relations overlap the clicked focus-post span
+    if (filterFocusSpan !== null) {
+      result = result.filter(s =>
+        (s.topPost.relations ?? []).some(r =>
+          r.focusStart < filterFocusSpan.end && filterFocusSpan.start < r.focusEnd
+        )
+      );
+    }
+
     return { displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown };
-  }, [relatedStacks, filterCategories, reRankAnchorIds, shownByAnchor]);
+  }, [relatedStacks, filterCategories, filterFocusSpan, reRankAnchorIds, shownByAnchor]);
 
   const handleShowMore = (anchorId: string) => {
     setShownByAnchor(prev => ({ ...prev, [anchorId]: (prev[anchorId] ?? SHOWN_INCREMENT) + SHOWN_INCREMENT }));
@@ -788,6 +797,45 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     claimedBy.forEach((anchorId) => s.add(anchorId));
     return s;
   }, [claimedBy]);
+
+  /**
+   * D3: shortest common related text — the narrowest focus-post substring that
+   * all currently-visible stacks' relevant relations collectively cover.
+   * Only computed when filterFocusSpan is active.
+   */
+  const shortestCommonText = useMemo<string | null>(() => {
+    if (!filterFocusSpan) return null;
+    if (displayStacks.length === 0) return null;
+
+    let maxStart = filterFocusSpan.start;
+    let minEnd = filterFocusSpan.end;
+
+    for (const s of displayStacks) {
+      const rels = (s.topPost.relations ?? []).filter(r =>
+        filterCategories.size === 0 || filterCategories.has(r.category)
+      );
+      for (const r of rels) {
+        // Only narrow on relations that actually overlap the span filter
+        if (r.focusStart < filterFocusSpan.end && filterFocusSpan.start < r.focusEnd) {
+          if (r.focusStart > maxStart) maxStart = r.focusStart;
+          if (r.focusEnd < minEnd) minEnd = r.focusEnd;
+        }
+      }
+    }
+
+    let text: string;
+    if (
+      maxStart < minEnd &&
+      maxStart >= filterFocusSpan.start &&
+      minEnd <= filterFocusSpan.end
+    ) {
+      text = filterFocusSpan.text.slice(maxStart - filterFocusSpan.start, minEnd - filterFocusSpan.start);
+    } else {
+      text = filterFocusSpan.text; // fallback: show the full clicked span
+    }
+
+    return text.length > 60 ? text.slice(0, 60) + '…' : text;
+  }, [displayStacks, filterFocusSpan, filterCategories]);
 
   const EDGE_HOVER_HEIGHT = 28;
 
@@ -964,6 +1012,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     if (rangeHoverTimer.current) clearTimeout(rangeHoverTimer.current);
     clearReRankAnchors();
     clearTapped();
+    clearFilterFocusSpan(); // D2: clear span filter when focus post changes
   }, [relatedStacks]);
 
   // Touch: tap-outside clears the active state so highlights/sidebar reset.
@@ -1017,10 +1066,40 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
         )}
 
         <Text size="xs" c="dimmed" mb={4}>
-          {filterCategories.size > 0
+          {filterCategories.size > 0 && filterFocusSpan !== null
+            ? `${displayStacks.length} post${displayStacks.length !== 1 ? 's' : ''} matching category + span`
+            : filterFocusSpan !== null
+            ? `${displayStacks.length} post${displayStacks.length !== 1 ? 's' : ''} matching span`
+            : filterCategories.size > 0
             ? `${displayStacks.length} ${Array.from(filterCategories).map(c => CATEGORY_LABELS[c] ?? c).join(' + ')} post${displayStacks.length !== 1 ? 's' : ''}`
             : `${displayStacks.length} posts across all categories`}
         </Text>
+
+        {/* D2: span filter active indicator */}
+        {filterFocusSpan !== null && (
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: '6px', padding: '3px 8px',
+            background: '#f1f5f9', borderRadius: '6px', marginBottom: '0.5rem',
+            border: '1px solid #cbd5e1', flexWrap: 'wrap',
+          }}>
+            <Text size="xs" c="#5a71a8" fw={600} style={{ fontSize: '11px', flexShrink: 0 }}>
+              Span:
+            </Text>
+            <Text size="xs" c="#64748b" style={{
+              fontSize: '10px', fontWeight: 500,
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              maxWidth: '140px', fontStyle: 'italic',
+            }}>
+              "{filterFocusSpan.text.length > 35 ? filterFocusSpan.text.slice(0, 35) + '…' : filterFocusSpan.text}"
+            </Text>
+            <button
+              type="button"
+              onClick={() => clearFilterFocusSpan()}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: '14px', lineHeight: 1, padding: '0 2px', marginLeft: 'auto' }}
+              aria-label="Clear span filter"
+            >×</button>
+          </div>
+        )}
 
         {/* "More like this" active indicator — shows all anchors */}
         {reRankAnchorIds.length > 0 && (
@@ -1440,6 +1519,23 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                   onClick={(e) => handleCardClick(e, stack.topPost.id, stack.stackId)}
                   style={{ paddingLeft: '54px', paddingRight: '1rem', cursor: 'pointer' }}
                 >
+                  {/* D3: shortest common related text label — only when span filter is active */}
+                  {shortestCommonText !== null && (
+                    <div style={{
+                      display: 'inline-flex', alignItems: 'center',
+                      background: '#f1f5f9', border: '1px solid #cbd5e1',
+                      borderRadius: '4px', padding: '1px 6px', marginBottom: '4px',
+                      maxWidth: '100%',
+                    }}>
+                      <Text size="xs" c="#64748b" style={{
+                        fontSize: '10px', fontWeight: 600,
+                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                        fontStyle: 'italic',
+                      }}>
+                        "{shortestCommonText}"
+                      </Text>
+                    </div>
+                  )}
                   <Text component="p" size="sm" lh={1.55} c="#011445" style={{ margin: '0 0 0.4rem 0' }}>
                     {hasPrefix && <span style={{ color: '#94a3b8', userSelect: 'none' }}>…</span>}
                     {contentNodes}

--- a/src/utils/highlightStore.ts
+++ b/src/utils/highlightStore.ts
@@ -27,6 +27,11 @@ interface HighlightState {
   reRankAnchorIds: string[];
   /** Which highlight range triggered each anchor (postId -> rangeIndex) */
   anchoredRangeByPost: Record<string, number>;
+  /**
+   * D2: focus-post mark clicked — filter sidebar to stacks whose relations overlap this span.
+   * Carries the text snippet so RelatedStacks can compute D3 without needing the full focus post text.
+   */
+  filterFocusSpan: { start: number; end: number; text: string } | null;
 }
 
 const INITIAL: HighlightState = {
@@ -39,6 +44,7 @@ const INITIAL: HighlightState = {
   tappedRangeIndex: null,
   reRankAnchorIds: [],
   anchoredRangeByPost: {},
+  filterFocusSpan: null,
 };
 
 // ─── Module-level store ─────────────────────────────────────────────────────
@@ -138,7 +144,20 @@ export function toggleFilterCategory(category: string): void {
 }
 
 export function resetHighlightStore(): void {
-  state = { ...INITIAL, filterCategories: new Set() };
+  state = { ...INITIAL, filterCategories: new Set(), filterFocusSpan: null };
+  notify();
+}
+
+/** D2: Set the span filter from a clicked focus-post mark. */
+export function setFilterFocusSpan(span: { start: number; end: number; text: string }): void {
+  state = { ...state, filterFocusSpan: span };
+  notify();
+}
+
+/** D2: Clear the span filter. */
+export function clearFilterFocusSpan(): void {
+  if (state.filterFocusSpan === null) return;
+  state = { ...state, filterFocusSpan: null };
   notify();
 }
 
@@ -167,7 +186,7 @@ function getSnapshot() {
 
 // Server snapshot uses a stable object. We cannot reuse INITIAL directly since
 // Set instances are mutable — create a fresh frozen copy for the server.
-const SERVER_SNAPSHOT: HighlightState = { ...INITIAL, filterCategories: new Set() };
+const SERVER_SNAPSHOT: HighlightState = { ...INITIAL, filterCategories: new Set(), filterFocusSpan: null };
 function getServerSnapshot() {
   return SERVER_SNAPSHOT;
 }


### PR DESCRIPTION
## Summary

Implements the three Group D behaviors on top of Group C (multi-category filter, merged via `bbc2e9d`):

- **D1** Hovering a `<mark>` on the focus post shows a neutral grey highlight (`rgba(100,116,139,0.30)`) via a scoped `<style>` injection. Suppressed when cross-highlight is active (sidebar card hovered).
- **D2** Clicking a focus-post mark filters the related panel to stacks whose `relations[i].focusStart..focusEnd` overlaps the clicked span. Stored in new `filterFocusSpan` in `highlightStore`. ANDs with C's `filterCategories`. Clicking the same mark again clears the filter. A dismissible chip in the sidebar header shows the active span.
- **D3** While a span filter is active, each sidebar card shows a small italic chip with the "shortest common related text" — the intersection of all visible stacks' relevant focus-post spans. Falls back to the full clicked span when spans are non-overlapping.

## Spec and Plan

- Spec: `docs/superpowers/specs/2026-05-13-group-d-highlight-to-filter-design.md`
- Plan: `docs/superpowers/plans/2026-05-13-group-d-highlight-to-filter.md`

## Files Changed

| File | Change |
|---|---|
| `src/utils/highlightStore.ts` | New field `filterFocusSpan`, actions `setFilterFocusSpan` / `clearFilterFocusSpan` |
| `src/components/Posts/Post.tsx` | `data-range-id` on marks; event delegation in `ActiveHighlightedContent`; D1 style injection; D2 click handler |
| `src/components/RelatedStacks.tsx` | D2 span filter clause in `displayStacks` useMemo; clear span filter on stacks change; D3 `shortestCommonText` useMemo; span filter header chip; D3 label in each card |

## Judgment Calls Made Without User Input

1. **JC1 — Event delegation over JSX rebuild.** Rather than rewriting `renderMultiHighlightHtml` to return React nodes (invasive), we use event delegation on the wrapper div. Simpler, less risk to the existing cross-highlight rendering.

2. **JC2 — data-range-id identifies relation index.** Each `<mark>` gets `data-range-id="{i}"` where `i` is its position in the `hoveredRelations` array. Relation's `focusStart/End` read from the store array.

3. **JC3 — Neutral hover via scoped `<style>` injection.** Cannot override per-element inline style inside `dangerouslySetInnerHTML` from outside. Inject a `<style>` block with a class selector that overrides the mark's background, scoped to a stable unique ID on the container.

4. **JC4 — Cross-highlight suppresses D1.** When a sidebar card is hovered and marks are in category colors, D1 neutral hover is disabled. Cross-highlight is the higher-intent signal. D1 only activates when no sidebar card is being hovered.

5. **JC5 — filterFocusSpan in highlightStore.** Co-locates all filter state. Both Post.tsx (writer) and RelatedStacks.tsx (reader) access it through the same store hook.

6. **JC6 — Click same mark toggles filter off.** Consistent with C's category filter toggle semantics.

7. **JC7 — Marks only visible when hoveredRelations is set.** D2 is safe: marks only exist during cross-highlight, so `hoveredRelations` is always non-null when a mark can be clicked.

8. **JC8 — D3 uses category-filtered relations when filter is active.** If the user has both a category filter and a span filter active, the intersection label only considers the filtered relation categories.

9. **JC9 — Empty intersection falls back to filterFocusSpan.text.** When stacks respond to non-overlapping parts of the span, we display the original clicked-span text.

10. **JC10 — No label when zero visible stacks.** Nothing to display.

11. **JC11 — Label placement: above content, below tags.** Placed as a chip between category tags and the post content text. Stays out of the way of the action bar.

12. **JC12 — Store carries text snippet.** `filterFocusSpan = { start, end, text }` where `text = plainText.slice(start, end)`. This means `RelatedStacks` doesn't need access to the full focus post's plain text to compute D3.

13. **JC13 — One visible stack: no special case.** Intersection of one span is itself.

14. **JC14 — Clear span filter on relatedStacks change.** Added to the existing cleanup effect in `RelatedStacks`.

15. **JC15 — Intersection computed in RelatedStacks from relation offsets + stored snippet.** RelatedStacks knows `filterFocusSpan.start` (base offset) and the `text` snippet. Each relation's `focusStart/End` are absolute offsets in the focus post's plain text. The intersection `[maxStart, minEnd]` can be sliced from the snippet as `text.slice(maxStart - start, minEnd - start)` when both offsets fall within `[start, end]`.

## Manual Test Plan

- [ ] Open a post with related stacks (e.g. `/listy-injection`)
- [ ] Hover a sidebar card → focus post marks appear in category colors (cross-highlight, unchanged)
- [ ] While sidebar card still hovered, move mouse over a focus-post mark → **no neutral color** (D1 suppressed per JC4)
- [ ] Move mouse away from sidebar card → marks disappear; now hover the focus-post text area → neutral grey appears on any mark under the cursor (D1)
- [ ] Click a focus-post mark → sidebar filters; count label shows "N posts matching span"; span chip appears in header (D2)
- [ ] D3 label chip appears on each visible sidebar card showing the common text snippet
- [ ] Click the same mark again → filter clears; all sidebar posts return (D2 toggle)
- [ ] Click a different mark → span filter switches to new span
- [ ] Apply a category filter chip (Group C) while span filter is active → AND: only stacks matching both category AND span show; count label says "matching category + span"
- [ ] Click × on the span chip in the header → span filter clears
- [ ] Navigate away and back → no stale span filter

Closes #(no issue — Group D is part of the superpowers UX overhaul roadmap)