### PR TITLE
Honest post dates and N-more counts

### DIFF
--- a/src/components/ListyInjection/FocusPost.tsx
+++ b/src/components/ListyInjection/FocusPost.tsx
@@ -9,7 +9,7 @@ import {
   IconBookmark,
   IconBookmarkFilled,
 } from "@tabler/icons-react";
-import { format } from "date-fns";
+import { formatPostDate } from "../../utils/formatPostDate";
 import type { FocusPostMock, RelatedPostMock, CategoryKey } from "../../types/PostType";
 import { parseHighlight, buildSegments } from "./highlightUtils";
 import { CATEGORY_COLORS, CATEGORY_LABELS } from "./constants";
@@ -145,7 +145,7 @@ export default function FocusPost({ post, relatedPosts, isAncestor, isActive = f
           </Text>
           <Text size="xs" c="dimmed">
             @{post.account.acct} ·{" "}
-            {format(new Date(post.created_at), "MMM d, yyyy")}
+            {formatPostDate(post.created_at)}
           </Text>
         </div>
         {/* "Focus Post" label — only on the current focus */}

--- a/src/components/ListyInjection/ListyInjectionShell.tsx
+++ b/src/components/ListyInjection/ListyInjectionShell.tsx
@@ -8,7 +8,7 @@ import {
   IconMessageCircle,
   IconBookmark,
 } from "@tabler/icons-react";
-import { format } from "date-fns";
+import { formatPostDate } from "../../utils/formatPostDate";
 import type { ListyInjectionData, ListyInjectionEntry, FocusPostMock, RelatedPostMock } from "../../types/PostType";
 import {
   useListyStore,
@@ -377,7 +377,7 @@ function ReplyCard({ reply }: { reply: FocusPostMock }) {
             {reply.account.display_name}
           </Text>
           <Text size="xs" c="dimmed" style={{ lineHeight: 1.3, fontSize: "10px" }}>
-            @{reply.account.acct} · {format(new Date(reply.created_at), "MMM d, yyyy")}
+            @{reply.account.acct} · {formatPostDate(reply.created_at)}
           </Text>
         </div>
       </Group>

--- a/src/components/ListyInjection/RankedPostCard.tsx
+++ b/src/components/ListyInjection/RankedPostCard.tsx
@@ -10,7 +10,7 @@ import {
   IconBookmarkFilled,
   IconChevronRight,
 } from "@tabler/icons-react";
-import { format } from "date-fns";
+import { formatPostDate } from "../../utils/formatPostDate";
 import type { RelatedPostMock } from "../../types/PostType";
 import { parseHighlight, buildSegments } from "./highlightUtils";
 import type { HighlightRange } from "./highlightUtils";
@@ -187,7 +187,7 @@ const RankedPostCard = forwardRef<HTMLDivElement, RankedPostCardProps>(
               {post.account.display_name}
             </Text>
             <Text size="xs" c="dimmed" style={{ lineHeight: 1.3 }}>
-              {format(new Date(post.created_at), "MMM d, yyyy")}
+              {formatPostDate(post.created_at)}
             </Text>
           </div>
         </Group>

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -4,6 +4,7 @@ import { Text, Avatar, Group, Paper, UnstyledButton, Divider, Anchor } from '@ma
 import { notifications } from '@mantine/notifications';
 import { IconHeart, IconBookmark, IconNote, IconMessageCircle, IconHeartFilled, IconBookmarkFilled, IconLink } from '@tabler/icons-react';
 import { format } from 'date-fns';
+import { formatPostDate } from '../../utils/formatPostDate';
 import StackCount from '../StackCount';
 import axios from 'axios';
 import AnnotationModal from '../AnnotationModal';
@@ -799,7 +800,7 @@ export default function Post({
               >
                 {author}
               </Anchor>
-              <Text size="xs" c="dimmed">{format(new Date(createdAt), "MMM d, yyyy")}</Text>
+              <Text size="xs" c="dimmed">{formatPostDate(createdAt)}</Text>
             </div>
           </Group>
         </div>

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -179,15 +179,16 @@ function topicOf(relation: { topic?: string; category: string }, stackId: string
  *  get a synthetic count here, but the missing-topic guard in the tooltip
  *  rendering path suppresses display whenever r.topic is falsy — so absent
  *  topics are never shown regardless of this count. */
-function getSyntheticTopicCount(topic: string, realCount: number): number {
-  if (realCount > 1) return realCount;
-  return 2 + (hashString(topic) % 6);
+function getSyntheticTopicCount(_topic: string, realCount: number): number {
+  // No-op: synthetic boost removed because tooltip "N more" was promising
+  // posts the load couldn't deliver. Real count is honest.
+  return realCount;
 }
 
 /** Same logic as getSyntheticTopicCount but for relation categories. */
-function getSyntheticCategoryCount(category: string, realCount: number): number {
-  if (realCount > 1) return realCount;
-  return 2 + (hashString(category) % 6);
+function getSyntheticCategoryCount(_category: string, realCount: number): number {
+  // No-op: synthetic boost removed; see getSyntheticTopicCount.
+  return realCount;
 }
 
 // ─── Tooltip label renderer ───────────────────────────────────────────────────

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useEffect, useLayoutEffect, useState, useMemo } from 're
 import { Paper, UnstyledButton, Group, Avatar, Text, Divider, Anchor } from '@mantine/core';
 import { IconMessageCircle, IconHeart, IconHeartFilled, IconBookmark, IconBookmarkFilled, IconShare, IconQuestionMark, IconBulb, IconQuote, IconLink, IconPointer, IconBook, IconMoodSmile, IconFrame, IconUser, IconThumbUp, IconThumbDown } from '@tabler/icons-react';
 import { Layers } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import { formatPostDate } from '../utils/formatPostDate';
 import RelatedStackCount from './RelatedStackCount';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
@@ -1818,7 +1818,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                         style={{ color: '#011445', fontWeight: 700, fontSize: 'var(--mantine-font-size-md)' }}>
                         {stack.topPost.account.display_name}
                       </Anchor>
-                      <Text size="xs" c="dimmed">{formatDistanceToNow(new Date(stack.topPost.created_at))} ago</Text>
+                      <Text size="xs" c="dimmed">{formatPostDate(stack.topPost.created_at)}</Text>
                     </div>
                   </Group>
                 </UnstyledButton>

--- a/src/components/RepliesStack.tsx
+++ b/src/components/RepliesStack.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useEffect, useState } from 'react';
 import { Paper, UnstyledButton, Group, Avatar, Text, Divider, Anchor } from '@mantine/core';
 import { IconMessageCircle, IconHeart, IconHeartFilled, IconBookmark, IconBookmarkFilled, IconShare, IconQuestionMark, IconBulb, IconQuote, IconLink, IconPointer, IconBook, IconMoodSmile, IconFrame, IconUser } from '@tabler/icons-react';
 import { Layers } from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
+import { formatPostDate } from '../utils/formatPostDate';
 import RelatedStackCount from './RelatedStackCount';
 import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
@@ -25,10 +25,10 @@ interface PostType {
     username?: string;
   };
   content_rewritten: string;
-  rewrite: 
-  {content: string; 
+  rewrite:
+  {content: string;
     significant:boolean;
- } 
+ }
 }
 
 interface RepliesStackType {
@@ -126,12 +126,12 @@ const RepliesStack: React.FC<RepliesStackProps> = ({ repliesStacks, cardWidth, o
 
   const itemVariants = (index: number) => ({
     hidden: showupdate ? { opacity: 0, x: -200, y: -200 * (index + 1) } : { opacity: 0, y: 200 },
-    show: { 
-      opacity: 1, 
-      x: 0, 
+    show: {
+      opacity: 1,
+      x: 0,
       y: 0,
       transition: {
-        duration: 0.5 
+        duration: 0.5
       }
     },
   });
@@ -142,13 +142,13 @@ const RepliesStack: React.FC<RepliesStackProps> = ({ repliesStacks, cardWidth, o
 
   return (
     <div
-      
+
       style={{ display: 'flex', flexDirection: 'column', gap: '2rem', alignItems: 'center', width: '100%' }}
     >
       {repliesStacks.slice(0, maxStacksToShow).map((stack, index) => (
         <div
           key={stack.stackId}
-     
+
           style={{
             position: 'relative',
             margin: '20px 20px',
@@ -170,7 +170,7 @@ const RepliesStack: React.FC<RepliesStackProps> = ({ repliesStacks, cardWidth, o
               paddingTop: '20px',
               cursor: 'pointer'
             }}
-     
+
           >
             {stack.topPost.rewrite.significant&&  (
              <div
@@ -210,7 +210,7 @@ const RepliesStack: React.FC<RepliesStackProps> = ({ repliesStacks, cardWidth, o
                     {stack.topPost.account.display_name}
                   </Anchor>
                   <Text size="xs" c="dimmed">
-                    {formatDistanceToNow(new Date(stack.topPost.created_at))} ago
+                    {formatPostDate(stack.topPost.created_at)}
                   </Text>
                 </div>
               </Group>
@@ -222,7 +222,7 @@ const RepliesStack: React.FC<RepliesStackProps> = ({ repliesStacks, cardWidth, o
                 paddingRight: '1rem',
                 cursor: 'pointer'
               }}
-                
+
             >
                 {stack.topPost.content_rewritten ? (
                   <Text c="#011445" dangerouslySetInnerHTML={{ __html: stack.topPost.rewrite.content }} />
@@ -271,7 +271,7 @@ const RepliesStack: React.FC<RepliesStackProps> = ({ repliesStacks, cardWidth, o
             )}
           </Paper>
 
-          {stack.size !== null && stack.size > 1 && 
+          {stack.size !== null && stack.size > 1 &&
             [...Array(3)].map((_, idx) => (
               <div
                 key={idx}

--- a/src/components/StackPostsModal.tsx
+++ b/src/components/StackPostsModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect,useRef, useState } from 'react';
 import { Modal, ScrollArea, Switch, SimpleGrid, Text, Container, Group, Avatar, Button, Divider, Paper, UnstyledButton, TextInput, rem, LoadingOverlay, Loader } from '@mantine/core';
 import axios from 'axios';
 import { IconBookmark, IconHeart, IconMessageCircle, IconPhoto, IconSettings, IconShare, IconHeartFilled, IconBookmarkFilled, IconSearch } from "@tabler/icons-react";
-import { formatDistanceToNow } from 'date-fns';
+import { formatPostDate } from '../utils/formatPostDate';
 import { Code } from '@mantine/core';
 import { useRouter } from 'next/navigation';
 import classes from './expandModal.module.css';
@@ -78,7 +78,7 @@ function StackPostsModal({ isOpen, onClose, apiUrl, stackId }: StackPostsModalPr
     setAccessToken(token);
     console.log("api", apiUrl);
     setCurrentUrl(apiUrl);
-  }, [apiUrl]); 
+  }, [apiUrl]);
 
   useEffect(() => {
     if (stackId) {
@@ -168,11 +168,11 @@ function StackPostsModal({ isOpen, onClose, apiUrl, stackId }: StackPostsModalPr
         style={{
           position: 'relative',
           width: '90%',
-          backgroundColor: '#ffffff',         
-          border: '1px solid #e7e7e7',        
-          borderRadius: '10px',           
+          backgroundColor: '#ffffff',
+          border: '1px solid #e7e7e7',
+          borderRadius: '10px',
           // boxShadow: '0 10px 10px rgba(0,0,0,0.1)',
-          padding: '1rem',             
+          padding: '1rem',
           zIndex: 5,
         }}
       >
@@ -188,17 +188,17 @@ function StackPostsModal({ isOpen, onClose, apiUrl, stackId }: StackPostsModalPr
             />
             <div>
               <Text size="sm" style={{ color: '#011445', fontWeight:"bold" }}>{stack.topPost.account.display_name}</Text>
-              <Text size="xs" c="dimmed">{formatDistanceToNow(new Date(stack.topPost.created_at))} ago</Text>
+              <Text size="xs" c="dimmed">{formatPostDate(stack.topPost.created_at)}</Text>
             </div>
           </Group>
-          <div ref={textRef} 
-          style={{ 
-            paddingLeft: '54px', 
-            paddingTop: '1rem', 
-            overflow: 'hidden', 
-            textOverflow: "ellipsis", 
-            display: '-webkit-box', 
-            WebkitLineClamp: '3', 
+          <div ref={textRef}
+          style={{
+            paddingLeft: '54px',
+            paddingTop: '1rem',
+            overflow: 'hidden',
+            textOverflow: "ellipsis",
+            display: '-webkit-box',
+            WebkitLineClamp: '3',
             WebkitBoxOrient: 'vertical' }}>
             <Text
               c="#011445"
@@ -308,7 +308,7 @@ function StackPostsModal({ isOpen, onClose, apiUrl, stackId }: StackPostsModalPr
         </Tabs.Panel>
       </Tabs>
     </div>
-      
+
     </Modal>
   );
 }

--- a/src/utils/formatPostDate.ts
+++ b/src/utils/formatPostDate.ts
@@ -1,0 +1,21 @@
+import { format, formatDistanceToNow, differenceInDays } from 'date-fns';
+
+/**
+ * Hybrid date formatter for post cards.
+ *
+ * - < 7 days ago  → relative "3 hours ago"
+ * - same year     → "May 13"
+ * - older         → "Jul 29, 2024"
+ *
+ * Replaces bare `formatDistanceToNow(new Date(x)) + ' ago'` calls that showed
+ * "almost 2 years ago" for all archived posts, and replaces hard-coded
+ * `format(date, "MMM d, yyyy")` calls that lost relative recency info.
+ */
+export function formatPostDate(input: string | Date): string {
+  const d = input instanceof Date ? input : new Date(input);
+  const now = new Date();
+  const days = differenceInDays(now, d);
+  if (days < 7) return `${formatDistanceToNow(d)} ago`;
+  if (d.getFullYear() === now.getFullYear()) return format(d, 'MMM d');
+  return format(d, 'MMM d, yyyy');
+}


### PR DESCRIPTION
Two related polish fixes:

1. Post dates: switch to a hybrid formatter — relative for last 7 days, then "Mon DD" within the year, then "Mon DD, YYYY" prior years. Replaces "almost 2 years ago" everywhere with the actual date for older posts.

2. Tooltip counts: pass through the real topic/category counts instead of the synthetic boost added by #154. The tooltip's "N more Topic" now matches what the see-more button can actually load.