### PR TITLE
Group I: simulated-feedback polish (per-robot avatars, badge, countdown label)

### DIFF
--- a/docs/superpowers/plans/2026-05-13-group-i-simulated-feedback.md
+++ b/docs/superpowers/plans/2026-05-13-group-i-simulated-feedback.md
@@ -1,0 +1,33 @@
+# Group I — Simulated Feedback Polish: Implementation Plan
+
+**Date:** 2026-05-13
+
+---
+
+## Steps
+
+### Step 1 — Write spec and plan docs
+Create `docs/superpowers/specs/` and `docs/superpowers/plans/` directories and write this plan + the design spec.
+Commit: `Add Group I spec and plan for simulated feedback polish`
+
+### Step 2 — Fix per-robot avatar cycling + remove dead avatar state
+In `src/components/ReplySection.tsx`:
+- Remove `const [avatar, setAvatar] = useState(avatars[0])` (dead state).
+- In the simulated replies map, change `<Avatar src={avatar} />` to `<Avatar src={avatars[index % avatars.length]} />`.
+Commit: `Fix per-robot avatar cycling in ReplySection`
+
+### Step 3 — SIMULATED badge: add uppercase text transform
+In the `<Badge>` for each simulated reply, add `tt="uppercase"` prop.
+Commit: `Add uppercase transform to SIMULATED badge`
+
+### Step 4 — Flatten Feedback paper nesting + improve countdown label
+- Replace the inner nested `<Paper>` (for advice/praise) with a plain `<div>` styled identically.
+- Change button countdown label from `Submit? (Wait ${countdown} seconds)` to `Wait ${countdown}s…`.
+Commit: `Flatten feedback paper nesting, improve countdown label`
+
+### Step 5 — Verify build
+Run `pnpm build` from the worktree root. Fix any TypeScript errors.
+
+### Step 6 — Open PR
+Target `tarcode2004/enhancement/listy-injection-main-app`.
+Include spec/plan links and judgment calls in PR body.

--- a/docs/superpowers/specs/2026-05-13-group-i-simulated-feedback-design.md
+++ b/docs/superpowers/specs/2026-05-13-group-i-simulated-feedback-design.md
@@ -1,0 +1,99 @@
+# Group I — Simulated Feedback Polish: Design Spec
+
+**Date:** 2026-05-13
+**Branch:** worktree-agent-a9f6fe233f47dca02
+**PR base:** tarcode2004/enhancement/listy-injection-main-app
+**Author (agent):** Group I
+
+---
+
+## 1. Problem Statement
+
+The existing `ReplySection.tsx` already implements real-time simulated feedback (debounced fetch, advice/praise display, simulated robot replies, 5-second countdown gate). However a close comparison of the current implementation against the reference screenshots surfaces several visual and behavioral gaps.
+
+---
+
+## 2. Scope
+
+**In scope (this group):**
+- Fix per-robot avatar cycling (all robots currently show the same avatar).
+- Tighten "SIMULATED" badge styling to match screenshots (pill, uppercase text, clear contrast).
+- Polish the "Feedback" paper: ensure bold header renders correctly, add gentle visual separation between praise and advice.
+- Verify and improve the submit button disabled-state styling (countdown text, grey color).
+- Remove the unused `avatar` state variable (dead code after per-robot fix).
+- SubmitPost extension: see Judgment Call #1 below — **skipped** due to API constraint.
+
+**Out of scope:**
+- RelatedStacks.tsx, HoverTooltip.tsx, Shell.tsx, ThreadedReplyList.tsx, Post.tsx, highlightStore.ts.
+- Any new routes or pages.
+- Any changes to the feedback API itself.
+
+---
+
+## 3. Current vs. Target State
+
+### 3a. Per-Robot Avatars
+
+| Current | Target |
+|---------|--------|
+| `<Avatar src={avatar} />` where `avatar = avatars[0]` (always `stacky_angry.PNG`) | `<Avatar src={avatars[index % avatars.length]} />` — distinct robot face per row |
+
+### 3b. SIMULATED Badge
+
+| Current | Target |
+|---------|--------|
+| `color="gray" variant="outline"` — rendered in Mantine's default small text size | Keep `color="gray" variant="outline"` but add `tt="uppercase"` for all-caps, `fw={700}`, and explicit `fontSize: '10px'` already present. Also verify badge text is exactly "SIMULATED" (it is). |
+
+After reading the code the badge is already structurally correct (gray outline, positioned top-right, 10px). The only missing piece is the all-caps transform which Mantine `Badge` does NOT apply by default even with uppercase text — `tt="uppercase"` fixes it. The screenshots show "SIMULATED" in all-caps with a slightly heavier feel.
+
+### 3c. Robot Card Layout
+
+The avatar and "Robot N" label sit in a `<Group>` but the label div only has a single `<Text>` child. The screenshots show the robot name appears slightly bolder and at medium size. Current: `fw="700" size="sm"`. This is acceptable — no change needed.
+
+### 3d. Submit Button Disabled State
+
+Current: `style={{ backgroundColor: isDisabled ? 'grey' : 'green' }}`. The countdown label reads `Submit? (Wait N seconds)` which is verbose and shows a question mark. This is functional but the question mark is odd. Change to `Wait ${countdown}s…` for clarity and conciseness while keeping the same UX intent.
+
+The button already goes grey while disabled — this matches the screenshots adequately. No further styling change needed.
+
+### 3e. Feedback Paper Nesting
+
+Currently there is a `<Paper>` wrapping the outer feedback block AND a nested `<Paper>` inside for the advice/praise section, both with identical `backgroundColor: '#f9f9f9'`. This double-nesting is invisible visually but causes unnecessary DOM nesting. Flatten: keep the outer Paper as the card boundary; make the inner advice block just a `<div>` with bottom margin.
+
+### 3f. Dead Code Removal
+
+`const [avatar, setAvatar] = useState(avatars[0])` — `setAvatar` is never called; the state is only read in the old per-robot render (which we are replacing). Remove this state variable after the fix.
+
+---
+
+## 4. SubmitPost Extension Analysis
+
+The `/posts/feedback` API call in `ReplySection.tsx` sends:
+```json
+{ "draftID": "...", "parentPostID": "<postId>", "draftText": "..." }
+```
+
+`parentPostID` is always the current post's ID. There is no documentation in the codebase about whether `parentPostID: null` is accepted for top-level posts. The field name "parentPostID" strongly implies a reply context is required by the backend contract.
+
+Attempting to call the endpoint with `parentPostID: null` or omitting it would require runtime verification against the live backend. Running speculative API calls against production without the user's explicit confirmation of that contract is outside YAGNI bounds for a polish pass.
+
+**Judgment Call #1 — Skip SubmitPost extension.** The feature is not extended to the top-level post composer. This is documented here and will be called out in the PR description as a known limitation.
+
+---
+
+## 5. Judgment Calls
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| JC1 | Skip SubmitPost.tsx simulated-feedback extension | `parentPostID` field name implies reply context; no API doc for null case; YAGNI for polish pass |
+| JC2 | Keep `color="gray" variant="outline"` for SIMULATED badge | Matches screenshots — gray pill outline is visible and distinct |
+| JC3 | Flatten inner Paper nesting | No visual impact, cleaner DOM; low-risk refactor |
+| JC4 | Change countdown label from `Submit? (Wait N seconds)` to `Wait Ns…` | Shorter, no question mark ambiguity; same behavioral intent |
+| JC5 | Do not add a separate CSS module for ReplySection | Component is self-contained with inline styles; adding a module file would be disproportionate |
+
+---
+
+## 6. Visual Gaps That Cannot Be Addressed Without More Design Input
+
+- The screenshots show robot cards with a subtle left-colored accent border (hard to tell if it is a design intent or screenshot compression artifact). No change made without confirmation.
+- The "Feedback" paper background in screenshots appears pure white (`#fff`) rather than the current `#f9f9f9`. This is a judgment call to leave as-is since `#f9f9f9` provides a subtle but useful visual distinction.

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -45,7 +45,7 @@ const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchP
 
     useEffect(() => {
         if (countdown > 0) {
-            setButtonLabel(`Submit? (Wait ${countdown} seconds)`);
+            setButtonLabel(`Wait ${countdown}s…`);
             if (!countdownIntervalRef.current) {
                 countdownIntervalRef.current = setInterval(() => {
                     setCountdown((c) => Math.max(0, c - 1));
@@ -195,20 +195,11 @@ const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchP
                     ) : (
                         <>
                             {(advice || praise) && (
-                                <Paper
-                                    style={{
-                                        padding: '10px',
-                                        backgroundColor: '#f9f9f9',
-                                        borderRadius: '8px',
-                                        fontFamily: 'Roboto, sans-serif',
-                                        fontSize: '14px',
-                                        marginBottom: '10px'
-                                    }}
-                                >
+                                <div style={{ marginBottom: '10px' }}>
                                     <Text fw="900" size="xl">Feedback</Text>
-                                    {praise && <Text>{praise}</Text>}
-                                    {advice && <Text>{advice}</Text>}
-                                </Paper>
+                                    {praise && <Text mt={4}>{praise}</Text>}
+                                    {advice && <Text mt={4}>{advice}</Text>}
+                                </div>
                             )}
 
                             {simulatedReplies.length > 0 && (

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -31,7 +31,6 @@ const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchP
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
     const [countdown, setCountdown] = useState<number>(0);
     const [simulatedReplies, setSimulatedReplies] = useState<any[]>([]);
-    const [avatar, setAvatar] = useState(avatars[0]);
 
     const draftIdRef = useRef(uuidv4());
     const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -230,7 +229,7 @@ const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchP
                                                 }}
                                             >
                                                 <Group>
-                                                    <Avatar src={avatar} radius="xl" />
+                                                    <Avatar src={avatars[index % avatars.length]} radius="xl" />
                                                     <div>
                                                         <Text fw="700" size="sm">Robot {index + 1}</Text>
                                                     </div>

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -238,6 +238,8 @@ const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchP
                                                 <Badge
                                                     color="gray"
                                                     variant="outline"
+                                                    tt="uppercase"
+                                                    fw={700}
                                                     style={{
                                                         position: 'absolute',
                                                         top: '10px',


### PR DESCRIPTION
## Summary

Polish pass on the existing `ReplySection.tsx` simulated-feedback feature:

- **Per-robot avatar cycling**: each Robot card now shows a distinct stacky avatar (`avatars[index % avatars.length]`) instead of all showing `stacky_angry.PNG`. Uses the existing 8-entry avatar array.
- **SIMULATED badge**: added `tt="uppercase"` and `fw={700}` to the Mantine Badge so the label renders as all-caps bold, matching the reference screenshots more closely.
- **Countdown label**: changed from the verbose `Submit? (Wait N seconds)` to `Wait Ns…` — same behavioral meaning, less awkward question mark.
- **Flatten feedback paper nesting**: removed a redundant nested `<Paper>` (with identical background) inside the Feedback section; replaced with a plain `<div>`. No visual regression — cleaner DOM.
- **Dead code removal**: removed the unused `const [avatar, setAvatar] = useState(avatars[0])` state variable (setAvatar was never called).
- **Docs**: added spec and plan under `docs/superpowers/specs/` and `docs/superpowers/plans/`.

## Judgment Calls

| # | Decision | Rationale |
|---|----------|-----------|
| JC1 | Skip SubmitPost.tsx simulated-feedback extension | The `/posts/feedback` endpoint's `parentPostID` field strongly implies a reply context is required. No documentation in the codebase confirms `parentPostID: null` is accepted for top-level posts. Extending without API confirmation is out of scope for a polish pass. |
| JC2 | Keep `color="gray" variant="outline"` badge style | Matches screenshots adequately. |
| JC3 | Flatten inner Paper nesting | No visual impact; slightly cleaner DOM. |
| JC4 | Change countdown label | Shorter, no question-mark ambiguity; same intent. |
| JC5 | No new CSS module for ReplySection | Component uses inline styles consistently; adding a module would be disproportionate. |

## Known Limitation

Simulated feedback is **only available on reply drafts** (`ReplySection`), not on the top-level post composer (`SubmitPost`). See JC1. Extending to top-level posts requires backend confirmation that `parentPostID: null` is accepted.

## Visual Gaps (cannot address without more design input)

- Screenshots may show a subtle left-accent border on robot cards — unclear if intentional or screenshot artifact. Not added.
- Feedback paper background is `#f9f9f9`; screenshots appear slightly lighter. Left as-is for the subtle visual distinction it provides.

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-13-group-i-simulated-feedback-design.md`
- Plan: `docs/superpowers/plans/2026-05-13-group-i-simulated-feedback.md`

## Test Plan

- [ ] Navigate to any post with `/posts/[id]`
- [ ] Type 10+ characters in the reply box — feedback panel should appear after 500 ms debounce
- [ ] Verify "Feedback" header is bold `fw=900 xl`
- [ ] Verify each Robot card shows a **different** stacky avatar image
- [ ] Verify SIMULATED badge reads "SIMULATED" (all-caps, bold) on each card
- [ ] Verify submit button shows `Wait 5s…` → `Wait 4s…` etc. during countdown, then reverts to `Submit`
- [ ] Verify button is greyed out during countdown and green when enabled
- [ ] Submit a reply — composer clears, feedback panel disappears
- [ ] `/listy-injection` page: confirm ReplySection renders identically there