### PR TITLE
Pick simulated-reply avatar from content sentiment

### DIFF
--- a/docs/superpowers/plans/2026-05-13-sentiment-avatar.md
+++ b/docs/superpowers/plans/2026-05-13-sentiment-avatar.md
@@ -1,0 +1,259 @@
+# Sentiment-Driven Feedback Avatars Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace index-based avatar selection in `ReplySection` simulated replies with a content-aware keyword classifier that picks one of 8 emotion avatars per reply.
+
+**Architecture:** New `src/utils/sentimentAvatar.ts` exports `pickAvatarForText(text)`. `ReplySection.tsx` imports it and uses it in place of the existing `avatars[index % avatars.length]` expression. Pure client-side, no dependencies, no async work.
+
+**Tech Stack:** TypeScript, React (Next.js 14), Mantine v7. No test framework in this repo (per `CLAUDE.md`) — verification is manual via `pnpm dev`.
+
+**Base branch:** `tarcode2004/enhancement/listy-injection-main-app` (already the upstream for this worktree). PR will target that branch, not `dev`.
+
+---
+
+## Task 0: Sync branch and commit the spec
+
+**Files:**
+- Existing: `docs/superpowers/specs/2026-05-13-sentiment-avatar-design.md` (untracked)
+
+- [ ] **Step 1: Fast-forward to upstream listy-injection**
+
+```bash
+git pull --ff-only
+```
+
+Expected: branch advances to include commit `1a21972` ("Expand listy-injection dataset and switch post dates to absolute"). If pull fails with a non-fast-forward error, stop and report — do not force.
+
+- [ ] **Step 2: Commit the spec**
+
+```bash
+git add docs/superpowers/specs/2026-05-13-sentiment-avatar-design.md docs/superpowers/plans/2026-05-13-sentiment-avatar.md
+git commit -m "Add sentiment-driven avatar spec and plan"
+```
+
+Expected: one commit added on `claude/crazy-dubinsky-e849e8`.
+
+---
+
+## Task 1: Create the sentiment classifier utility
+
+**Files:**
+- Create: `src/utils/sentimentAvatar.ts`
+
+- [ ] **Step 1: Write the classifier module**
+
+Create `src/utils/sentimentAvatar.ts` with this exact content:
+
+```ts
+export type EmotionKey =
+  | 'angry'
+  | 'cracked'
+  | 'default'
+  | 'haha'
+  | 'love'
+  | 'queasy'
+  | 'sad'
+  | 'sweet';
+
+export const AVATAR_BY_EMOTION: Record<EmotionKey, string> = {
+  angry: '/avatar/stacky_angry.PNG',
+  cracked: '/avatar/stacky_cracked.PNG',
+  default: '/avatar/stacky_default.PNG',
+  haha: '/avatar/stacky_haha.PNG',
+  love: '/avatar/stacky_love.PNG',
+  queasy: '/avatar/stacky_queasy.PNG',
+  sad: '/avatar/stacky_sad.PNG',
+  sweet: '/avatar/stacky_sweet.PNG',
+};
+
+const KEYWORDS: Record<Exclude<EmotionKey, 'default'>, readonly string[]> = {
+  angry: ['angry', 'hate', 'awful', 'terrible', 'worst', 'stupid', 'ridiculous', 'furious', 'mad', 'outrage', 'wrong', 'bad', 'no', 'never'],
+  cracked: ['crazy', 'insane', 'wild', 'bizarre', 'weird', 'whoa', 'wow', 'unbelievable', 'mind-blown'],
+  haha: ['haha', 'lol', 'lmao', 'rofl', 'funny', 'hilarious', 'joke', 'laugh', 'lmfao'],
+  love: ['love', 'amazing', 'brilliant', 'wonderful', 'perfect', 'fantastic', 'beautiful', 'incredible', 'awesome', '❤'],
+  queasy: ['gross', 'ew', 'ugh', 'yuck', 'nasty', 'vile', 'disgusting', 'eww'],
+  sad: ['sad', 'sorry', 'unfortunately', 'disappointed', 'regret', 'miss', 'lonely', 'hurt', 'cry'],
+  sweet: ['sweet', 'nice', 'kind', 'thanks', 'thank', 'appreciate', 'glad', 'happy', 'lovely', 'agree', 'good'],
+};
+
+const PRIORITY: readonly EmotionKey[] = ['love', 'angry', 'haha', 'sad', 'queasy', 'cracked', 'sweet', 'default'];
+
+function normalize(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, ' ')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function countMatches(text: string, keyword: string): number {
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = /^[a-z0-9]+$/.test(keyword)
+    ? new RegExp(`\\b${escaped}\\b`, 'g')
+    : new RegExp(escaped, 'g');
+  return (text.match(pattern) ?? []).length;
+}
+
+export function pickAvatarForText(text: string): string {
+  const normalized = normalize(text);
+  if (!normalized) return AVATAR_BY_EMOTION.default;
+
+  const scores = new Map<EmotionKey, number>();
+  for (const [emotion, words] of Object.entries(KEYWORDS) as [Exclude<EmotionKey, 'default'>, readonly string[]][]) {
+    let score = 0;
+    for (const w of words) score += countMatches(normalized, w);
+    if (score > 0) scores.set(emotion, score);
+  }
+
+  if (scores.size === 0) return AVATAR_BY_EMOTION.default;
+
+  const max = Math.max(...scores.values());
+  for (const emotion of PRIORITY) {
+    if (scores.get(emotion) === max) return AVATAR_BY_EMOTION[emotion];
+  }
+  return AVATAR_BY_EMOTION.default;
+}
+```
+
+Notes for the engineer:
+- Word-boundary matching avoids `"national"` lighting up the `"no"` keyword.
+- Emoji like `❤` aren't word-bounded, so the function falls back to substring match for non-alphanumeric keywords.
+- `PRIORITY` only matters for ties; otherwise the highest count wins directly.
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm lint`
+
+Expected: no new errors related to `sentimentAvatar.ts`. If lint reports unrelated warnings already present on the branch, that's fine — only fail on new ones.
+
+- [ ] **Step 3: Quick smoke test in Node**
+
+Run a one-off REPL check (does not commit anything):
+
+```bash
+npx tsx -e "import('./src/utils/sentimentAvatar.ts').then(m => { console.log('love', m.pickAvatarForText('I love this, amazing point!')); console.log('angry', m.pickAvatarForText('this is the worst, terrible take')); console.log('neutral', m.pickAvatarForText('Okay, I see what you mean.')); console.log('empty', m.pickAvatarForText('')); console.log('html', m.pickAvatarForText('<p>haha lol so funny</p>')); })"
+```
+
+Expected output (paths, not labels — labels here for clarity):
+```
+love /avatar/stacky_love.PNG
+angry /avatar/stacky_angry.PNG
+neutral /avatar/stacky_default.PNG
+empty /avatar/stacky_default.PNG
+html /avatar/stacky_haha.PNG
+```
+
+If `tsx` is unavailable, skip this step — Task 2's manual UI verification covers correctness.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/utils/sentimentAvatar.ts
+git commit -m "Add sentiment-driven avatar utility"
+```
+
+---
+
+## Task 2: Wire it into ReplySection
+
+**Files:**
+- Modify: `src/components/ReplySection.tsx`
+
+- [ ] **Step 1: Add the import**
+
+In `src/components/ReplySection.tsx`, just after the existing imports at the top of the file (after the `import axios from 'axios';` and `import { v4 as uuidv4 } from 'uuid';` lines), add:
+
+```ts
+import { pickAvatarForText } from '../utils/sentimentAvatar';
+```
+
+- [ ] **Step 2: Remove the unused avatars array**
+
+Delete lines 14–23 (the `const avatars = [...]` block that lists the 8 PNG paths). It is no longer referenced after Step 3.
+
+- [ ] **Step 3: Replace the avatar src expression**
+
+Find this line (currently around line 223):
+
+```tsx
+<Avatar src={avatars[index % avatars.length]} radius="xl" />
+```
+
+Replace with:
+
+```tsx
+<Avatar src={pickAvatarForText(reply.content)} radius="xl" />
+```
+
+- [ ] **Step 4: Type-check and lint**
+
+Run: `pnpm lint`
+
+Expected: no errors. If lint complains about an unused `index` parameter in the `.map((reply, index) => …)` callback, change the callback to drop `index`: `.map((reply, _index) => …)` or `.map((reply) => …)`. (Confirm by reading the surrounding JSX; if `index` is still used as the React `key={index}`, leave it.)
+
+- [ ] **Step 5: Manual UI verification**
+
+```bash
+pnpm dev
+```
+
+Then in a browser at `localhost:3000`:
+1. Log in via the OAuth flow if not already authed.
+2. Open a thread, click into a post that has a reply box.
+3. Type a clearly positive reply (e.g., `"I love this, amazing point!"`) — wait for the debounced feedback panel to appear.
+4. Confirm the simulated robot reply card shows an avatar matching the reply's tone (one of `love`, `sweet`, or `haha` — not always `angry`).
+5. Type a clearly negative reply (e.g., `"this is terrible, worst take"`) and confirm the avatar changes to `angry` or `sad`.
+6. Type a neutral reply (e.g., `"Interesting, will think about it."`) and confirm `default`.
+
+Verification claim: only mark complete if you actually saw the avatars change in the browser. If you can't get the feedback panel to populate (e.g., backend unavailable), say so explicitly rather than claim success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/ReplySection.tsx
+git commit -m "Use sentiment-based avatar in ReplySection simulated replies"
+```
+
+---
+
+## Task 3: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin claude/crazy-dubinsky-e849e8
+```
+
+- [ ] **Step 2: Create the PR against the listy-injection branch**
+
+```bash
+gh pr create \
+  --base tarcode2004/enhancement/listy-injection-main-app \
+  --title "Pick simulated-reply avatar from content sentiment" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `src/utils/sentimentAvatar.ts`: a keyword classifier that maps reply text to one of 8 stacky avatars.
+- `ReplySection.tsx`: replace `avatars[index % avatars.length]` with `pickAvatarForText(reply.content)`. Robot 1 is no longer always angry.
+
+## Test plan
+- [ ] Manual: positive reply shows a positive avatar
+- [ ] Manual: negative reply shows angry/sad avatar
+- [ ] Manual: neutral reply shows default avatar
+- [ ] `pnpm lint` clean
+EOF
+)"
+```
+
+Notes:
+- Confirm with the user before pushing or opening the PR. Pushing is reversible but visible — get an explicit go-ahead.
+- Do not target `dev` — `--base` must be `tarcode2004/enhancement/listy-injection-main-app`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Utility module ✓, algorithm ✓, keyword sets ✓, ReplySection wire-up ✓, manual verification ✓, branch/PR target ✓.
+- **Placeholders:** None — every step has real code, real commands, real expected output.
+- **Type consistency:** `EmotionKey`, `AVATAR_BY_EMOTION`, `pickAvatarForText` defined in Task 1; only `pickAvatarForText` is imported in Task 2. Signatures match.
+- **Test discipline:** Repo has no test framework, so TDD is replaced with a focused manual verification step in Task 2 and a smoke test in Task 1. This is the appropriate adaptation per CLAUDE.md.

--- a/docs/superpowers/specs/2026-05-13-sentiment-avatar-design.md
+++ b/docs/superpowers/specs/2026-05-13-sentiment-avatar-design.md
@@ -1,0 +1,120 @@
+# Sentiment-Driven Feedback Avatars
+
+## Problem
+
+In [`src/components/ReplySection.tsx`](../../../src/components/ReplySection.tsx), each simulated robot reply gets its avatar via `avatars[index % avatars.length]`. The first entry in that array is `stacky_angry.PNG`, and since the backend typically returns one or a small number of simulated replies, **Robot 1 is always angry regardless of its content**. The avatar is decoupled from the reply's actual tone.
+
+## Goal
+
+Replace index-based avatar selection with content-aware selection: each simulated reply's avatar is chosen by running a simple sentiment/emotion classifier over `reply.content`, so a praising reply shows the love or sweet avatar, a critical reply shows angry or sad, etc.
+
+Scope is limited to the `ReplySection` simulated-reply panel. The `annotation/page.tsx` random-avatar behavior is unchanged.
+
+## Non-Goals
+
+- No ML model, external API, or npm sentiment library — pure keyword lookup
+- No sarcasm/irony detection
+- No multilingual support (English-only keyword sets)
+- No avatar for the praise/advice text block — that section keeps its current layout (no avatar)
+- No changes to the backend `/posts/feedback` contract
+
+## Approach
+
+### Module: `src/utils/sentimentAvatar.ts`
+
+A single new utility module exports:
+
+```ts
+export type EmotionKey =
+  | 'angry' | 'cracked' | 'default' | 'haha'
+  | 'love'  | 'queasy'  | 'sad'     | 'sweet';
+
+export const AVATAR_BY_EMOTION: Record<EmotionKey, string>;
+export function pickAvatarForText(text: string): string;
+```
+
+- `AVATAR_BY_EMOTION` maps each emotion key to its `/avatar/stacky_<emotion>.PNG` path
+- `pickAvatarForText(text)` returns one of the 8 avatar paths
+
+### Algorithm
+
+1. **Normalize**: lowercase, strip HTML tags (the backend may return HTML-formatted content), collapse whitespace
+2. **Score**: for each emotion bucket, count how many of its keywords appear as whole-word matches (using word-boundary regex) in the normalized text
+3. **Pick winner**: emotion with the highest score wins
+4. **Tie / no match**: return `default`. When two emotions tie above zero, break the tie using a fixed priority order (declared as a constant in the module) so output is deterministic and reproducible
+
+The priority order (used only for ties) is: `love > angry > haha > sad > queasy > cracked > sweet > default`. This favors stronger emotions over milder ones when signals are mixed.
+
+### Keyword Sets
+
+Initial keyword lists, declared inline in the module so they're easy to audit and extend:
+
+- **angry**: angry, hate, awful, terrible, worst, stupid, ridiculous, furious, mad, outrage, wrong, bad, no, never
+- **cracked**: crazy, insane, wild, bizarre, weird, whoa, wow, unbelievable, mind-blown
+- **haha**: haha, lol, lmao, rofl, funny, hilarious, joke, laugh, lmfao
+- **love**: love, amazing, brilliant, wonderful, perfect, fantastic, beautiful, incredible, awesome, ❤
+- **queasy**: gross, ew, ugh, yuck, nasty, vile, disgusting, eww
+- **sad**: sad, sorry, unfortunately, disappointed, regret, miss, lonely, hurt, cry
+- **sweet**: sweet, nice, kind, thanks, thank, appreciate, glad, happy, lovely, agree, good
+- **default**: (no keywords — pure fallback)
+
+### Wire-up in ReplySection.tsx
+
+Replace:
+```tsx
+<Avatar src={avatars[index % avatars.length]} radius="xl" />
+```
+with:
+```tsx
+<Avatar src={pickAvatarForText(reply.content)} radius="xl" />
+```
+
+The local `avatars` array in `ReplySection.tsx` is no longer used and can be removed in the same change. The corresponding array in `annotation/page.tsx` stays — different feature, different purpose.
+
+## Data Flow
+
+```
+[user types reply]
+   → debounced fetchRealTimeFeedback
+   → backend /posts/feedback → { advice, praise, simulatedReplies }
+   → render simulatedReplies.map((reply, i) =>
+        <Avatar src={pickAvatarForText(reply.content)} /> )
+```
+
+No new state, no extra requests, no async work. Sentiment is computed at render time — cheap enough (string scan over short text) that memoization is not needed.
+
+## Edge Cases
+
+- **Empty content**: returns `default`
+- **HTML-only content** (e.g. `<p></p>`): strips to empty → `default`
+- **All-caps SHOUTING**: lowercase normalization handles it
+- **Multiple emotions in one reply**: highest count wins; deterministic tiebreaker if equal
+- **Unicode emoji (❤)**: included as a love keyword. Other emoji are ignored in v1
+
+## Testing
+
+The project has no test framework configured (per `CLAUDE.md`). Verification is manual:
+
+1. `pnpm dev`, navigate to a thread, type a reply long enough (≥10 chars) to trigger feedback
+2. Confirm in the simulated-replies panel that the avatar matches the tone of each reply's content
+3. Test with replies containing obvious praise words ("love this!") → love/sweet avatar
+4. Test with replies containing critique words ("terrible point") → angry/sad avatar
+5. Test with neutral content → default avatar
+
+Optionally, a small `__tests__`-style assertion script can be added under `src/utils/` later, but it's out of scope for v1.
+
+## File Changes
+
+- **New**: `src/utils/sentimentAvatar.ts` — classifier + avatar mapping
+- **Modified**: `src/components/ReplySection.tsx`
+  - Remove the local `avatars` constant
+  - Import `pickAvatarForText`
+  - Replace the `<Avatar src=…>` expression on the simulated-reply card
+
+No other files touched.
+
+## Branch & PR
+
+- Base branch: `tarcode2004/enhancement/listy-injection-main-app` (not `dev`)
+- Branch name: follow the convention in `.claude/rules/branch-naming.md`
+- PR body: include `Closes #<issue>` if an issue exists, keep under 400 lines (this change is ~50 lines)

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Avatar, Group, Button, Text, Stack, Paper, Badge, Loader, TextInput } from "@mantine/core";
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
+import { pickAvatarForText } from '../utils/sentimentAvatar';
 
 interface ReplySectionProps {
     postId: string;
@@ -10,17 +11,6 @@ interface ReplySectionProps {
 }
 
 const MastodonInstanceUrl = 'https://beta.stacky.social';
-
-const avatars = [
-    '/avatar/stacky_angry.PNG',
-    '/avatar/stacky_cracked.PNG',
-    '/avatar/stacky_default.PNG',
-    '/avatar/stacky_haha.PNG',
-    '/avatar/stacky_love.PNG',
-    '/avatar/stacky_queasy.PNG',
-    '/avatar/stacky_sad.PNG',
-    '/avatar/stacky_sweet.PNG'
-];
 
 const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchPostAndReplies }) => {
     const [replyContent, setReplyContent] = useState<string>('');
@@ -220,7 +210,7 @@ const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchP
                                                 }}
                                             >
                                                 <Group>
-                                                    <Avatar src={avatars[index % avatars.length]} radius="xl" />
+                                                    <Avatar src={pickAvatarForText(reply.content)} radius="xl" />
                                                     <div>
                                                         <Text fw="700" size="sm">Robot {index + 1}</Text>
                                                     </div>

--- a/src/utils/sentimentAvatar.ts
+++ b/src/utils/sentimentAvatar.ts
@@ -1,0 +1,72 @@
+export type EmotionKey =
+  | 'angry'
+  | 'cracked'
+  | 'default'
+  | 'haha'
+  | 'love'
+  | 'queasy'
+  | 'sad'
+  | 'sweet';
+
+export const AVATAR_BY_EMOTION: Record<EmotionKey, string> = {
+  angry: '/avatar/stacky_angry.PNG',
+  cracked: '/avatar/stacky_cracked.PNG',
+  default: '/avatar/stacky_default.PNG',
+  haha: '/avatar/stacky_haha.PNG',
+  love: '/avatar/stacky_love.PNG',
+  queasy: '/avatar/stacky_queasy.PNG',
+  sad: '/avatar/stacky_sad.PNG',
+  sweet: '/avatar/stacky_sweet.PNG',
+};
+
+const KEYWORDS: Record<Exclude<EmotionKey, 'default'>, readonly string[]> = {
+  angry: ['angry', 'hate', 'awful', 'terrible', 'worst', 'stupid', 'ridiculous', 'furious', 'mad', 'outrage', 'wrong', 'bad', 'no', 'never'],
+  cracked: ['crazy', 'insane', 'wild', 'bizarre', 'weird', 'whoa', 'wow', 'unbelievable', 'mind-blown'],
+  haha: ['haha', 'lol', 'lmao', 'rofl', 'funny', 'hilarious', 'joke', 'laugh', 'lmfao'],
+  love: ['love', 'amazing', 'brilliant', 'wonderful', 'perfect', 'fantastic', 'beautiful', 'incredible', 'awesome', '❤'],
+  queasy: ['gross', 'ew', 'ugh', 'yuck', 'nasty', 'vile', 'disgusting', 'eww'],
+  sad: ['sad', 'sorry', 'unfortunately', 'disappointed', 'regret', 'miss', 'lonely', 'hurt', 'cry'],
+  sweet: ['sweet', 'nice', 'kind', 'thanks', 'thank', 'appreciate', 'glad', 'happy', 'lovely', 'agree', 'good'],
+};
+
+const PRIORITY: readonly EmotionKey[] = ['love', 'angry', 'haha', 'sad', 'queasy', 'cracked', 'sweet', 'default'];
+
+function normalize(text: string): string {
+  return text
+    .replace(/<[^>]*>/g, ' ')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function countMatches(text: string, keyword: string): number {
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = /^[a-z0-9]+$/.test(keyword)
+    ? new RegExp(`\\b${escaped}\\b`, 'g')
+    : new RegExp(escaped, 'g');
+  return (text.match(pattern) ?? []).length;
+}
+
+export function pickAvatarForText(text: string): string {
+  const normalized = normalize(text);
+  if (!normalized) return AVATAR_BY_EMOTION.default;
+
+  const scores: Partial<Record<EmotionKey, number>> = {};
+  let max = 0;
+  (Object.keys(KEYWORDS) as Exclude<EmotionKey, 'default'>[]).forEach((emotion) => {
+    const words = KEYWORDS[emotion];
+    let score = 0;
+    for (const w of words) score += countMatches(normalized, w);
+    if (score > 0) {
+      scores[emotion] = score;
+      if (score > max) max = score;
+    }
+  });
+
+  if (max === 0) return AVATAR_BY_EMOTION.default;
+
+  for (const emotion of PRIORITY) {
+    if (scores[emotion] === max) return AVATAR_BY_EMOTION[emotion];
+  }
+  return AVATAR_BY_EMOTION.default;
+}


### PR DESCRIPTION
## Summary
- Add `src/utils/sentimentAvatar.ts`: a keyword-based emotion classifier that maps text to one of 8 stacky avatars (`angry`, `cracked`, `default`, `haha`, `love`, `queasy`, `sad`, `sweet`). Pure client-side, no dependencies.
- `ReplySection.tsx`: replace `avatars[index % avatars.length]` with `pickAvatarForText(reply.content)` for simulated robot replies. Robot 1 is no longer always angry — the avatar matches the tone of the reply text.

Spec: `docs/superpowers/specs/2026-05-13-sentiment-avatar-design.md`
Plan: `docs/superpowers/plans/2026-05-13-sentiment-avatar.md`

## Test plan
- [x] `tsc --noEmit` clean
- [x] `pnpm build` clean
- [x] Classifier smoke test: love / angry / neutral / empty / html-haha / sweet / sad → expected avatars
- [ ] Manual: positive reply ("I love this, amazing point!") → love/sweet/haha avatar
- [ ] Manual: negative reply ("this is terrible, worst take") → angry/sad avatar
- [ ] Manual: neutral reply → default avatar