### PR TITLE
Add per-card relation indicator top-right (Group F)

### DIFF
--- a/docs/superpowers/plans/2026-05-13-group-f-relation-indicator.md
+++ b/docs/superpowers/plans/2026-05-13-group-f-relation-indicator.md
@@ -1,0 +1,159 @@
+# Group F — Per-Card Relation Indicator (Implementation Plan)
+
+**Date:** 2026-05-13
+**Branch:** `tarcode2004/enhancement/group-f-relation-indicator`
+**Base:** `tarcode2004/enhancement/group-e-reordering`
+**Spec:** `docs/superpowers/specs/2026-05-13-group-f-relation-indicator-design.md`
+
+---
+
+## File Modified
+
+`src/components/RelatedStacks.tsx` — card rendering region only (lines ~1411–1663).
+
+---
+
+## Step-by-Step Plan
+
+### Step 1 — Write spec and plan docs ✓
+Files: `docs/superpowers/specs/2026-05-13-group-f-relation-indicator-design.md`, this file.
+Commit: `Add Group F design spec and implementation plan`
+
+---
+
+### Step 2 — Remove the existing top-right navigation chevron
+
+**Location:** lines 1569–1571 in `RelatedStacks.tsx`:
+```tsx
+<div style={{ position: 'absolute', top: '12px', right: '10px', zIndex: 10 }}>
+  <IconChevronRight size={14} color="#94a3b8" />
+</div>
+```
+
+**Action:** Delete this block.
+
+**Rationale:** Per JC #1 — the card has explicit cursor/border affordance; the chevron is redundant and occupies the same corner as the new relation indicator.
+
+**Commit:** `Remove nav-chevron from related card top-right (Group F)`
+
+---
+
+### Step 3 — Add the relation indicator element
+
+**Location:** Inside the `<Paper>` element, after the existing category-tags block (after the closing `</div>` of the tags block at line ~1567) and before `<UnstyledButton>` at line 1573. Specifically, place it as a sibling to the tags div, also `position: absolute`.
+
+**What to insert:**
+
+```tsx
+{/* F: Relation indicator — top-right, dominant topic + cluster count */}
+{(() => {
+  const rels = stack.topPost.relations ?? [];
+  if (rels.length === 0) return null;
+  const dominantRel = rels[0];
+  const dominantTopic = dominantRel.topic;
+  if (!dominantTopic) return null;
+  const isMultiType = new Set(rels.map(r => r.category)).size > 1;
+  const dominantColors = getCategoryColors(dominantRel.category);
+  const showColor = !isMultiType || panelHovered;
+  const indicatorColor = showColor ? dominantColors.text : '#888888';
+  const clusterCount = topicTotal.get(dominantTopic) ?? 0;
+  const isCurrentAnchor =
+    reRankAnchorIds.length > 0 &&
+    reRankAnchorIds[reRankAnchorIds.length - 1] === stack.topPost.id;
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        handleToggleAnchor(stack.topPost.id, 0);
+      }}
+      aria-label={`Show more posts about ${dominantTopic}`}
+      aria-pressed={isCurrentAnchor}
+      style={{
+        position: 'absolute',
+        top: '10px',
+        right: '10px',
+        zIndex: 10,
+        background: isCurrentAnchor ? dominantColors.bg : 'transparent',
+        border: isCurrentAnchor ? `1px solid ${dominantColors.border}55` : 'none',
+        borderRadius: '4px',
+        padding: isCurrentAnchor ? '1px 5px' : '1px 4px',
+        cursor: 'pointer',
+        color: indicatorColor,
+        fontSize: '11px',
+        fontWeight: 600,
+        lineHeight: 1.3,
+        maxWidth: '160px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        opacity: showColor ? (isCurrentAnchor ? 1 : 0.75) : 0.6,
+        transition: 'opacity 200ms ease, background 200ms ease, color 200ms ease',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '2px',
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLElement).style.opacity = '1';
+      }}
+      onMouseLeave={(e) => {
+        const el = e.currentTarget as HTMLElement;
+        const currentAnchor =
+          reRankAnchorIds.length > 0 &&
+          reRankAnchorIds[reRankAnchorIds.length - 1] === stack.topPost.id;
+        el.style.opacity = currentAnchor ? '1' : (showColor ? '0.75' : '0.6');
+      }}
+    >
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '130px' }}>
+        {dominantTopic} ({clusterCount})
+      </span>
+      <span aria-hidden style={{ flexShrink: 0, fontSize: '10px', marginLeft: '1px' }}>›</span>
+    </button>
+  );
+})()}
+```
+
+**Commit:** `Add relation indicator (top-right) to related-post cards (F1-F4)`
+
+---
+
+### Step 4 — Verify build passes
+
+Run `pnpm build`. Fix any TypeScript errors. Common risks:
+- `reRankAnchorIds` already in scope (from `useHighlightStore` destructure at line 598)
+- `topicTotal` already in scope (computed in `useMemo` at line 679)
+- `panelHovered` already in scope (state at line 602)
+- `handleToggleAnchor` already in scope (defined at line 948)
+
+**Commit:** (only if build-only fixes needed) `Fix TS errors in Group F indicator`
+
+---
+
+### Step 5 — Open PR
+
+```bash
+gh pr create \
+  --base tarcode2004/enhancement/group-e-reordering \
+  --head tarcode2004/enhancement/group-f-relation-indicator \
+  --title "Add per-card relation indicator (Group F)" \
+  --body "..."
+```
+
+---
+
+## Verification Checklist
+
+| Test | Expected |
+|---|---|
+| Card with single relation, panel not hovered | Indicator shows topic + count, category color, opacity ~0.75 |
+| Card with single relation, panel hovered | Indicator full opacity |
+| Card with multiple relations, panel not hovered | Indicator shows first relation's topic, grey color |
+| Card with multiple relations, panel hovered | Indicator shows dominant-category color |
+| Click indicator on unanchored card | Card becomes anchor; list reorders; indicator shows active bg |
+| Click indicator on already-anchored card | Anchor clears; list reverts; indicator returns to default |
+| Click indicator while different card is anchor | Anchor switches; old group collapses; new group forms |
+| Card with no relations | No indicator rendered |
+| Card with relations but first relation has no topic | No indicator rendered |
+| Card is a "claim" under an anchor | Indicator still renders; clicking it switches anchor |
+| Navigation still works | Clicking card body (not indicator) still navigates |
+| Indicator `aria-pressed` | `true` when card is active anchor, `false` otherwise |

--- a/docs/superpowers/specs/2026-05-13-group-f-relation-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-13-group-f-relation-indicator-design.md
@@ -1,0 +1,188 @@
+# Group F — Per-Card Relation Indicator (Design Spec)
+
+**Date:** 2026-05-13
+**Status:** Ready for implementation.
+**Scope:** Add a top-right "relation indicator" to each related-post card showing the post's topic name, a count of other posts sharing that topic, and a right-chevron. Clicking the indicator triggers the same "see more like this" behavior that the existing bottom "N more Topic" button uses.
+**Owner:** tarcode2004
+**Base branch:** `tarcode2004/enhancement/group-e-reordering`
+
+---
+
+## 1. Problem
+
+Currently, the relationship between a related post and the focus post is signaled only through (a) left-side category tags and (b) in-text highlight marks that appear on hover. Neither of these surfaces the *topic* of a relation at a glance, nor do they invite the user to explore related posts without first hovering.
+
+The user's meeting notes describe a "3rd option": show the relation topic prominently at the top-right of each card. This gives every card an at-a-glance label ("Trial results (8)") that communicates both *what* it is about and *how common* that relation is in the current panel — a direct invitation to explore the cluster.
+
+## 2. Goals
+
+1. **F1. Top-right relation indicator on each card.** Each card renders, at position `top: 10px, right: 10px`, a compact inline element showing the post's dominant topic name plus `(N)` — where N is the total count of posts in the current panel that share that topic (including the current post; use `topicTotal` directly).
+2. **F2. Color affordance.** Single-topic posts: indicator uses that topic's category color. Multi-topic posts: neutral grey until the panel mouse-enters (`panelHovered`), then dominant-category color.
+3. **F3. Click → activate anchor.** Clicking the indicator calls `handleToggleAnchor(postId, relIdx)` where `relIdx` is the index of the dominant relation. If the current card is already the active anchor for this relation, the click unselects (same toggle semantics as `handleToggleAnchor` already provides via `toggleReRankAnchor`).
+4. **F4. Navigation chevron disposition.** Remove the existing `<IconChevronRight>` at `top:12px, right:10px`. See Judgment Call #1.
+
+## 3. Non-Goals
+
+- Changing the existing top-left category tags (Group C territory).
+- Changing the existing bottom "N more Topic" pagination button (Group E territory).
+- Changing `reorderForAnchor` logic (Group E territory).
+- Changing filter chip behavior (Group C territory).
+- Adding animations beyond what framer-motion already provides for card layout.
+
+## 4. Visual Specification
+
+### 4.1 Indicator element
+
+```
+┌────────────────────────────────────────────────┐
+│ [Agree ▪ Evidence]             Trial results (8) ›│  ← top bar (absolute)
+│                                                  │
+│ @username · 4 minutes ago                        │
+│ Post content with highlighted spans…             │
+│                                                  │
+│ ── ──────────────────────────────────────────── │
+│ 💬 0   ♥ 2   🔖   ⤢                            │
+└────────────────────────────────────────────────┘
+```
+
+- **Position:** `position: absolute`, `top: 10px`, `right: 10px`, `zIndex: 10`
+- **Font size:** `11px`
+- **Font weight:** `600`
+- **Color:** category text color (or `#888888` for neutral)
+- **Content:** `{topic} ({N}) ›`
+  - `›` is a right-chevron character (Unicode `›`, U+203A) — visually lighter than `<IconChevronRight>`, avoids a second icon element at the same corner
+- **Cursor:** `pointer`
+- **Max-width:** `160px` with `overflow: hidden`, `textOverflow: ellipsis`, `whiteSpace: nowrap`
+- **Hover effect:** `opacity` transitions from `0.7` → `1` on hover (subtle brightening)
+- **Active state:** when this card is the current anchor, the indicator uses full opacity and a faint background tint (the category `bg` color) to communicate "this is active"
+
+### 4.2 Color logic (F2)
+
+| Card type | `panelHovered = false` | `panelHovered = true` |
+|---|---|---|
+| Single topic | category text color, opacity 0.75 | category text color, opacity 1 |
+| Multi-topic | `#888888`, opacity 0.6 | dominant-category text color, opacity 1 |
+
+`panelHovered` already exists in the component and is toggled by the wrapper div's `onMouseEnter`/`onMouseLeave` at line 1172.
+
+### 4.3 Count display
+
+Use `topicTotal.get(dominantTopic) ?? 0`. This gives the total across all posts in the current panel (including the card itself). We do NOT subtract self because:
+- The tooltip on the bottom "MORE" button already subtracts self (to show "others")
+- The top-right indicator is meant to communicate cluster size — "you are looking at one of 8 Trial-results posts" — so including self is appropriate and consistent with what the user sees in the brief's screenshot
+
+### 4.4 Dominant-topic selection rule (F2 multi-topic case)
+
+**Rule:** Use the **first relation** (`relations[0]`) as the dominant. Rationale:
+- The first relation is generally the most prominent (the API orders them by offset in the content, so the first-mentioned relation is the most salient)
+- A smarter frequency-based rule would need to compare across posts and adds complexity with marginal visual benefit
+- This rule is deterministic, stable, and easy to explain
+
+See Judgment Call #2 for full discussion.
+
+## 5. Interaction Specification (F3)
+
+### 5.1 Click behavior
+
+```
+onClick (on indicator):
+  e.stopPropagation()         // prevent card navigation
+  handleToggleAnchor(postId, dominantRelIdx)
+```
+
+`handleToggleAnchor` internally calls `toggleReRankAnchor(postId, rangeIndex)`, which:
+- If not active: adds `postId` to `reRankAnchorIds`, sets `anchoredRangeByPost[postId] = rangeIndex`
+- If already active: removes it (unselects)
+
+The "click while anchored on a different topic → switches" behavior is already handled: `toggleReRankAnchor` with a new postId replaces the old one (Group E single-anchor semantics).
+
+### 5.2 Active visual state
+
+The indicator should reflect whether the card is currently the active anchor:
+
+```tsx
+const isCurrentAnchor = reRankAnchorIds[reRankAnchorIds.length - 1] === stack.topPost.id;
+```
+
+When `isCurrentAnchor`:
+- Background: `anchorColors.bg` (or `dominantColors.bg` if not in a group yet)
+- Border: `1px solid {dominantColors.border}55`
+- Opacity: 1
+
+When not anchor:
+- Background: `transparent`
+- No border
+- Opacity per F2 color logic above
+
+## 6. Behavior in Edge Cases
+
+| Case | Behavior |
+|---|---|
+| Post has no relations | Indicator not rendered (guard: `!rels || rels.length === 0`) |
+| Post has relations but first relation has no topic | Indicator not rendered (guard: `!dominantTopic`) |
+| `topicTotal.get(dominantTopic)` is 0 or 1 | Still render indicator; "1" means only this post has that topic — valid information |
+| Card is a "claim" (pulled in under another anchor) | Indicator still renders; clicking it would switch the anchor to this card (Group E abandon-prior semantics) |
+| Panel cross-highlight active (another card hovered) | Indicator obeys the same `cardDimStyle` that dims non-hovered cards — no special handling needed |
+
+## 7. Judgment Calls
+
+### JC #1 — Navigation chevron disposition
+
+**Question:** The existing `<IconChevronRight>` at `top:12px, right:10px` (line 1569-1571) occupies the same corner as the new indicator. What to do?
+
+**Options:**
+- A. Remove the existing chevron (card is still fully clickable; chevron is redundant)
+- B. Move it to bottom-right corner
+- C. Stack both vertically at the right edge
+
+**Decision: Option A — remove the existing chevron.**
+
+Rationale:
+- The entire card has `cursor: pointer` and a solid border — affordance is clear without a chevron
+- The existing chevron is 14px grey icon with no label; it adds visual noise
+- The new relation indicator is more information-dense and more semantically useful in that position
+- Removing the old icon avoids a two-element top-right cluster
+- This is the simplest change and produces the cleanest visual output
+
+### JC #2 — Dominant-topic selection for multi-relation posts
+
+**Question:** When a post has multiple relations (e.g., relation 0 = "agree → Trial results", relation 1 = "evidence_public → Contract"), which topic does the indicator show?
+
+**Decision: First relation (`relations[0]`).**
+
+Rationale:
+- Relations are ordered by content offset (first-mentioned = topically leading the post)
+- Alternative (highest-frequency topic across the panel) requires a cross-post lookup per card — O(n) per render for each card, adds complexity
+- Alternative (match active anchor's topic) would cause the indicator to change dynamically as the user clicks around — confusing
+- `relations[0]` is stable, deterministic, and already used by existing code as the fallback in multiple places
+
+### JC #3 — Count semantics: total vs. others
+
+**Decision: Show `topicTotal.get(topic)` (total including self), NOT `total - 1`.**
+
+The indicator reads as "you are in a cluster of N". The bottom "N more" button already says "others". These two affordances are complementary: indicator = cluster size, bottom button = how many more to load.
+
+### JC #4 — Cross-highlight interaction
+
+**Question:** Should the relation indicator hide or change when a different card is hovered (cross-highlight active)?
+
+**Decision: No special handling.** The card's `cardDimStyle` already applies `opacity: 0.45, filter: grayscale(0.3)` to non-hovered cards. The indicator inherits this dimming naturally as part of the card. No additional logic needed.
+
+### JC #5 — `stopPropagation` on indicator click
+
+**Decision:** Call `e.stopPropagation()` on the indicator's `onClick`. The `Paper` and the content `div` both route clicks to `handleCardClick` → `handleNavigate`. The indicator click should not navigate; it should only toggle the anchor.
+
+## 8. Implementation Checklist
+
+- [ ] Derive `dominantRel` from `rels[0]` (guard: empty rels)
+- [ ] Derive `dominantColors` from `getCategoryColors(dominantRel.category)`
+- [ ] Compute `isMultiType` (already available in the category-tags block)
+- [ ] Compute indicator color based on `isMultiType` and `panelHovered`
+- [ ] Compute `isCurrentAnchor`
+- [ ] Remove existing `<IconChevronRight>` at line 1569
+- [ ] Render `<button type="button">` or `<div role="button">` at `position: absolute, top: 10px, right: 10px` inside `<Paper>`
+- [ ] Count: `topicTotal.get(dominantTopic) ?? 0`
+- [ ] Click: `e.stopPropagation()` then `handleToggleAnchor(postId, 0)` (index 0 for dominant)
+- [ ] Active state: faint background when card is current anchor
+- [ ] Hover opacity transition
+- [ ] Guard: skip render when no relations or no topic on first relation

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useLayoutEffect, useState, useMemo } from 'react';
 import { Paper, UnstyledButton, Group, Avatar, Text, Divider, Anchor } from '@mantine/core';
-import { IconMessageCircle, IconHeart, IconHeartFilled, IconBookmark, IconBookmarkFilled, IconShare, IconQuestionMark, IconBulb, IconQuote, IconLink, IconPointer, IconBook, IconMoodSmile, IconFrame, IconUser, IconThumbUp, IconThumbDown, IconChevronRight } from '@tabler/icons-react';
+import { IconMessageCircle, IconHeart, IconHeartFilled, IconBookmark, IconBookmarkFilled, IconShare, IconQuestionMark, IconBulb, IconQuote, IconLink, IconPointer, IconBook, IconMoodSmile, IconFrame, IconUser, IconThumbUp, IconThumbDown } from '@tabler/icons-react';
 import { Layers } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import RelatedStackCount from './RelatedStackCount';
@@ -1566,9 +1566,70 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                   })()}
                 </div>
 
-                <div style={{ position: 'absolute', top: '12px', right: '10px', zIndex: 10 }}>
-                  <IconChevronRight size={14} color="#94a3b8" />
-                </div>
+                {/* F: Relation indicator — top-right, dominant topic + cluster count */}
+                {(() => {
+                  const rels = stack.topPost.relations ?? [];
+                  if (rels.length === 0) return null;
+                  const dominantRel = rels[0];
+                  const dominantTopic = dominantRel.topic;
+                  if (!dominantTopic) return null;
+                  const uniqueCategories = new Set(rels.map(r => r.category));
+                  const isMultiTypeIndicator = uniqueCategories.size > 1;
+                  const dominantColors = getCategoryColors(dominantRel.category);
+                  const showIndicatorColor = !isMultiTypeIndicator || panelHovered;
+                  const indicatorColor = showIndicatorColor ? dominantColors.text : '#888888';
+                  const clusterCount = topicTotal.get(dominantTopic) ?? 0;
+                  const isCurrentAnchor =
+                    reRankAnchorIds.length > 0 &&
+                    reRankAnchorIds[reRankAnchorIds.length - 1] === stack.topPost.id;
+                  const baseOpacity = showIndicatorColor ? (isCurrentAnchor ? 1 : 0.75) : 0.6;
+                  return (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleToggleAnchor(stack.topPost.id, 0);
+                      }}
+                      aria-label={`Show more posts about ${dominantTopic}`}
+                      aria-pressed={isCurrentAnchor}
+                      style={{
+                        position: 'absolute',
+                        top: '10px',
+                        right: '10px',
+                        zIndex: 10,
+                        background: isCurrentAnchor ? dominantColors.bg : 'transparent',
+                        border: isCurrentAnchor ? `1px solid ${dominantColors.border}55` : 'none',
+                        borderRadius: '4px',
+                        padding: isCurrentAnchor ? '1px 5px' : '1px 4px',
+                        cursor: 'pointer',
+                        color: indicatorColor,
+                        fontSize: '11px',
+                        fontWeight: 600,
+                        lineHeight: 1.3,
+                        maxWidth: '160px',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        opacity: baseOpacity,
+                        transition: 'opacity 200ms ease, background 200ms ease, color 200ms ease',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '2px',
+                      }}
+                      onMouseEnter={(e) => {
+                        (e.currentTarget as HTMLButtonElement).style.opacity = '1';
+                      }}
+                      onMouseLeave={(e) => {
+                        (e.currentTarget as HTMLButtonElement).style.opacity = String(baseOpacity);
+                      }}
+                    >
+                      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '130px' }}>
+                        {dominantTopic} ({clusterCount})
+                      </span>
+                      <span aria-hidden style={{ flexShrink: 0, fontSize: '10px', marginLeft: '1px' }}>&#x203A;</span>
+                    </button>
+                  );
+                })()}
 
                 <UnstyledButton onClick={() => handleNavigate(stack.topPost.id, stack.stackId)} style={{ width: '100%' }}>
                   <Group style={{ paddingLeft: '1rem' }}>


### PR DESCRIPTION
## Summary

Implements Group F: a per-card \"relation indicator\" in the top-right of each related-post card in the Related Panel.

- **F1. Top-right indicator** — each card shows `{topic} ({N}) ›` at `top:10px, right:10px`. N is the total number of posts in the current panel sharing that topic (cluster size including self).
- **F2. Color affordance** — single-topic cards use that topic's category color; multi-topic cards are neutral grey until the panel is hovered (`panelHovered`), then switch to dominant-category color.
- **F3. Click → activate anchor** — clicking the indicator calls `handleToggleAnchor(postId, 0)` (the dominant relation's index). This threads through Group E's `reorderForAnchor` machinery. Active anchor shows a faint background tint. Re-clicking unselects.
- **F4. Nav chevron removed** — the existing `<IconChevronRight>` at `top:12px, right:10px` was removed (see Judgment Calls). `IconChevronRight` import also removed.

## Spec & Plan

- Spec: `docs/superpowers/specs/2026-05-13-group-f-relation-indicator-design.md`
- Plan: `docs/superpowers/plans/2026-05-13-group-f-relation-indicator.md`

## Judgment Calls

| # | Decision |
|---|---|
| JC1: Nav chevron | **Removed** (Option A). Card has `cursor:pointer` + colored border — affordance is clear. Two icons at the same corner would collide. |
| JC2: Dominant topic | **First relation (`relations[0]`)**. Relations are ordered by content offset; first-mentioned is topically leading. Stable, deterministic, matches existing fallback patterns in the file. |
| JC3: Count semantics | **`topicTotal` (includes self)** — indicator communicates cluster size ("you are 1 of 8"), not "others remaining". The bottom "N more" button already shows "others". Complementary framing. |
| JC4: Cross-highlight interaction | **No special handling** — indicator inherits `cardDimStyle` opacity naturally when a different card is hovered. |
| JC5: stopPropagation | Indicator `onClick` calls `e.stopPropagation()` to prevent card navigation from also firing. |

## Files Changed

- `src/components/RelatedStacks.tsx` — card rendering region only (~lines 1569–1632 new indicator, line 3 import cleanup, old nav-chevron block removed)

## Manual Test Plan

- [ ] Open the Related Panel on any post with related stacks
- [ ] Verify each card shows `{topic} ({N}) ›` at top-right, colored to match its category
- [ ] Hover off the panel, verify multi-topic cards show grey indicator; hover panel, verify they show category color
- [ ] Click an indicator — verify card becomes anchor, list reorders per Group E, indicator gets faint bg
- [ ] Click same indicator again — verify anchor clears, list reverts
- [ ] Click a different card's indicator while one is anchored — verify anchor switches
- [ ] Verify clicking the card body (not the indicator) still navigates to the post
- [ ] Verify cards with no relations render no indicator
- [ ] Confirm old `›` nav chevron is gone from top-right

## Concerns / Dependency Notes

- **Base is Group E's open PR branch.** Once Group E merges to `listy-injection-main-app`, this PR's base should be retargeted there (or to `dev` after that).
- **Rebase risk**: if Group E's branch is rebased or force-pushed before this PR merges, this branch will need to be rebased on top of the new E head. No conflicts expected since F only touches the card-rendering section and Group E touched the reordering algorithm.
- **Synthetic counts (PR `94311cb`)**: not present in Group E's branch. The indicator uses `topicTotal` as-is — if synthetic counts are later merged into E's branch and then rebased into F, the displayed counts will increase. This is correct behavior (the indicator should show the augmented count).
- **Cross-highlight interaction**: the indicator fully participates in the card's dim/undim behavior via `cardDimStyle` inheritance. No separate treatment needed.

Closes #152