### PR TITLE
Make relation.topic optional; drop literal Related from listy mock

### DIFF
--- a/src/app/(shell)/listy-injection/page.tsx
+++ b/src/app/(shell)/listy-injection/page.tsx
@@ -113,7 +113,6 @@ function generateSyntheticRelation(newFocusText: string, siblingContent: string,
     focusCommentStart: bestStart, focusCommentEnd: bestEnd,
     contentCommentStart: 0, contentCommentEnd: Math.min(siblingContent.length, 50),
     category,
-    topic: "Related",
   };
 }
 

--- a/src/types/PostType.tsx
+++ b/src/types/PostType.tsx
@@ -66,8 +66,8 @@ export interface Relation {
   contentCommentEnd: number;
   /** Relation type for this specific substring pair */
   category: CategoryKey;
-  /** Short topic label from NLP, e.g. "Trial results" */
-  topic: string;
+  /** Short topic label from NLP, e.g. "Trial results". Optional — synthesized via topicOf() when missing. */
+  topic?: string;
 }
 
 export interface FocusPostMock {


### PR DESCRIPTION
Listy-injection page's synthetic relation generator was setting `topic: "Related"` literally. Since `topicOf()` only synthesizes when topic is missing (nullish-coalescing), every relation on the /listy-injection route rendered as "Related".

Fix: make `Relation.topic` optional in the type and remove the literal assignment in the mock generator. `topicOf()` now synthesizes a real-looking topic for every mock relation.

Build: `pnpm exec tsc --noEmit` clean.