### PR TITLE
Group E: above/below split reordering for see-more anchor

### DIFF
--- a/docs/superpowers/plans/2026-05-13-group-e-reordering.md
+++ b/docs/superpowers/plans/2026-05-13-group-e-reordering.md
@@ -1,0 +1,150 @@
+# Group E — Reordering Algorithm (Implementation Plan)
+
+**Date:** 2026-05-13
+**Spec:** `docs/superpowers/specs/2026-05-13-group-e-reordering-design.md`
+**Branch:** `tarcode2004/enhancement/group-e-reordering`
+**Base branch:** `tarcode2004/enhancement/listy-injection-main-app`
+
+---
+
+## Prerequisites
+
+- [ ] Branch created from `tarcode2004/enhancement/listy-injection-main-app`.
+- [ ] `pnpm build` passes on the base branch before any changes.
+
+---
+
+## Step 1 — Add `reorderForAnchor` utility
+
+**File:** `src/utils/reorderForAnchor.ts` (new file)
+
+- [ ] Create the file with the pure `reorderForAnchor<T>` function.
+  ```ts
+  /**
+   * Reorders `stacks` so that posts matching `matchPredicate` above `targetPostId`
+   * move immediately above it, and those below move immediately below it.
+   * Non-matching posts stay in their relative positions.
+   */
+  export function reorderForAnchor<T extends { topPost: { id: string } }>(
+    stacks: T[],
+    targetPostId: string,
+    matchPredicate: (postId: string) => boolean,
+  ): T[]
+  ```
+- [ ] Implementation: find `targetIdx`; split into `above`/`below`; partition each by predicate; return `[...aboveUnmatched, ...aboveMatched, target, ...belowMatched, ...belowUnmatched]`.
+- [ ] Export only the function (no React imports needed).
+
+**Commit:** `Add reorderForAnchor utility for above/below grouping`
+
+---
+
+## Step 2 — Add refs to `RelatedStacks`
+
+**File:** `src/components/RelatedStacks.tsx`
+
+- [ ] Add `baseOrderRef = useRef<string[]>([])` — stack post IDs at the time the current anchor was created.
+- [ ] Add `activeAnchorIdRef = useRef<string | null>(null)` — the anchor currently driving reordering.
+- [ ] Add `prevDisplayStacksRef = useRef<RelatedStackType[]>([])` — updated by a `useEffect` after each render to track the most recently painted displayStacks.
+- [ ] Add `useEffect(() => { prevDisplayStacksRef.current = displayStacks; }, [displayStacks])` — must be placed AFTER the `displayStacks` memo and before the return statement.
+
+**Commit:** `Add baseOrder and prevDisplayStacks refs to RelatedStacks`
+
+---
+
+## Step 3 — Replace the reranking loop in `displayStacks`
+
+**File:** `src/components/RelatedStacks.tsx`
+
+The existing loop (lines ~724–781) processes every anchor in `reRankAnchorIds` in order, using a cumulative "remove-and-reinsert-after" pattern. Replace it with the single-anchor above/below algorithm.
+
+- [ ] Import `reorderForAnchor` from `../utils/reorderForAnchor`.
+- [ ] At the top of the `useMemo` body, keep the same declarations: `anchorSet`, `claimedBy`, `anchorParent`, `groupTotal`, `groupShown`, `result = [...relatedStacks]`.
+- [ ] If `reRankAnchorIds.length === 0`:
+  - Reset `baseOrderRef.current = []` and `activeAnchorIdRef.current = null`.
+  - Skip the reranking block entirely.
+- [ ] If `reRankAnchorIds.length > 0`:
+  - Take `anchorId = reRankAnchorIds[reRankAnchorIds.length - 1]` (the most recently added anchor).
+  - If `anchorId !== activeAnchorIdRef.current` (new anchor):
+    - `baseOrderRef.current = prevDisplayStacksRef.current.map(s => s.topPost.id)`.
+    - `activeAnchorIdRef.current = anchorId`.
+  - Build `baseStacks: RelatedStackType[]` from `baseOrderRef.current`: for each ID in `baseOrderRef`, find the matching entry in `relatedStacks`. Drop IDs with no match (stale data safety). If `baseOrderRef.current` is empty (first activation on this focus post), fall back to `[...relatedStacks]`.
+  - Compute `anchorTopic` (same as today: `anchorRangeIdx = anchoredRangeByPost[anchorId]`, then `anchor.topPost.relations?.[anchorRangeIdx]?.topic`).
+  - Build `matchPredicate`:
+    ```ts
+    const matchPredicate = anchorTopic
+      ? (pid: string) => pid !== anchorId && (relatedStacks.find(s => s.topPost.id === pid)?.topPost.relations?.some(r => r.topic === anchorTopic) ?? false)
+      : (pid: string) => pid !== anchorId && similarityScore(relatedStacks.find(s => s.topPost.id === pid)?.topPost.content ?? '', anchorContent) > SIMILARITY_THRESHOLD;
+    ```
+  - Compute `allMatched = baseStacks.filter(s => matchPredicate(s.topPost.id))`.
+  - Compute `shown = shownByAnchor[anchorId] ?? SHOWN_INCREMENT`.
+  - `visibleMatched = allMatched.slice(0, shown)`.
+  - Set `groupTotal.set(anchorId, allMatched.length)`.
+  - Set `groupShown.set(anchorId, visibleMatched.length)`.
+  - `visibleMatchedIds = new Set(visibleMatched.map(s => s.topPost.id))`.
+  - For each of `visibleMatched`: `claimedBy.set(s.topPost.id, anchorId)`.
+  - Remove non-visible matched posts from `baseStacks`: `paginatedBase = baseStacks.filter(s => s.topPost.id === anchorId || !matchPredicate(s.topPost.id) || visibleMatchedIds.has(s.topPost.id))`.
+  - Apply `result = reorderForAnchor(paginatedBase, anchorId, (pid) => visibleMatchedIds.has(pid))`.
+  - Populate `anchorSet.add(anchorId)`.
+  - For compatibility with label/connector rendering, also populate `anchorParent` (walk the `anchorSet` to find if the anchor is inside another anchor's claimed group — keep the existing parent-detection loop but only for this single anchor).
+
+- [ ] Keep the filter-chip application block (`if (filterCategories.size > 0) ...`) unchanged after the reranking block.
+- [ ] Return the same shape: `{ displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown }`.
+
+**Commit:** `Replace reranking loop with above/below split algorithm`
+
+---
+
+## Step 4 — Verify build
+
+- [ ] Run `pnpm build` — must produce zero TypeScript errors and zero ESLint errors.
+- [ ] Fix any type errors (the main risk is the generic parameter on `reorderForAnchor`).
+
+**Commit:** (fix errors if any, otherwise skip)
+
+---
+
+## Step 5 — Manual smoke test (mental walkthrough)
+
+With the implementation in place, trace through the algorithm manually with a small example:
+
+- `relatedStacks` = [A, B, C, D, E] (IDs a, b, c, d, e)
+- User clicks anchor on C (postId = c), topic = "Contract reform"
+- A and D share that topic; B, E do not.
+- `baseOrder` = [a, b, c, d, e] (from prevDisplayStacks, which at first activation = relatedStacks order)
+- `allMatched` = [A, D]
+- `shown` = 3 (SHOWN_INCREMENT)
+- `visibleMatched` = [A, D] (both fit)
+- `paginatedBase` = [A, B, C, D, E] (no non-visible matched to drop)
+- `reorderForAnchor`: above = [A, B], below = [D, E]; aboveMatched = [A], aboveUnmatched = [B]; belowMatched = [D], belowUnmatched = [E]
+- `result` = [B, A, C, D, E]
+
+Expected: A moves from above-C to immediately-above-C (stays above), D stays below C (already was). B (unmatched above) stays above. E (unmatched below) stays below. Correct.
+
+Now user clicks anchor on B while C's grouping is active:
+- `prevDisplayStacks` = [B, A, C, D, E] (the order from the last render)
+- New anchor = b; `activeAnchorIdRef` = c → new anchor detected
+- `baseOrderRef` = [b, a, c, d, e] (captured from prevDisplayStacks)
+- New reordering runs on top of this base.
+
+Correct per spec.
+
+---
+
+## Step 6 — Open PR
+
+- [ ] `git push -u origin tarcode2004/enhancement/group-e-reordering`
+- [ ] `gh pr create --base tarcode2004/enhancement/listy-injection-main-app --head tarcode2004/enhancement/group-e-reordering`
+
+---
+
+## Verification Checklist
+
+- [ ] `pnpm build` exits 0
+- [ ] Related stacks above anchor with matching topic move immediately above anchor
+- [ ] Related stacks below anchor with matching topic move immediately below anchor
+- [ ] Unmatched stacks remain in relative positions
+- [ ] Clicking anchor "×" or the header badge reverts to original order
+- [ ] "N more [topic]" pagination still works (increases visible count)
+- [ ] Selecting a second anchor while first is active: first grouping abandoned, new base = current visible order
+- [ ] No TypeScript `any` types introduced without existing precedent
+- [ ] No touched files outside `RelatedStacks.tsx` and `src/utils/reorderForAnchor.ts`

--- a/docs/superpowers/specs/2026-05-13-group-e-reordering-design.md
+++ b/docs/superpowers/specs/2026-05-13-group-e-reordering-design.md
@@ -1,0 +1,201 @@
+# Group E — Reordering Algorithm (Design Spec)
+
+**Date:** 2026-05-13
+**Status:** Ready for implementation.
+**Scope:** Change the "see-more" anchor reordering so that matched posts above the anchor stay above, matched posts below stay below, and switching anchors resets the base rather than composing.
+**Owner:** tarcode2004
+
+---
+
+## 1. Problem
+
+The current reranking logic in `RelatedStacks.tsx` (`displayStacks` memo, lines ~716–796) pulls all similar posts **below** the anchor regardless of their original positions. This violates the user's reading direction: posts the user has already scrolled past should not resurface below the anchor because that creates re-exposure to content already seen above.
+
+Additionally, when the user clicks a second "see more" on a different anchor while one is already active, the two groupings silently compose (the second anchor also moves its matches, possibly interleaving with the first group). The brief requires that selecting a new anchor **abandons** the prior grouping — the new base is the visible order at the moment of selection.
+
+## 2. Goals
+
+1. **Above → above, below → below.** Matched posts originally above the anchor (in `baseOrder`) move immediately above the anchor; matched posts originally below move immediately below. Non-matched posts stay put.
+2. **Unselect reverts.** When an anchor is toggled off, the list reverts to `baseOrder` (the order before that grouping was applied).
+3. **Single active grouping.** Only one anchor may be "active" at a time for the reordering effect. If the user clicks a new anchor while another is active, the prior grouping is abandoned; the *current visible order* becomes the new `baseOrder`.
+4. **Consistent with existing pagination.** The `shownByAnchor` / `SHOWN_INCREMENT` pagination (how many matched items are shown before the "N more Topic" link) continues to work as before.
+
+## 3. Non-Goals
+
+- Composing multiple simultaneous groupings (not in scope; brief explicitly says "not grouped by both").
+- Changing the "see more" button styling or tooltip UI (Group B territory).
+- Changing the filter chip behavior (Group C territory).
+- Changing highlight-to-filter interactions (Group D territory).
+- Threaded replies, focus-post marks (Groups G and D respectively).
+
+## 4. Decisions Locked
+
+| # | Question | Decision |
+|---|---|---|
+| Q1 | How many anchors can drive reordering at once? | **Exactly one.** Multiple anchors in `reRankAnchorIds` is still possible (the store supports it for nested grouping), but the reordering algorithm only acts on the *most recently added* anchor. The prior anchor's grouping is abandoned when a new one is created. |
+| Q2 | What is `baseOrder`? | The array of stack IDs representing the order at the moment the **current** anchor was created. When no anchor is active it is empty/null. |
+| Q3 | When does `baseOrder` reset? | On two events: (a) a new anchor **replaces** the existing one — `baseOrder` is captured from `displayStacks` at that moment; (b) the anchor is toggled off — `baseOrder` is cleared and `displayStacks` reverts to `relatedStacks` order. |
+| Q4 | Where to track `baseOrder`? | A `useRef<string[]>` inside `RelatedStacks`. Not a state variable — updates do not need to re-render; they are read synchronously inside the `displayStacks` memo on the same render cycle that processes the new anchor. |
+| Q5 | Does `baseOrder` interact with the filter? | No. Filtering runs after reordering (same as today). `baseOrder` only records unfiltered stack IDs. |
+| Q6 | What about the similarity-based fallback (word-overlap)? | The same above/below split applies. If `anchorTopic` is undefined and content-similarity is used, the same algorithm: above-matched go above, below-matched go below. |
+| Q7 | Do sub-anchors (nested groupings via `anchorParent`) survive? | Judgment call: Group E does not attempt to preserve nested sub-anchor behavior. If the user adds a second anchor while one is active, the first is cleared from `reRankAnchorIds` before the second is processed. See "Judgment Calls" section. |
+
+## 5. Behavior Specification
+
+### 5.1 State additions
+
+```ts
+// Inside RelatedStacks component:
+const baseOrderRef = useRef<string[]>([]);          // stack IDs before current grouping
+const activeAnchorIdRef = useRef<string | null>(null); // the anchor currently driving reordering
+```
+
+### 5.2 Reorder algorithm
+
+Given:
+- `baseOrder`: array of `stackId` (not `postId`; both are unique but the component primarily uses `stackId` for keys — see JC #1)
+- `targetId`: the anchor's `topPost.id`
+- `matchPredicate(id: string) => boolean`: returns true if the stack with that post ID matches
+
+```ts
+function reorderForAnchor(
+  stacks: RelatedStackType[],
+  targetPostId: string,
+  matchPredicate: (postId: string) => boolean,
+): RelatedStackType[] {
+  const targetIdx = stacks.findIndex(s => s.topPost.id === targetPostId);
+  if (targetIdx < 0) return stacks;
+
+  const above = stacks.slice(0, targetIdx);
+  const target = stacks[targetIdx];
+  const below = stacks.slice(targetIdx + 1);
+
+  const aboveMatched   = above.filter(s => matchPredicate(s.topPost.id));
+  const aboveUnmatched = above.filter(s => !matchPredicate(s.topPost.id));
+  const belowMatched   = below.filter(s => matchPredicate(s.topPost.id));
+  const belowUnmatched = below.filter(s => !matchPredicate(s.topPost.id));
+
+  return [
+    ...aboveUnmatched,
+    ...aboveMatched,
+    target,
+    ...belowMatched,
+    ...belowUnmatched,
+  ];
+}
+```
+
+The target is **excluded** from `matchPredicate` results (it is always in the center).
+
+### 5.3 Integration into `displayStacks` memo
+
+Replace the existing nested-reranking loop with:
+
+1. If `reRankAnchorIds` is empty: return `[...relatedStacks]` (no reordering). Clear `baseOrderRef` and `activeAnchorIdRef`.
+2. Take the **last** element of `reRankAnchorIds` as the active anchor (`anchorId = reRankAnchorIds[reRankAnchorIds.length - 1]`). Group E only processes one anchor.
+3. If `anchorId !== activeAnchorIdRef.current` (new anchor was added or replaced):
+   - Capture `baseOrderRef.current` = the IDs of `relatedStacks` in their current display order (from the *previous* render's `displayStacks`, if available, or `relatedStacks` directly).
+   - Update `activeAnchorIdRef.current = anchorId`.
+4. Build `baseStacks`: reconstruct `RelatedStackType[]` from `baseOrderRef.current` IDs, mapping back to `relatedStacks` objects. Filter out any IDs that no longer exist in `relatedStacks` (safety).
+5. Compute `anchorTopic` from `anchoredRangeByPost[anchorId]` as today.
+6. Build `matchPredicate`: `(postId) => postId !== anchorId && (stack.topPost.relations?.some(r => r.topic === anchorTopic) ?? false)`. If no `anchorTopic`, fall back to `similarityScore > SIMILARITY_THRESHOLD`.
+7. Apply `reorderForAnchor(baseStacks, anchorId, matchPredicate)` → `reordered`.
+8. Apply pagination: compute `visible` (first `shownByAnchor[anchorId] ?? SHOWN_INCREMENT` matched items). This is needed to drive `groupShown` / `groupTotal` and the "N more" link.
+9. Build `claimedBy`, `anchorSet`, `groupTotal`, `groupShown` from the matched/visible sets.
+10. The `displayStacks` output is `reordered` with only `visible` matched posts (non-visible matched posts are removed from the list, same as today).
+11. Apply filter chips on the final result (same as today).
+
+### 5.4 `baseOrder` capture timing
+
+The critical challenge: `baseOrderRef` must be captured from the **currently displayed** order, not from `relatedStacks` (which is always the server order). But `displayStacks` is computed inside a memo — we cannot read it from a ref inside its own computation without a cycle.
+
+**Solution:** Use a separate `useRef<RelatedStackType[]>` called `prevDisplayStacksRef` that is updated at render-bottom using a plain `useEffect(..., [displayStacks])`. When a new anchor triggers, `baseOrderRef` is set to the IDs from `prevDisplayStacksRef.current` at that moment.
+
+```
+render N  → displayStacks computed (old anchor or no anchor)
+          → useEffect fires (after paint): prevDisplayStacksRef = displayStacks
+render N+1 (new anchor): memo sees new anchorId, reads prevDisplayStacksRef.current
+                          → captures baseOrder from the order that was visible to the user
+```
+
+There is a one-render lag: the base is from the *previous* render's visible order, not the current render. This is correct and acceptable — when the user clicks a new anchor, the order they saw was render N's `displayStacks`, which is what `prevDisplayStacksRef` holds.
+
+### 5.5 Unselect
+
+When `reRankAnchorIds` becomes empty:
+- `baseOrderRef.current = []`
+- `activeAnchorIdRef.current = null`
+- `displayStacks` returns `[...relatedStacks]`
+
+### 5.6 Different-grouping replaces base
+
+When `reRankAnchorIds.length > 0` and the last ID differs from `activeAnchorIdRef.current`:
+- `baseOrderRef.current = prevDisplayStacksRef.current.map(s => s.topPost.id)`
+- `activeAnchorIdRef.current = newAnchorId`
+- Reorder runs on top of the captured base.
+
+**Important sub-case:** The brief says "the current visible order becomes the new ground truth." We capture from `prevDisplayStacksRef` (the order the user saw on screen), not from `relatedStacks`. This correctly encodes "what the user had in front of them."
+
+### 5.7 `anchorParent` / nested anchors
+
+Group E does not support nested anchors. The `anchorParent` map is still computed for compatibility with the label-rendering and connector-line code (which uses it for indentation), but `reorderForAnchor` only runs on the single active anchor.
+
+## 6. Files Touched
+
+| File | Change |
+|---|---|
+| `src/components/RelatedStacks.tsx` | Replace the nested-reranking loop in `displayStacks` memo; add `baseOrderRef`, `activeAnchorIdRef`, `prevDisplayStacksRef`; add `reorderForAnchor` helper (or import it). |
+| `src/utils/reorderForAnchor.ts` | New utility file with the pure `reorderForAnchor` function (YAGNI: only if the function benefits from isolation; otherwise inline). |
+
+Do NOT touch: `HoverTooltip.tsx`, `Shell.tsx`, `ThreadedReplyList.tsx`, `ReplySection.tsx`, `Post.tsx`, `highlightStore.ts`.
+
+## 7. Verification
+
+```bash
+pnpm build   # must produce zero TypeScript errors and zero ESLint errors
+```
+
+Manual test plan:
+1. Open a focus post with ≥ 6 related stacks.
+2. Note the initial order (mentally label: stack A at position 1, B at 2, … F at 6).
+3. Hover stack C and click one of its highlight marks to trigger the anchor.
+4. **Verify:** stacks that share C's topic AND were originally *above* C (A, B) are now immediately above C; stacks originally *below* C that share the topic are immediately below C.
+5. Click the anchor label's "×" to deselect. **Verify:** list reverts to original order.
+6. Trigger anchor on D (different post), then click "N more [topic]". **Verify:** the "show more" still works (pagination increases).
+7. With D's grouping active, trigger anchor on B (different post). **Verify:** D's grouping is abandoned, B becomes the new anchor, reordering runs on the order visible just before B was clicked.
+
+## 8. Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `prevDisplayStacksRef` one-render lag shows wrong base | Low | The lag is exactly one render, which is imperceptible to users. The base is always the most recently *painted* order. |
+| `anchorParent` / connector-line rendering breaks | Low | `anchorParent` is still computed (now for a single anchor only), so label and connector-line code is unaffected. |
+| Pagination ("N more") breaks because `groupTotal`/`groupShown` changes | Low | `groupTotal` = total matched count across `baseStacks`; `groupShown` = visible slice. Logic is identical to today's. |
+| Filter categories interact badly | Low | Filter still runs after reordering, same as today. |
+| Framer Motion FLIP jumps on reorder | Low | `layout` props are already set on `motion.div` and the scroll-pinning `useLayoutEffect` already compensates. |
+
+## 9. Next Steps
+
+1. Write implementation plan (`docs/superpowers/plans/2026-05-13-group-e-reordering.md`).
+2. Implement step-by-step.
+3. `pnpm build` verification.
+4. Open PR against `tarcode2004/enhancement/listy-injection-main-app`.
+
+---
+
+## Judgment Calls Made Without User Input
+
+**JC-1: Use `postId` (not `stackId`) as the key in `baseOrder`.**
+The reorder algorithm needs to identify individual stacks by a stable ID. `topPost.id` (postId) is what `toggleReRankAnchor`, `claimedBy`, and the match predicate already use. `stackId` is the React `key` for `motion.div`. Using `postId` in `baseOrder` is consistent with the existing codebase. Risk: near-zero (postId and stackId are both unique and one-to-one per card).
+
+**JC-2: Only the *last* anchor in `reRankAnchorIds` drives reordering.**
+The brief says "if the user picks a different group-by while already grouped, the prior grouping is abandoned." This implies single-active-anchor semantics. The existing store supports multiple anchors (nested re-ranking), but Group E's reordering replaces the nested loop with a single-anchor algorithm. Older anchors in `reRankAnchorIds` are preserved in state (for the "Grouped by: Topic ×" header UI) but do not drive reordering. Conservative choice: the UI still shows all anchors so the user can deselect them; only the last one actually moves cards.
+
+**JC-3: Capture `baseOrder` from `prevDisplayStacksRef`, not from `relatedStacks`.**
+The brief: "the current visible order becomes the new ground truth." `relatedStacks` is the server order; it does not reflect any active grouping. To capture what the user *sees*, we must read the previously-rendered `displayStacks`. The one-render lag is acceptable.
+
+**JC-4: Non-visible matched posts are *removed* from `displayStacks` (same as today).**
+When `shownByAnchor[anchorId] = 3` and there are 8 matches, only 3 are shown. The other 5 are removed from the list (they are "claimed" but not displayed until the user clicks "N more"). This is the same as the existing behavior and is not changed by Group E.
+
+**JC-5: `anchorParent` is retained in the memo output for compatibility.**
+The label-rendering and connector-line code references `anchorParent` for visual indentation. Group E preserves this map even though reordering now only acts on one anchor. This avoids breaking the visual grouping chrome while keeping the reordering logic simple.

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -10,6 +10,7 @@ import StackPostsModal from './StackPostsModal';
 import InteractionControl from './InteractionControl';
 import { toggleFavourite, toggleBookmark } from '../utils/mastoActions';
 import { setHoveredSidebarPost, setHoveredHighlightRangeIndex, setHoveredCategory, setTapped, clearTapped, toggleReRankAnchor, clearReRankAnchors, setFilterCategories, useHighlightStore } from '../utils/highlightStore';
+import { reorderForAnchor } from '../utils/reorderForAnchor';
 import type { Relation } from '../types/PostType';
 import { showTooltip, hideTooltip, type TooltipColors } from './HoverTooltip';
 import './RelatedStacks.css';
@@ -709,76 +710,156 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     });
   }, [reRankAnchorIds]);
 
-  /** Nested re-ranking: process anchors in order, each pulling unclaimed similar posts after itself.
-   *  Re-ranking runs on the FULL set so groupings stay stable; the active filter
-   *  is applied AFTER re-ranking and only hides non-matching cards. This keeps
-   *  filtering from changing the order or breaking groups. */
+  // E: base order tracking — the post-ID order at the moment the active anchor was created.
+  // Using refs (not state) so captures don't trigger extra re-renders.
+  const baseOrderRef = useRef<string[]>([]);
+  const activeAnchorIdRef = useRef<string | null>(null);
+  // E: previous render's displayStacks — updated after each render via useEffect.
+  // Used to capture the "current visible order" when a new anchor replaces the old one.
+  const prevDisplayStacksRef = useRef<RelatedStackType[]>([]);
+
+  /** E: Single-anchor reordering — above-matched move above target, below-matched move below.
+   *  Re-ranking runs on the base order captured at anchor-creation time so a new anchor
+   *  can layer on top of the previously visible ordering. The active filter is applied
+   *  AFTER re-ranking (same as before) so filtering never breaks group connectivity. */
   const { displayStacks, claimedBy, anchorSet, anchorParent, groupTotal, groupShown } = useMemo(() => {
     const anchorSet = new Set(reRankAnchorIds);
     const claimedBy = new Map<string, string>(); // postId -> anchorId
     const anchorParent = new Map<string, string>(); // anchorId -> parent anchorId
     const groupTotal = new Map<string, number>(); // anchorId -> total similar count
     const groupShown = new Map<string, number>(); // anchorId -> shown similar count
-    let result = [...relatedStacks];
 
-    if (reRankAnchorIds.length > 0) {
-      for (let ai = 0; ai < reRankAnchorIds.length; ai++) {
-        const anchorId = reRankAnchorIds[ai];
-        const anchorIdx = result.findIndex(s => s.topPost.id === anchorId);
-        if (anchorIdx === -1) continue;
-
-        // Determine if this anchor sits inside another anchor's group
-        for (let k = anchorIdx - 1; k >= 0; k--) {
-          const prevId = result[k].topPost.id;
-          if (anchorSet.has(prevId)) { anchorParent.set(anchorId, prevId); break; }
-          if (!claimedBy.has(prevId)) break;
-        }
-
-        const anchor = result[anchorIdx];
-        const anchorContent = anchor.topPost.content;
-
-        // Topic-based when the anchor was created by clicking a specific highlight
-        // (so it matches the "N more <topic>" tooltip exactly). Falls back to
-        // content word-similarity when the anchor has no specific range/topic.
-        const anchorRangeIdx = anchoredRangeByPost[anchorId];
-        const anchorTopic = anchorRangeIdx !== undefined
-          ? anchor.topPost.relations?.[anchorRangeIdx]?.topic
-          : undefined;
-
-        const similar: { stack: RelatedStackType; score: number }[] = [];
-        for (const s of result) {
-          if (s.topPost.id === anchorId) continue;
-          // Skip anchors that were added BEFORE this one — they're senior, don't move them
-          const sAnchorOrder = reRankAnchorIds.indexOf(s.topPost.id);
-          if (sAnchorOrder >= 0 && sAnchorOrder < ai) continue;
-
-          if (anchorTopic) {
-            const hasTopic = s.topPost.relations?.some(r => r.topic === anchorTopic) ?? false;
-            if (hasTopic) similar.push({ stack: s, score: 1 });
-          } else {
-            const score = similarityScore(s.topPost.content, anchorContent);
-            if (score > SIMILARITY_THRESHOLD) similar.push({ stack: s, score });
-          }
-        }
-        // Topic-based: keep original order (all scores equal). Similarity-based: sort by score.
-        if (!anchorTopic) similar.sort((a, b) => b.score - a.score);
-        groupTotal.set(anchorId, similar.length);
-        if (similar.length === 0) { groupShown.set(anchorId, 0); continue; }
-
-        // Take only the first N — pagination via "MORE [topic]" link.
-        const shown = shownByAnchor[anchorId] ?? SHOWN_INCREMENT;
-        const visible = similar.slice(0, shown);
-        groupShown.set(anchorId, visible.length);
-
-        for (const { stack } of visible) {
-          claimedBy.set(stack.topPost.id, anchorId);
-        }
-
-        const similarIds = new Set(visible.map(s => s.stack.topPost.id));
-        result = result.filter(s => !similarIds.has(s.topPost.id));
-        const newAnchorIdx = result.findIndex(s => s.topPost.id === anchorId);
-        result.splice(newAnchorIdx + 1, 0, ...visible.map(s => s.stack));
+    // No active anchors — revert to server order and clear tracking refs.
+    if (reRankAnchorIds.length === 0) {
+      baseOrderRef.current = [];
+      activeAnchorIdRef.current = null;
+      let result = [...relatedStacks];
+      if (filterCategories.size > 0) {
+        result = result.filter((s) => {
+          const cats = new Set<string>();
+          for (const r of s.topPost.relations ?? []) cats.add(r.category);
+          let allPresent = true;
+          filterCategories.forEach(c => { if (!cats.has(c)) allPresent = false; });
+          return allPresent;
+        });
       }
+      return { displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown };
+    }
+
+    // E: Only the most recently added anchor drives reordering (single-anchor semantics).
+    const anchorId = reRankAnchorIds[reRankAnchorIds.length - 1];
+
+    // Detect anchor transition: new anchor was added or replaced the previous one.
+    if (anchorId !== activeAnchorIdRef.current) {
+      // Capture the order the user currently sees as the new base.
+      // prevDisplayStacksRef holds the displayStacks from the previous render (before this anchor).
+      const prev = prevDisplayStacksRef.current;
+      baseOrderRef.current = (prev.length > 0 ? prev : relatedStacks).map(s => s.topPost.id);
+      activeAnchorIdRef.current = anchorId;
+    }
+
+    // Reconstruct baseStacks from the captured IDs (drop IDs no longer in relatedStacks).
+    const stackById = new Map(relatedStacks.map(s => [s.topPost.id, s]));
+    const baseStacks: RelatedStackType[] = baseOrderRef.current
+      .map(id => stackById.get(id))
+      .filter((s): s is RelatedStackType => s !== undefined);
+    // Fall back to relatedStacks order if base is somehow empty.
+    const workingStacks = baseStacks.length > 0 ? baseStacks : [...relatedStacks];
+
+    // Find anchor entry in the working set.
+    const anchorEntry = workingStacks.find(s => s.topPost.id === anchorId);
+    if (!anchorEntry) {
+      // Anchor not found — return as-is.
+      let result = [...workingStacks];
+      if (filterCategories.size > 0) {
+        result = result.filter((s) => {
+          const cats = new Set<string>();
+          for (const r of s.topPost.relations ?? []) cats.add(r.category);
+          let allPresent = true;
+          filterCategories.forEach(c => { if (!cats.has(c)) allPresent = false; });
+          return allPresent;
+        });
+      }
+      return { displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown };
+    }
+
+    const anchorContent = anchorEntry.topPost.content;
+
+    // Topic-based when the anchor was created by clicking a specific highlight.
+    // Falls back to content word-similarity when the anchor has no specific topic.
+    const anchorRangeIdx = anchoredRangeByPost[anchorId];
+    const anchorTopic = anchorRangeIdx !== undefined
+      ? anchorEntry.topPost.relations?.[anchorRangeIdx]?.topic
+      : undefined;
+
+    // Build the set of ALL matching post IDs (before pagination).
+    const allMatchedIds = new Set<string>();
+    if (anchorTopic) {
+      for (const s of workingStacks) {
+        if (s.topPost.id === anchorId) continue;
+        if (s.topPost.relations?.some(r => r.topic === anchorTopic)) {
+          allMatchedIds.add(s.topPost.id);
+        }
+      }
+    } else {
+      // Similarity-based fallback — collect sorted by score.
+      const scored: { id: string; score: number }[] = [];
+      for (const s of workingStacks) {
+        if (s.topPost.id === anchorId) continue;
+        const score = similarityScore(s.topPost.content, anchorContent);
+        if (score > SIMILARITY_THRESHOLD) scored.push({ id: s.topPost.id, score });
+      }
+      // Sort by score descending; then add IDs in that order (Set preserves insertion order).
+      scored.sort((a, b) => b.score - a.score);
+      for (const { id } of scored) allMatchedIds.add(id);
+    }
+
+    groupTotal.set(anchorId, allMatchedIds.size);
+
+    if (allMatchedIds.size === 0) {
+      groupShown.set(anchorId, 0);
+      let result = [...workingStacks];
+      if (filterCategories.size > 0) {
+        result = result.filter((s) => {
+          const cats = new Set<string>();
+          for (const r of s.topPost.relations ?? []) cats.add(r.category);
+          let allPresent = true;
+          filterCategories.forEach(c => { if (!cats.has(c)) allPresent = false; });
+          return allPresent;
+        });
+      }
+      return { displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown };
+    }
+
+    // Pagination: only show the first N matched posts.
+    const shown = shownByAnchor[anchorId] ?? SHOWN_INCREMENT;
+    const allMatchedArray = Array.from(allMatchedIds);
+    const visibleMatchedIds = new Set(allMatchedArray.slice(0, shown));
+    groupShown.set(anchorId, visibleMatchedIds.size);
+
+    allMatchedArray.slice(0, shown).forEach(id => {
+      claimedBy.set(id, anchorId);
+    });
+
+    // Remove non-visible matched posts (they are paginated out).
+    const hiddenMatchedIds = new Set(allMatchedArray.slice(shown));
+    const paginatedStacks = workingStacks.filter(s => !hiddenMatchedIds.has(s.topPost.id));
+
+    // E: Apply above/below split — matched above anchor stay above, matched below stay below.
+    let result = reorderForAnchor(
+      paginatedStacks,
+      anchorId,
+      (pid) => visibleMatchedIds.has(pid),
+    );
+
+    // Populate anchorParent for visual connector-line indentation (single anchor: no parent).
+    // If there are older anchors still in reRankAnchorIds (shouldn't happen with single-anchor
+    // semantics, but kept for safety), walk the result to detect nesting.
+    const anchorIdx = result.findIndex(s => s.topPost.id === anchorId);
+    for (let k = anchorIdx - 1; k >= 0; k--) {
+      const prevId = result[k].topPost.id;
+      if (anchorSet.has(prevId)) { anchorParent.set(anchorId, prevId); break; }
+      if (!claimedBy.has(prevId)) break;
     }
 
     // C1: multi-category filter with AND semantics across relations array
@@ -793,7 +874,13 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     }
 
     return { displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown };
-  }, [relatedStacks, filterCategories, reRankAnchorIds, shownByAnchor]);
+  }, [relatedStacks, filterCategories, reRankAnchorIds, shownByAnchor, anchoredRangeByPost]);
+
+  // E: keep prevDisplayStacksRef up-to-date so the next anchor activation can
+  // capture the order the user currently sees as the new baseOrder.
+  useEffect(() => {
+    prevDisplayStacksRef.current = displayStacks;
+  }, [displayStacks]);
 
   const handleShowMore = (anchorId: string) => {
     setShownByAnchor(prev => ({ ...prev, [anchorId]: (prev[anchorId] ?? SHOWN_INCREMENT) + SHOWN_INCREMENT }));

--- a/src/utils/reorderForAnchor.ts
+++ b/src/utils/reorderForAnchor.ts
@@ -1,0 +1,34 @@
+/**
+ * Reorders `stacks` so that posts matching `matchPredicate` that were above
+ * `targetPostId` move immediately above it, and those below move immediately
+ * below it. Non-matching posts stay in their relative positions.
+ *
+ * This implements the Group E "above → above, below → below" invariant:
+ * users reading in order should not be re-exposed to posts they already
+ * scrolled past just because those posts match the anchor's topic.
+ */
+export function reorderForAnchor<T extends { topPost: { id: string } }>(
+  stacks: T[],
+  targetPostId: string,
+  matchPredicate: (postId: string) => boolean,
+): T[] {
+  const targetIdx = stacks.findIndex(s => s.topPost.id === targetPostId);
+  if (targetIdx < 0) return stacks;
+
+  const above = stacks.slice(0, targetIdx);
+  const target = stacks[targetIdx];
+  const below = stacks.slice(targetIdx + 1);
+
+  const aboveMatched   = above.filter(s =>  matchPredicate(s.topPost.id));
+  const aboveUnmatched = above.filter(s => !matchPredicate(s.topPost.id));
+  const belowMatched   = below.filter(s =>  matchPredicate(s.topPost.id));
+  const belowUnmatched = below.filter(s => !matchPredicate(s.topPost.id));
+
+  return [
+    ...aboveUnmatched,
+    ...aboveMatched,
+    target,
+    ...belowMatched,
+    ...belowUnmatched,
+  ];
+}


### PR DESCRIPTION
## Summary

Implements the Group E reordering algorithm specified in the research brief:

- When a user activates a "see more" anchor on a related post, matched posts **above** the target stay above (move immediately above it), and matched posts **below** stay below (move immediately below it). The old behavior moved everything below the anchor regardless of original position.
- When the anchor is deselected, the list reverts to the base order (the order before the grouping was applied).
- When the user activates a **different** anchor while one is already active, the prior grouping is abandoned. The current visible order at that moment becomes the new base order for the new grouping.

Spec: `docs/superpowers/specs/2026-05-13-group-e-reordering-design.md`
Plan: `docs/superpowers/plans/2026-05-13-group-e-reordering.md`

## Judgment Calls

**JC-1: Use `postId` as the key in `baseOrder`** — consistent with how `toggleReRankAnchor`, `claimedBy`, and match predicates already identify stacks throughout the file.

**JC-2: Only the *last* anchor in `reRankAnchorIds` drives reordering** — the brief says "prior grouping is abandoned" on new selection, which implies single-active-anchor semantics. Older anchors remain in state so the "Grouped by: Topic ×" header can display and dismiss them, but only the newest moves cards.

**JC-3: Capture `baseOrder` from `prevDisplayStacksRef`** — to correctly encode "the current visible order becomes the new ground truth," we must read the previously-rendered `displayStacks` (not `relatedStacks`, which is always the server order). A `useEffect` keeps `prevDisplayStacksRef` updated after each render; there is one unavoidable render-lag which is imperceptible to users.

**JC-4: Non-visible matched posts are removed from `displayStacks`** — same behavior as the existing code. Posts beyond the pagination window are hidden until the user clicks "N more [topic]."

**JC-5: `anchorParent` map is retained** — the label-rendering and connector-line code references it for visual indentation. Group E preserves this map even though reordering now acts on only one anchor, avoiding breakage to existing visual chrome.

## Files Changed

- `src/utils/reorderForAnchor.ts` — new pure utility function (above/below split)
- `src/components/RelatedStacks.tsx` — replaced the old nested-reranking loop with the single-anchor above/below algorithm; added `baseOrderRef`, `activeAnchorIdRef`, `prevDisplayStacksRef` refs; added `anchoredRangeByPost` to the memo dependency array (it was missing before)

## Manual Test Plan

1. Open `/listy-injection` and select a focus post with ≥ 6 related stacks.
2. Note the initial order (label positions A=1, B=2, C=3, D=4, E=5, F=6).
3. Hover stack C and click one of its highlight marks to trigger the "see more" anchor.
4. **Verify:** matched posts originally *above* C are now immediately above C (e.g., A and B stay above, but matched ones cluster right above C); matched posts originally *below* C are immediately below C.
5. Click the "×" on the anchor label or the topic badge in the header. **Verify:** list reverts to the original order.
6. Trigger anchor on C again, then click "N more [topic]". **Verify:** pagination works (more matched posts appear).
7. With C's grouping active, click an anchor on D (a different post). **Verify:** C's grouping is abandoned, D becomes the new anchor; new reordering runs on top of the order visible just before D was clicked (not the original server order).

## Build Verification

```
pnpm build  ✓  (zero TypeScript/ESLint errors)
```

Closes (no linked issue — this is a research ablation group implementation).