### PR TITLE
Group H: URL state, back-navigation, and share/bookmark persistence

### DIFF
--- a/docs/superpowers/plans/2026-05-13-group-h-url-state.md
+++ b/docs/superpowers/plans/2026-05-13-group-h-url-state.md
@@ -1,0 +1,347 @@
+# Group H — URL State Implementation Plan
+
+**Date:** 2026-05-13
+**Status:** Ready
+**Spec:** `docs/superpowers/specs/2026-05-13-group-h-url-state-design.md`
+
+---
+
+## Step 1 — Add `useUrlSync` utility hook
+
+**File:** `src/utils/useUrlSync.ts` (new file)
+
+### 1.1 Create the hook
+
+This hook owns all URL ↔ state sync for the post-detail route.
+
+Responsibilities:
+- **Hydrate on mount:** read `?tab`, `?fc`, `?fs` from `useSearchParams()` and push into local state + store.
+- **Write on change:** debounced `router.replace` that encodes current `activeTab`, `filterCategories`, and `filterFocusSpan`.
+
+Key implementation notes:
+- Import `useSearchParams`, `useRouter`, `usePathname` from `next/navigation`.
+- Import `setFilterCategories`, `setFilterFocusSpan`, `useHighlightStore` from `./highlightStore`.
+- The debounce ref holds a `ReturnType<typeof setTimeout>`.
+- **Hydration** runs in a `useEffect` gated on a `hydratedRef` flag — fires once per mount (i.e., once per post ID change when the page remounts). After hydrating, it calls `onHydratedTab?.(tab)` so the page can trigger tab-specific fetches.
+- **Write** runs in a separate `useEffect` watching `[activeTab, filterCategories, filterFocusSpan]`. It builds the new search params string and calls `router.replace`.
+- `"use client"` directive at the top.
+
+Implementation:
+
+```ts
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import {
+  setFilterCategories,
+  setFilterFocusSpan,
+  clearFilterFocusSpan,
+  useHighlightStore,
+} from "./highlightStore";
+
+export interface UrlSyncOptions {
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+  /** Plain-text content of the focus post — needed to reconstruct fs text on hydration */
+  plainPostText: string | null;
+  /** Called once on mount when URL has a tab param (so page can trigger data fetch) */
+  onHydratedTab?: (tab: string) => void;
+}
+
+const VALID_TABS = ["time", "recommended", "stacked", "summary"] as const;
+
+export function useUrlSync({
+  activeTab,
+  setActiveTab,
+  plainPostText,
+  onHydratedTab,
+}: UrlSyncOptions): void {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const { filterCategories, filterFocusSpan } = useHighlightStore();
+
+  const hydratedRef = useRef(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── HYDRATION: runs once on mount (or when pathname changes = new post) ──
+  useEffect(() => {
+    hydratedRef.current = false;
+  }, [pathname]);
+
+  useEffect(() => {
+    if (hydratedRef.current) return;
+
+    // tab
+    const tabParam = searchParams.get("tab");
+    if (tabParam && VALID_TABS.includes(tabParam as any)) {
+      setActiveTab(tabParam);
+      onHydratedTab?.(tabParam);
+    }
+
+    // fc (filter categories)
+    const fcParam = searchParams.get("fc");
+    if (fcParam) {
+      const cats = new Set(fcParam.split(",").filter(Boolean));
+      if (cats.size > 0) setFilterCategories(cats);
+    } else {
+      // Clear any stale store state when navigating to a URL with no fc
+      setFilterCategories(new Set());
+    }
+
+    // fs (filter focus span) — text reconstructed once post loads
+    // Stored as a pending parse; actual setFilterFocusSpan called below when plainPostText available
+    hydratedRef.current = true;
+  }, [pathname, searchParams]);
+
+  // ── SPAN HYDRATION: deferred until post content is available ──
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    const fsParam = searchParams.get("fs");
+    if (!fsParam || !plainPostText) return;
+    const parts = fsParam.split("-").map(Number);
+    if (parts.length !== 2 || parts.some(isNaN)) return;
+    const [start, end] = parts;
+    if (start < 0 || end <= start || start >= plainPostText.length) return;
+    const safeEnd = Math.min(end, plainPostText.length);
+    const text = plainPostText.slice(start, safeEnd);
+    setFilterFocusSpan({ start, end: safeEnd, text });
+  }, [plainPostText, pathname]); // re-run when post loads
+
+  // ── WRITE: debounced URL update when state changes ──
+  useEffect(() => {
+    if (!hydratedRef.current) return; // don't write before hydration reads
+
+    const params = new URLSearchParams();
+
+    if (activeTab && activeTab !== "time") {
+      params.set("tab", activeTab);
+    }
+
+    if (filterCategories.size > 0) {
+      params.set("fc", Array.from(filterCategories).join(","));
+    }
+
+    if (filterFocusSpan !== null) {
+      params.set("fs", `${filterFocusSpan.start}-${filterFocusSpan.end}`);
+    }
+
+    // Preserve ?stackId and ?from if present (don't clobber pre-existing params)
+    const stackId = searchParams.get("stackId");
+    if (stackId) params.set("stackId", stackId);
+    const from = searchParams.get("from");
+    if (from) params.set("from", from);
+
+    const newSearch = params.toString();
+    const currentSearch = searchParams.toString();
+    if (newSearch === currentSearch) return; // no-op
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      router.replace(`${pathname}${newSearch ? "?" + newSearch : ""}`);
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [activeTab, filterCategories, filterFocusSpan, pathname]);
+}
+```
+
+**Verification:** `pnpm build` — no errors.
+
+---
+
+## Step 2 — Integrate `useUrlSync` into `/posts/[id]/page.tsx`
+
+**File:** `src/app/(shell)/posts/[id]/page.tsx`
+
+### 2.1 Add import
+
+```ts
+import { useUrlSync } from "../../../../utils/useUrlSync";
+```
+
+### 2.2 Add plain-text helper
+
+After the existing `withAuth` and `mapWithStackFields` helpers, add:
+
+```ts
+/** Strip HTML tags to extract plain text for span hydration */
+function stripHtmlToPlain(html: string): string {
+  if (typeof document !== "undefined") {
+    const el = document.createElement("div");
+    el.innerHTML = html;
+    return el.textContent ?? el.innerText ?? "";
+  }
+  return html.replace(/<[^>]*>/g, "");
+}
+```
+
+### 2.3 Derive `plainPostText`
+
+After the `post` state declaration, add a derived value (not state — computed inline):
+
+```ts
+const plainPostText = post ? stripHtmlToPlain(post.content) : null;
+```
+
+### 2.4 Call `useUrlSync`
+
+After `const [activeTab, setActiveTab] = useState<string>("time")`, add:
+
+```ts
+useUrlSync({
+  activeTab,
+  setActiveTab,
+  plainPostText,
+  onHydratedTab: async (tab) => {
+    // Trigger data fetch for tabs that need it on initial load
+    const actions: Record<string, (() => Promise<void>) | undefined> = {
+      recommended: fetchRecommended,
+      stacked: fetchRepliesStack,
+      summary: fetchSummary,
+    };
+    const fn = actions[tab];
+    if (fn) await fn();
+  },
+});
+```
+
+Note: `fetchRecommended`, `fetchRepliesStack`, and `fetchSummary` are defined later in the component with `useCallback`. The `onHydratedTab` callback captures them via closure — this is safe because `useUrlSync` calls `onHydratedTab` only after mount effects have run (after hydration).
+
+### 2.5 Seed `?from=` into sessionStorage on mount
+
+After the main init `useEffect`, add:
+
+```ts
+// H5: seed BackButton sessionStorage from ?from= param on shared links
+useEffect(() => {
+  const fromId = searchParamsRef.current?.get("from");
+  if (!fromId) return;
+  const key = `previousPath:${window.location.pathname}`;
+  if (!sessionStorage.getItem(key)) {
+    sessionStorage.setItem(key, `/posts/${fromId}`);
+  }
+}, []);
+```
+
+This requires `useSearchParams()` to be called in the component. Add:
+
+```ts
+const searchParamsObj = useSearchParams();
+```
+
+at the top of the component (alongside existing hooks).
+
+### 2.6 Pass `sourcePostId` to `RelatedStacks` (for `?from=`)
+
+The focus post's ID is `id` (from `params`). We need to thread this through to `RelatedStacks` when rendering the aside. The aside is rendered via the parallel route (`@aside/page.tsx`) which receives stacks from context — it doesn't receive a `sourcePostId` prop directly.
+
+**Approach:** Update `handleNavigate` in `RelatedStacks.tsx` to accept `sourcePostId` via a new optional prop on `RelatedStacks`.
+
+In `page.tsx`, find where `RelatedStacks` is called (only in the inline `showFocusRelatedStacks` section — actually RelatedStacks is only called in `@aside/page.tsx`, not directly in `page.tsx`). We need to thread `sourcePostId` through the context OR add it to `RelatedStacksProvider`.
+
+**Simpler approach:** Pass `sourcePostId` as a prop to `RelatedStacks` in `@aside/page.tsx`. The aside page reads `id` from URL params via `useParams()`.
+
+Update `@aside/page.tsx` to:
+```ts
+"use client";
+import { useParams } from "next/navigation";
+import RelatedStacks from "../../../../../components/RelatedStacks";
+import { useRelatedStacks } from "../../../related-stacks-context";
+
+export default function PostAside() {
+  const { relatedStacks, showUpdate } = useRelatedStacks();
+  const params = useParams();
+  const focusPostId = typeof params.id === "string" ? params.id : undefined;
+  if (!relatedStacks || relatedStacks.length === 0) return null;
+  return (
+    <div style={{ width: "100%" }}>
+      <RelatedStacks
+        relatedStacks={relatedStacks}
+        cardWidth={"100%"}
+        onStackClick={() => {}}
+        showupdate={showUpdate}
+        sourcePostId={focusPostId}
+      />
+    </div>
+  );
+}
+```
+
+**Verification:** `pnpm build` — no errors.
+
+---
+
+## Step 3 — Update `RelatedStacks.tsx`: add `sourcePostId` prop + `?from=` in navigation
+
+**File:** `src/components/RelatedStacks.tsx`
+
+### 3.1 Add `sourcePostId` to props interface
+
+In `RelatedStacksProps`:
+```ts
+/** When set, appends ?from={sourcePostId} to related-post navigation URLs (H5) */
+sourcePostId?: string;
+```
+
+### 3.2 Destructure in component
+
+```ts
+const RelatedStacks: React.FC<RelatedStacksProps> = ({
+  relatedStacks, cardWidth = "100%", onStackClick, showupdate,
+  onOpenModalWithStackId, onPostNavigate, sourcePostId
+}) => {
+```
+
+### 3.3 Update `handleNavigate`
+
+Current:
+```ts
+const handleNavigate = (postId: string, newStackId: string) => {
+  if (onPostNavigate) { onPostNavigate(postId); return; }
+  const url = `/posts/${postId}?stackId=${newStackId || ''}`;
+  sessionStorage.setItem(`previousPath:/posts/${postId}`, window.location.pathname);
+  sessionStorage.setItem(`scrollY:${window.location.pathname}`, String(window.scrollY));
+  router.push(url);
+};
+```
+
+Updated:
+```ts
+const handleNavigate = (postId: string, newStackId: string) => {
+  if (onPostNavigate) { onPostNavigate(postId); return; }
+  const params = new URLSearchParams();
+  if (newStackId) params.set("stackId", newStackId);
+  if (sourcePostId) params.set("from", sourcePostId);
+  const search = params.toString();
+  const url = `/posts/${postId}${search ? "?" + search : ""}`;
+  sessionStorage.setItem(`previousPath:/posts/${postId}`, window.location.pathname);
+  sessionStorage.setItem(`scrollY:${window.location.pathname}`, String(window.scrollY));
+  router.push(url);
+};
+```
+
+**Verification:** `pnpm build` — no errors.
+
+---
+
+## Step 4 — Final build verification
+
+Run `pnpm build` from the worktree root. Confirm:
+- Zero TypeScript errors.
+- Zero Next.js build errors.
+- No unexpected bundle size increases.
+
+---
+
+## Step 5 — Write spec and plan, commit all
+
+Commit sequence:
+
+1. `Add Group H URL state design spec and implementation plan`
+2. `Add useUrlSync hook for URL-state sync on post-detail route`
+3. `Integrate useUrlSync and from-param seeding in posts/[id]/page`
+4. `Pass sourcePostId to RelatedStacks for from-param navigation`

--- a/docs/superpowers/specs/2026-05-13-group-h-url-state-design.md
+++ b/docs/superpowers/specs/2026-05-13-group-h-url-state-design.md
@@ -1,0 +1,221 @@
+# Group H — URL / Browser Navigation & Share/Bookmark Persistence (Design Spec)
+
+**Date:** 2026-05-13
+**Status:** Ready for implementation
+**Scope:** URL state for current screen, browser back restoration, per-view canonical routes, share/bookmark filter + highlight preservation.
+**Owner:** tarcode2004
+**Approach:** Add a lightweight `urlState` utility module. Sync `filterCategories`, `filterFocusSpan`, and `activeTab` into URL search params on the `/posts/[id]` route. Let Next.js App Router history handle back naturally.
+
+---
+
+## 1. Problem
+
+Five related navigation/persistence gaps:
+
+1. **Refreshing `/posts/[id]` loses filter state.** Category filter chips (`?fc=`) and span filter (`?fs=`) live only in the module-level `highlightStore`; they vanish on refresh.
+2. **Active tab (`time|recommended|stacked|summary`) is not in the URL.** Two users sharing the same post URL land on "time" regardless of what the sender was looking at.
+3. **Browser Back partially works** (Next.js handles the route change) but the aside panel state (which post's stacks are shown) is context-only and doesn't survive re-mount after back navigation when the context is re-initialized.
+4. **Share/bookmark on a filtered related panel** does not preserve list order because filter state is absent from the shareable URL.
+5. **Share/bookmark on a related post** only navigates to `/posts/{relatedId}` — losing the focus+aside pairing and highlight state.
+
+## 2. Goals
+
+- **H1.** `?tab=`, `?fc=`, `?fs=` params on `/posts/[id]` — hydrated on mount, written on change.
+- **H2.** Browser Back restores the full view (route + params) naturally via App Router history. No custom stack needed; we verify and fix the context re-hydration gap.
+- **H3.** Each post has `/posts/[id]` as its canonical URL. Each main view has its own segment already. Verify nothing new needed, document the finding.
+- **H4.** Share = current URL with all params. Since we encode filter state, copying the URL inherently shares a filtered, ordered view.
+- **H5.** Related-post navigation preserves focus+related pair: `/posts/{relatedId}?from={focusId}`. Opening this URL renders the focus context in the aside (or a back-link) without re-engineering the entire aside.
+
+## 3. Non-Goals
+
+- Encoding `reRankAnchorIds` or `shownByAnchor` in the URL (ephemeral UX state, not shareable).
+- Encoding `hoveredPostId`, `tappedCardPostId` (transient interaction state).
+- Custom history stack or scroll restoration beyond what sessionStorage already provides.
+- Changing the aside parallel-route architecture (remains context-driven; URL only seeds context).
+- Any change to `HoverTooltip.tsx`, `ThreadedReplyList.tsx`, `ReplySection.tsx`, or the focus-post dwell logic in `Post.tsx`.
+
+## 4. URL Schema
+
+### 4.1 Parameter names and formats
+
+| Param | Meaning | Format | Example |
+|---|---|---|---|
+| `tab` | Active reply tab on `/posts/[id]` | `time` \| `recommended` \| `stacked` \| `summary` | `?tab=recommended` |
+| `fc` | Filter categories (filterCategories) | CSV of category keys | `?fc=evidence_public,agree` |
+| `fs` | Filter focus span (filterFocusSpan) | `{start}-{end}` integers; text omitted (recomputed from post content) | `?fs=42-97` |
+| `from` | Focus post ID when navigating to a related post | Post ID string | `?from=109876543` |
+
+### 4.2 Judgment call: why CSV for `fc`
+
+Alternatives considered:
+- **Repeated params** (`?fc=evidence_public&fc=agree`): verbose, slightly harder to read/write in Next.js `searchParams`.
+- **JSON-encoded** (`?fc=["evidence_public","agree"]`): URL-escaping makes it ugly.
+- **CSV** (`?fc=evidence_public,agree`): concise, human-readable, no encoding needed (category keys are alphanumeric + underscore). Max realistic length: ~150 chars for all 13 categories combined. Chosen.
+
+### 4.3 Judgment call: `fs` text omission
+
+`filterFocusSpan` carries `{ start, end, text }`. The `text` field is a substring of the focus post's content. We do **not** serialize `text` into the URL because:
+- The content is already available from the Mastodon API fetch that happens on mount.
+- Including text would balloon URL length (up to 100+ chars for long spans).
+- On hydration, we reconstruct `text` from the fetched post content and the `start`/`end` offsets.
+
+This means the URL `?fs=42-97` reconstructs correctly as long as the post content doesn't change — acceptable for a social post.
+
+### 4.4 Judgment call: aside panel `?aside=` param NOT included
+
+The aside shows related stacks for the active post. On `/posts/[id]`, the aside always starts showing the focus post's stacks (loaded via `setFromPost` in `fetchFocusRelatedStacks`). There is no user-driven "which aside is open" state to persist on that route — the focus post's stacks are always shown by default.
+
+On the home feed, the aside IS driven by user click (via `RelatedStacksContext`). Encoding that in the URL would require making the home feed URL state-aware, which touches `PostList.tsx` and `Shell.tsx` — too invasive for this group. The aside on home is a transient overlay, not a persistent view.
+
+**Decision:** No `?aside=` param. The aside on `/posts/[id]` self-initializes from the post ID in the path. The aside on home is ephemeral (intentional — it clears on navigation and back).
+
+### 4.5 Judgment call: `?from=` for H5
+
+When a user clicks a related post card in `RelatedStacks.tsx`, they navigate to `/posts/{relatedId}`. The "focus+related pair with highlights" requirement (H5) asks that this navigation be shareable. We encode the source post as `?from={focusId}`.
+
+On the target `/posts/{relatedId}` page, `?from=` is used to:
+1. Show a "Back to post {focusId}" link (the existing BackButton already does this via `previousPath` in sessionStorage; `?from=` provides a URL-based fallback that works on refresh).
+2. That's all. We do NOT recreate the full aside filter state on the related page (H5 says "save the focus + related pair, with highlights" — this refers to the URL being shareable, not to re-mounting the full filter UI in the aside of the related post). The highlights on the related post card are properties of the related post itself, not URL state.
+
+**Simpler than it sounds:** `?from=` is effectively a back-link hint. The highlights the user saw are the `relations` data on the related post — always present in the API response.
+
+## 5. State ↔ URL Sync Strategy
+
+### 5.1 Architecture: single sync component per route
+
+The `/posts/[id]/page.tsx` component is a client component that already owns `activeTab` state. We add a `useUrlSync` hook (new utility: `src/utils/useUrlSync.ts`) that:
+
+1. **On mount (hydrate):** reads `?tab`, `?fc`, `?fs` from `useSearchParams()` and initializes local/store state.
+2. **On change (write):** `router.replace(pathname + '?' + newParams)` with a **debounce of 300ms** for rapid-fire filter toggles.
+
+### 5.2 Why `router.replace`, not `router.push`
+
+- `router.push` adds a history entry every time a filter chip is clicked — Back would require many clicks to escape the post page.
+- `router.replace` updates the current history entry in place — the URL reflects current state without polluting history.
+- The post-to-post navigation (clicking a related post card) continues to use `router.push` so Back returns to the correct post.
+
+### 5.3 Why debounce
+
+Rapid filter toggling (click A, click B, click A) would fire 3 `router.replace` calls in quick succession. With a 300ms debounce, only the final state is written. This prevents jank and avoids React 18's concurrent mode surprises with multiple in-flight router updates.
+
+### 5.4 filterFocusSpan text reconstruction
+
+On hydration, if `?fs=42-97` is present, we:
+1. Wait for the post content to load (`post` state non-null).
+2. Strip HTML from `post.content` to get plain text.
+3. Extract `plainText.slice(42, 97)` as the `text` field.
+4. Call `setFilterFocusSpan({ start: 42, end: 97, text })`.
+
+This happens in a `useEffect` that depends on `post` and the parsed `?fs` param.
+
+### 5.5 Back button and context re-hydration
+
+When the user navigates from `/posts/A` → `/posts/B` → Back:
+
+- Next.js App Router restores `/posts/A` with its **previous URL** (including `?tab=`, `?fc=`, `?fs=`).
+- The `useUrlSync` hydration effect runs again (because `params.id` changed from B to A).
+- `highlightStore` is module-level state (not React state) — it persists across navigation in the SPA. When navigating A → B, `resetHighlightStore()` is NOT called automatically; `fetchFocusRelatedStacks` does call `setFromPost` which replaces the aside stacks, and the `useEffect` on `relatedStacks` in `RelatedStacks.tsx` calls `clearFilterFocusSpan()` + `clearReRankAnchors()`. So after back-navigation to A, the URL params re-hydrate the store correctly.
+- **Potential issue:** `highlightStore` is module-level (survives SPA navigation). If the user navigated A→B→Back, when A re-mounts the URL says `?fc=evidence_public` but the store might already have a different `filterCategories` from B. The hydration effect in `useUrlSync` runs on mount and explicitly re-sets the store to match the URL, overriding whatever was in the store. This is correct behavior.
+
+### 5.6 `?from=` hydration
+
+On `/posts/[id]` mount, if `?from=` is present:
+- Read the value.
+- Prefer sessionStorage `previousPath:/posts/{id}` if it exists (set by `handleNavigate` in `RelatedStacks.tsx`).
+- If sessionStorage doesn't have it (user opened a shared link), set the sessionStorage key so BackButton renders correctly.
+
+No change to `BackButton.tsx` itself — it already reads from sessionStorage.
+
+## 6. Files Touched
+
+| File | Action |
+|---|---|
+| `src/utils/useUrlSync.ts` | NEW — encapsulates URL ↔ state sync logic for the post-detail page |
+| `src/app/(shell)/posts/[id]/page.tsx` | Import and call `useUrlSync`; pass `activeTab` + setter; write `?from=` on related-post navigation |
+| `src/components/RelatedStacks.tsx` | Update `handleNavigate` to append `?from={sourcePostId}` when a `sourcePostId` prop is available |
+| `src/app/(shell)/posts/[id]/@aside/page.tsx` | No change needed |
+| `src/app/(shell)/related-stacks-context.tsx` | No change needed |
+| `src/utils/highlightStore.ts` | No change needed (already has all the actions) |
+
+No changes to HoverTooltip.tsx, ThreadedReplyList.tsx, ReplySection.tsx, or Shell.tsx.
+
+## 7. `useUrlSync` API
+
+```ts
+// src/utils/useUrlSync.ts
+export interface UrlSyncOptions {
+  /** Current active tab value */
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+  /** Post content as plain text — needed to reconstruct filterFocusSpan text */
+  plainPostText: string | null;
+  /** Called after hydration completes so the page can trigger tab-specific data fetches */
+  onHydratedTab?: (tab: string) => void;
+}
+
+export function useUrlSync(opts: UrlSyncOptions): void;
+```
+
+Internals:
+- `useSearchParams()` — read-only, reactive.
+- `useRouter()` from `next/navigation` — for `router.replace`.
+- `usePathname()` — for building replacement URLs.
+- Debounce ref for write batching.
+- Mount effect for hydration (runs once per `id` change via `params.id` in the parent).
+
+## 8. `handleNavigate` update in RelatedStacks.tsx
+
+The current `handleNavigate` in `RelatedStacks.tsx`:
+```ts
+const url = `/posts/${postId}?stackId=${newStackId || ''}`;
+```
+
+Updated to also append `?from=` when we can determine the source post. `RelatedStacks.tsx` receives an optional `sourcePostId?: string` prop (added alongside existing props). When set, it appends `&from={sourcePostId}` to the navigation URL.
+
+The prop is populated from `/posts/[id]/page.tsx` which knows `id` (the current focus post).
+
+`stackId` param is already there (pre-existing); we keep it.
+
+## 9. Verification Plan
+
+| Scenario | Expected |
+|---|---|
+| Navigate to `/posts/ABC`, click filter chip "evidence_public" | URL updates to `?fc=evidence_public` within 300ms |
+| Refresh at `?fc=evidence_public` | Page loads with evidence_public filter chip active |
+| Click span on focus post (D2) | URL updates to `?fs=42-97` |
+| Refresh at `?fs=42-97` | Span filter re-applied; span indicator shown in aside |
+| Click tab "recommended" | URL updates to `?tab=recommended` |
+| Refresh at `?tab=recommended` | Recommended tab is active; data loaded |
+| Navigate A → B via related post card | URL at B includes `?from=A` |
+| Refresh at B with `?from=A` | Back button shows "Back" (sessionStorage seeded from `?from=`) |
+| Navigate A → B → Back | Lands on A with its previous `?fc=`, `?fs=`, `?tab=` intact |
+| Copy URL with `?fc=agree&tab=recommended`, open in new tab | Filter + tab both restored |
+| `pnpm build` | Zero TypeScript errors |
+
+## 10. Risks and Edge Cases
+
+| Risk | Mitigation |
+|---|---|
+| Very long `?fc=` with all 13 categories (~150 chars) | Acceptable; URL length well under 2048 limit |
+| `?fs=` offsets out of range (post content changed) | Guard: if `start >= plainText.length`, silently skip span hydration |
+| Rapid filter toggling causes router.replace storm | 300ms debounce collapses to one write |
+| `useSearchParams` on server component | `useUrlSync` is client-only (`"use client"`); `/posts/[id]/page.tsx` is already a client component |
+| Back navigation restores stale `?fc=` from store | Hydration effect always wins: re-applies URL state to store on mount |
+| `?from=` present but `previousPath` already set in sessionStorage | We only write sessionStorage if the key is absent — avoids clobbering actual navigation history |
+
+## 11. Judgment Calls
+
+| # | Ambiguity | Choice | Rationale |
+|---|---|---|---|
+| JC1 | `router.replace` vs `router.push` for param writes | `router.replace` | Avoids polluting history with every filter toggle click |
+| JC2 | Debounce duration | 300ms | Short enough to feel responsive; long enough to batch rapid toggles |
+| JC3 | Encode `filterFocusSpan.text` in URL? | No — recompute from offsets + fetched content | Keeps URLs clean; text is always derivable |
+| JC4 | Aside panel state in URL? | No `?aside=` param | On post-detail, aside is always the focus post's stacks. On home, aside is ephemeral |
+| JC5 | Encode `reRankAnchorIds` in URL? | No | Anchor state is ephemeral per-session UX; not appropriate to persist |
+| JC6 | H5 "with highlights" meaning | `?from=` back-link only | The highlight data is in the related post's `relations` field — always fetched. URL doesn't need to encode which ranges are lit |
+| JC7 | Where does `useUrlSync` live? | `src/utils/useUrlSync.ts` | Keeps page.tsx clean; follows project pattern of utilities in `src/utils/` |
+| JC8 | `stackId` param already on related-post navigation | Keep it | Pre-existing; no reason to remove |
+
+## 12. Next Step
+
+Hand off to implementation plan.

--- a/src/app/(shell)/posts/[id]/@aside/page.tsx
+++ b/src/app/(shell)/posts/[id]/@aside/page.tsx
@@ -1,13 +1,23 @@
 "use client";
+import { useParams } from "next/navigation";
 import RelatedStacks from "../../../../../components/RelatedStacks";
 import { useRelatedStacks } from "../../../related-stacks-context";
 
 export default function PostAside() {
     const { relatedStacks, showUpdate } = useRelatedStacks();
+    const params = useParams();
+    // H5: pass focus post ID so RelatedStacks can append ?from= on related-post navigation
+    const focusPostId = typeof params?.id === "string" ? params.id : undefined;
     if (!relatedStacks || relatedStacks.length === 0) return null;
     return (
         <div style={{ width: "100%" }}>
-            <RelatedStacks relatedStacks={relatedStacks} cardWidth={"100%"} onStackClick={() => {}} showupdate={showUpdate} />
+            <RelatedStacks
+                relatedStacks={relatedStacks}
+                cardWidth={"100%"}
+                onStackClick={() => {}}
+                showupdate={showUpdate}
+                sourcePostId={focusPostId}
+            />
         </div>
     );
 }

--- a/src/app/(shell)/posts/[id]/page.tsx
+++ b/src/app/(shell)/posts/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import axios from "axios";
 import { Button, Divider, Loader, Paper, Tabs, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
@@ -11,6 +11,7 @@ import ReplySection from "../../../../components/ReplySection";
 import BackButton from "../../../../components/BackButton";
 import ThreadedReplyList from "../../../../components/ThreadedReplyList";
 import { useRelatedStacks } from "../../related-stacks-context";
+import { useUrlSync } from "../../../../utils/useUrlSync";
 
 // -------------------- Types --------------------
 interface Account {
@@ -54,9 +55,20 @@ const mapWithStackFields = <T extends object>(x: T) => ({
 const THREAD_LINE_COLOR = "#ccd1dc";
 const THREAD_LINE_LEFT = 32; // aligns with avatar center (~16px padding + ~19px half-avatar)
 
+/** Strip HTML tags to produce plain text for span-filter hydration */
+function stripHtmlToPlain(html: string): string {
+  if (typeof document !== "undefined") {
+    const el = document.createElement("div");
+    el.innerHTML = html;
+    return el.textContent ?? el.innerText ?? "";
+  }
+  return html.replace(/<[^>]*>/g, "");
+}
+
 // -------------------- Component --------------------
 export default function PostView({ params }: { params: { id: string } }) {
   const router = useRouter();
+  const searchParamsObj = useSearchParams();
   const { id } = params;
   const { setFromPost, activePostId: asideActivePostId, relatedStacks: asideStacks } = useRelatedStacks();
 
@@ -71,6 +83,10 @@ export default function PostView({ params }: { params: { id: string } }) {
   // UI state
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<string>("time");
+
+  // H1: plain-text content of focus post — needed for ?fs= span hydration
+  const plainPostText = post ? stripHtmlToPlain(post.content) : null;
+
   /** Number of top-level reply branches visible in the Time tab. */
   const [visibleTopLevelReplies, setVisibleTopLevelReplies] = useState(5);
   const [recommendedLoading, setRecommendedLoading] = useState(false);
@@ -304,6 +320,33 @@ export default function PostView({ params }: { params: { id: string } }) {
       console.error("Failed to fetch summary:", e);
     }
   }, [id, replyIDs]);
+
+  // -------------------- URL sync (H1/H2/H4/H5) --------------------
+  useUrlSync({
+    activeTab,
+    setActiveTab,
+    plainPostText,
+    onHydratedTab: async (tab) => {
+      const actions: Record<string, (() => Promise<void>) | undefined> = {
+        recommended: fetchRecommended,
+        stacked: fetchRepliesStack,
+        summary: fetchSummary,
+      };
+      const fn = actions[tab];
+      if (fn) await fn();
+    },
+  });
+
+  // H5: seed BackButton sessionStorage from ?from= when opening a shared link
+  useEffect(() => {
+    const fromId = searchParamsObj?.get("from");
+    if (!fromId) return;
+    const key = `previousPath:${window.location.pathname}`;
+    if (!sessionStorage.getItem(key)) {
+      sessionStorage.setItem(key, `/posts/${fromId}`);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // -------------------- Effects --------------------
   useEffect(() => {

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -49,6 +49,8 @@ interface RelatedStacksProps {
   onOpenModalWithStackId?: (stackId: string) => void;
   /** When provided, intercepts post navigation instead of routing to /posts/{id} */
   onPostNavigate?: (postId: string) => void;
+  /** H5: when set, appends ?from={sourcePostId} to related-post navigation URLs */
+  sourcePostId?: string;
 }
 
 // ─── Category colors ─────────────────────────────────────────────────────────
@@ -587,7 +589,7 @@ function similarityScore(textA: string, textB: string): number {
 
 // ─── Main component ──────────────────────────────────────────────────────────
 
-const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth = "100%", onStackClick, showupdate, onOpenModalWithStackId, onPostNavigate }) => {
+const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth = "100%", onStackClick, showupdate, onOpenModalWithStackId, onPostNavigate, sourcePostId }) => {
   const router = useRouter();
   const paperRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [stackPostsModalOpen, setStackPostsModalOpen] = useState(false);
@@ -858,7 +860,12 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
 
   const handleNavigate = (postId: string, newStackId: string) => {
     if (onPostNavigate) { onPostNavigate(postId); return; }
-    const url = `/posts/${postId}?stackId=${newStackId || ''}`;
+    // H5: build params — preserve stackId, add ?from= when navigating from a known focus post
+    const navParams = new URLSearchParams();
+    if (newStackId) navParams.set("stackId", newStackId);
+    if (sourcePostId) navParams.set("from", sourcePostId);
+    const search = navParams.toString();
+    const url = `/posts/${postId}${search ? "?" + search : ""}`;
     sessionStorage.setItem(`previousPath:/posts/${postId}`, window.location.pathname);
     sessionStorage.setItem(`scrollY:${window.location.pathname}`, String(window.scrollY));
     router.push(url);

--- a/src/utils/useUrlSync.ts
+++ b/src/utils/useUrlSync.ts
@@ -1,0 +1,186 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import {
+  setFilterCategories,
+  setFilterFocusSpan,
+  useHighlightStore,
+} from "./highlightStore";
+
+export interface UrlSyncOptions {
+  /** Current active tab value */
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+  /**
+   * Plain-text content of the focus post — needed to reconstruct the `text`
+   * field of filterFocusSpan from the ?fs= offset param on hydration.
+   * Pass null until the post content is loaded.
+   */
+  plainPostText: string | null;
+  /**
+   * Called once on initial mount when the URL contains a ?tab= param.
+   * Use this to trigger the tab's data fetch (e.g., fetchRecommended).
+   */
+  onHydratedTab?: (tab: string) => void;
+}
+
+const VALID_TABS = ["time", "recommended", "stacked", "summary"] as const;
+type ValidTab = (typeof VALID_TABS)[number];
+
+function isValidTab(v: string): v is ValidTab {
+  return VALID_TABS.includes(v as ValidTab);
+}
+
+/**
+ * Synchronizes URL search params with local/store state for the post-detail route.
+ *
+ * Read direction (hydration):
+ *   ?tab    → setActiveTab()
+ *   ?fc     → setFilterCategories()
+ *   ?fs     → setFilterFocusSpan() (deferred until plainPostText is available)
+ *
+ * Write direction (debounced):
+ *   activeTab + filterCategories + filterFocusSpan → router.replace(pathname + ?params)
+ *
+ * ?stackId and ?from are preserved (pass-through) and not modified here.
+ */
+export function useUrlSync({
+  activeTab,
+  setActiveTab,
+  plainPostText,
+  onHydratedTab,
+}: UrlSyncOptions): void {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const { filterCategories, filterFocusSpan } = useHighlightStore();
+
+  // Tracks whether we have completed the initial hydration for the current pathname.
+  // Reset when the pathname changes (i.e., user navigated to a different post).
+  const hydratedRef = useRef(false);
+  // Tracks whether we triggered onHydratedTab for the current mount.
+  const hydratedTabCalledRef = useRef(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset hydration gate when the route changes.
+  useEffect(() => {
+    hydratedRef.current = false;
+    hydratedTabCalledRef.current = false;
+  }, [pathname]);
+
+  // ── HYDRATION: tab + filter categories ───────────────────────────────────
+  // Runs once per pathname (i.e., once per post ID). Reads URL params and
+  // initializes local state + highlightStore.
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    hydratedRef.current = true;
+
+    // tab
+    const tabParam = searchParams.get("tab");
+    if (tabParam && isValidTab(tabParam)) {
+      setActiveTab(tabParam);
+      if (!hydratedTabCalledRef.current) {
+        hydratedTabCalledRef.current = true;
+        onHydratedTab?.(tabParam);
+      }
+    }
+
+    // fc (filter categories — CSV)
+    const fcParam = searchParams.get("fc");
+    if (fcParam) {
+      const cats = new Set(fcParam.split(",").map((c) => c.trim()).filter(Boolean));
+      if (cats.size > 0) {
+        setFilterCategories(cats);
+      }
+    } else {
+      // Navigating to a URL with no ?fc — clear any stale store state
+      setFilterCategories(new Set());
+    }
+
+    // fs (filter focus span) — text reconstruction deferred to the effect below
+  }, [pathname, searchParams]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── SPAN HYDRATION: deferred until post content loads ────────────────────
+  // ?fs=start-end can only be applied once we have the post's plain text to
+  // reconstruct the `text` field of filterFocusSpan.
+  const fsHydratedRef = useRef(false);
+
+  useEffect(() => {
+    // Reset when pathname changes
+    fsHydratedRef.current = false;
+  }, [pathname]);
+
+  useEffect(() => {
+    if (fsHydratedRef.current) return;
+    if (!plainPostText) return; // wait for post to load
+
+    const fsParam = searchParams.get("fs");
+    if (!fsParam) {
+      fsHydratedRef.current = true;
+      return;
+    }
+
+    const parts = fsParam.split("-").map(Number);
+    if (parts.length !== 2 || parts.some((n) => isNaN(n))) {
+      fsHydratedRef.current = true;
+      return;
+    }
+
+    const [start, end] = parts;
+    if (start < 0 || end <= start || start >= plainPostText.length) {
+      // Offsets out of range — silently skip; post content may have changed
+      fsHydratedRef.current = true;
+      return;
+    }
+
+    const safeEnd = Math.min(end, plainPostText.length);
+    const text = plainPostText.slice(start, safeEnd);
+    setFilterFocusSpan({ start, end: safeEnd, text });
+    fsHydratedRef.current = true;
+  }, [plainPostText, pathname, searchParams]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── WRITE: debounced URL update when UI state changes ────────────────────
+  // Uses router.replace (not push) so filter toggles don't pollute history.
+  // Preserves ?stackId and ?from (set by other parts of the app).
+  useEffect(() => {
+    // Don't write until we've finished hydrating — would immediately overwrite the
+    // URL params we just read.
+    if (!hydratedRef.current) return;
+
+    const params = new URLSearchParams();
+
+    // Only encode non-default tab (default is "time")
+    if (activeTab && activeTab !== "time") {
+      params.set("tab", activeTab);
+    }
+
+    if (filterCategories.size > 0) {
+      params.set("fc", Array.from(filterCategories).sort().join(","));
+    }
+
+    if (filterFocusSpan !== null) {
+      params.set("fs", `${filterFocusSpan.start}-${filterFocusSpan.end}`);
+    }
+
+    // Pass through params managed by other parts of the app
+    const stackId = searchParams.get("stackId");
+    if (stackId) params.set("stackId", stackId);
+    const from = searchParams.get("from");
+    if (from) params.set("from", from);
+
+    const newSearch = params.toString();
+    const currentSearch = searchParams.toString();
+    if (newSearch === currentSearch) return; // already up to date
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const newUrl = pathname + (newSearch ? "?" + newSearch : "");
+      router.replace(newUrl);
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [activeTab, filterCategories, filterFocusSpan, pathname]);  // eslint-disable-line react-hooks/exhaustive-deps
+}


### PR DESCRIPTION
## Summary

- **H1 — URL state for current screen:** `?tab=`, `?fc=` (filter categories, CSV), `?fs=` (filter focus span, `start-end` offsets) are encoded in the URL on `/posts/[id]`. Refreshing or sharing the URL fully restores tab, category filters, and span filter.
- **H2 — Browser back restores view:** `router.replace` keeps each filter-toggle in the same history entry; navigating between posts uses `router.push`; the `useUrlSync` hydration effect re-applies URL params to the store on every remount, so Back lands back on the correct state.
- **H3 — Posts and views have canonical URLs:** Verified — no changes needed. `/posts/[id]` and each view segment already provide canonical routes.
- **H4 — Share/bookmark preserves filter order:** The current URL *is* the shareable artifact. With filter state in `?fc=` and `?fs=`, copying the URL encodes the full filtered view.
- **H5 — Share a related post with focus context:** `handleNavigate` in `RelatedStacks.tsx` now appends `?from={focusPostId}` when navigating to a related post. On the target page, `?from=` is seeded into `sessionStorage` so `BackButton` renders a "Back" link even on a fresh load from a shared URL.

## Files changed

| File | Change |
|---|---|
| `src/utils/useUrlSync.ts` | **New** — hook encapsulating URL ↔ store sync (hydration + debounced write) |
| `src/app/(shell)/posts/[id]/page.tsx` | Adds `useSearchParams`, `useUrlSync` call, `stripHtmlToPlain` helper, `?from=` sessionStorage seeding |
| `src/app/(shell)/posts/[id]/@aside/page.tsx` | Adds `useParams` to get `focusPostId`, passes `sourcePostId` to `RelatedStacks` |
| `src/components/RelatedStacks.tsx` | Adds `sourcePostId` prop, updates `handleNavigate` to append `?from=` |
| `docs/superpowers/specs/2026-05-13-group-h-url-state-design.md` | Design spec |
| `docs/superpowers/plans/2026-05-13-group-h-url-state.md` | Implementation plan |

## Judgment calls

| # | Decision |
|---|---|
| JC1 | `router.replace` (not push) for filter-toggle writes — avoids polluting history |
| JC2 | 300ms debounce on URL writes — batches rapid chip clicks |
| JC3 | `?fs=` stores offsets only, not text — text recomputed from post content on hydration |
| JC4 | No `?aside=` param — aside on `/posts/[id]` is always the focus post's stacks (self-initializing); aside on home is ephemeral by design |
| JC5 | No `reRankAnchorIds` or `shownByAnchor` in URL — ephemeral per-session UX, not shareable |
| JC6 | H5 "with highlights" = `?from=` back-link only — highlight data is always in the related post's `relations` API field, no URL encoding needed |
| JC7 | `"time"` tab is the default and is omitted from the URL (clean URLs); all other tabs are written explicitly |
| JC8 | `?from=` writes to `sessionStorage` only if the key is absent — avoids clobbering real navigation history |

## Manual test plan

- [ ] Navigate to `/posts/{id}` and click a filter chip — URL updates to `?fc={cat}` within 300ms
- [ ] Refresh with `?fc=agree` in URL — "Agree" filter chip is active on load
- [ ] Click a span on the focus post (D2 filter) — URL updates to `?fs={start}-{end}`
- [ ] Refresh with `?fs=10-50` in URL — span filter active, indicator shown in aside
- [ ] Click "Recommended" tab — URL updates to `?tab=recommended`
- [ ] Refresh with `?tab=recommended` — tab is active, recommended data loaded
- [ ] Click a related post card — URL of target page includes `?from={focusId}`
- [ ] Refresh on target page with `?from={focusId}` — Back button shows "Back"
- [ ] Navigate A → B via related card, click Back — lands on A with previous `?fc=`/`?fs=`/`?tab=` intact
- [ ] Rapid-fire 5 filter chip clicks — only one `router.replace` fires (debounce)
- [ ] `pnpm build` — zero TypeScript errors ✓

## Notes

- Build verified clean: `pnpm build` passes with zero TypeScript errors.
- Browser preview verified: page loads at `/posts/{id}?tab=recommended&fc=agree,evidence_public&fs=10-50` with no React errors, no error overlays, no console errors.
- The app requires authentication (OAuth tokens in localStorage) for full end-to-end testing; functional data flows were verified at code level.

Closes #H