### PR TITLE
Allow only one group-by anchor at a time

### DIFF
--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -931,8 +931,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     );
 
     // Populate anchorParent for visual connector-line indentation (single anchor: no parent).
-    // If there are older anchors still in reRankAnchorIds (shouldn't happen with single-anchor
-    // semantics, but kept for safety), walk the result to detect nesting.
+    // reRankAnchorIds is always length ≤ 1 by setter invariant, so anchorParent stays empty.
     const anchorIdx = result.findIndex(s => s.topPost.id === anchorId);
     for (let k = anchorIdx - 1; k >= 0; k--) {
       const prevId = result[k].topPost.id;
@@ -1289,7 +1288,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
           </div>
         )}
 
-        {/* "More like this" active indicator — shows all anchors */}
+        {/* "More like this" active indicator — single anchor only */}
         {reRankAnchorIds.length > 0 && (
           <div style={{
             display: 'flex', alignItems: 'center', gap: '6px', padding: '4px 8px',
@@ -1314,17 +1313,6 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                 </span>
               );
             })}
-            {reRankAnchorIds.length > 1 && (
-              <button
-                onClick={() => clearReRankAnchors()}
-                style={{
-                  background: 'none', border: 'none', cursor: 'pointer',
-                  color: '#94a3b8', fontSize: '11px', fontWeight: 600, padding: '0 2px', marginLeft: 'auto',
-                }}
-              >
-                Clear all
-              </button>
-            )}
           </div>
         )}
       </div>

--- a/src/utils/highlightStore.ts
+++ b/src/utils/highlightStore.ts
@@ -96,17 +96,25 @@ export function clearTapped(): void {
   notify();
 }
 
-/** Toggle a post as an anchor. Optionally records which highlight range triggered it. */
+/**
+ * Toggle a post as an anchor. Optionally records which highlight range triggered it.
+ *
+ * Single-anchor invariant: at most one anchor is active at any time.
+ * - Toggling the same anchor that is already active clears it (empty state).
+ * - Selecting a different anchor while one is active replaces the old one entirely;
+ *   the old anchor and its anchoredRangeByPost entry are removed before the new one
+ *   is added. reRankAnchorIds.length is therefore always 0 or 1.
+ */
 export function toggleReRankAnchor(postId: string, rangeIndex?: number): void {
   const idx = state.reRankAnchorIds.indexOf(postId);
   if (idx >= 0) {
+    // Same anchor toggled again — clear it.
     const { [postId]: _, ...rest } = state.anchoredRangeByPost;
-    state = { ...state, reRankAnchorIds: state.reRankAnchorIds.filter(id => id !== postId), anchoredRangeByPost: rest };
+    state = { ...state, reRankAnchorIds: [], anchoredRangeByPost: rest };
   } else {
-    const newAnchored = rangeIndex !== undefined
-      ? { ...state.anchoredRangeByPost, [postId]: rangeIndex }
-      : state.anchoredRangeByPost;
-    state = { ...state, reRankAnchorIds: [...state.reRankAnchorIds, postId], anchoredRangeByPost: newAnchored };
+    // New anchor selected — replace any existing anchor entirely.
+    const newAnchored = rangeIndex !== undefined ? { [postId]: rangeIndex } : {};
+    state = { ...state, reRankAnchorIds: [postId], anchoredRangeByPost: newAnchored };
   }
   notify();
 }


### PR DESCRIPTION
## Summary

- Selecting a \"More like this\" anchor while another is already active now **replaces** the old anchor entirely rather than accumulating a second one.
- Toggling the same anchor again still clears it (empty state), preserving existing dismiss behavior.
- The underlying type (`reRankAnchorIds: string[]`) is unchanged; the invariant `length ≤ 1` is enforced in `toggleReRankAnchor` by resetting to a fresh single-element array on every new selection rather than appending to the existing array.
- The now-unreachable \"Clear all\" button (was gated on `length > 1`) has been removed from the chip header UI.
- `shownByAnchor` cleanup is handled by the existing `useEffect` that mirrors `reRankAnchorIds` — when the array is replaced with a new single element, the effect drops the old entry and initialises the new one, verified by reading the effect.

## Files modified

- `src/utils/highlightStore.ts` — `toggleReRankAnchor` setter (lines 100–120)
- `src/components/RelatedStacks.tsx` — removed dead \"Clear all\" button; updated stale comment

## Test plan

- [ ] Click \"More like this\" on card A → one chip header appears for A
- [ ] Click \"More like this\" on card B while A is active → chip header switches to B (A disappears immediately, no stale grouping)
- [ ] Click the chip × for the active anchor → chip disappears, list reverts to default order
- [ ] Click the same card's \"More like this\" twice → grouping cleared on second click
- [ ] Verify `pnpm build` passes clean (confirmed locally)