### PR TITLE
Add resizable center and related shell columns

### DIFF
--- a/docs/superpowers/plans/2026-05-13-resizable-shell-columns.md
+++ b/docs/superpowers/plans/2026-05-13-resizable-shell-columns.md
@@ -1,0 +1,814 @@
+# Resizable Shell Columns Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three draggable borders that resize the center and related-posts columns. Center column stays pinned to viewport center; nav and related float to its sides. Widths persist to localStorage. Active at `lg+` breakpoint only.
+
+**Architecture:** New `useResizableColumns` hook owns width state + localStorage. New `ResizableDivider` component handles pointer-drag UI. `Shell.tsx` is restructured: existing AppShell is preserved for `<lg` (mobile/tablet); a custom absolute-positioned three-column layout takes over at `lg+`, with the active layout selected via `useMediaQuery`. CSS variables (`--center-w`, `--related-w`, `--nav-w`) drive all positioning math so React only sets values.
+
+**Tech Stack:** Next.js 14 App Router, TypeScript, React 18 (client components), Mantine v7 (`@mantine/hooks` for `useMediaQuery`, `Burger`, `Drawer`), Tabler icons. No test framework — verification is manual via `pnpm dev` and browser.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-resizable-shell-columns-design.md`
+
+**Target branch:** `tarcode2004/enhancement/listy-injection-main-app` (not `dev`).
+
+---
+
+## File Structure
+
+Files this plan creates or modifies:
+
+- **Create:** `src/app/(shell)/useResizableColumns.ts` — width state, localStorage I/O, viewport-clamped bounds.
+- **Create:** `src/app/(shell)/ResizableDivider.tsx` — drag/double-click UI for one border.
+- **Modify:** `src/app/(shell)/Shell.tsx` — add desktop branch with custom layout + dividers; preserve mobile branch (existing AppShell).
+- **Modify:** `src/styles/globals.css` — body background (gutter color) + `overflow-x: hidden`.
+
+No other files are touched.
+
+---
+
+## Constants Used Across Tasks
+
+These values appear in multiple tasks. Treat as canonical:
+
+```ts
+// Bounds
+const CENTER_MIN = 500;
+const CENTER_MAX = 1100;
+const RELATED_MIN = 320;
+const RELATED_MAX = 700;
+
+// localStorage keys
+const LS_CENTER = "stacky:centerWidth";
+const LS_RELATED = "stacky:relatedWidth";
+
+// Breakpoint: Mantine's default lg = 1200px (em-based in Mantine, but useMediaQuery accepts px)
+const LG_QUERY = "(min-width: 1200px)";
+
+// Default related width (resolved at first paint)
+const DEFAULT_RELATED = 460; // mid-point of clamp(360, 26vw, 520) for typical viewport
+
+// Divider hit zone
+const DIVIDER_HIT_WIDTH = 8;   // px
+const DIVIDER_LINE_WIDTH = 1;  // visible line
+const DIVIDER_HOVER_LINE = 3;  // visible line on hover
+const DIVIDER_COLOR = "rgba(0, 0, 0, 0.08)";
+const DIVIDER_HOVER_COLOR = "rgba(0, 0, 0, 0.20)";
+```
+
+---
+
+## Task 1: `useResizableColumns` hook
+
+**Files:**
+- Create: `src/app/(shell)/useResizableColumns.ts`
+
+The hook owns two persisted numbers (`centerWidth`, `relatedWidth`), reads/writes localStorage, enforces bounds (including viewport-derived bound for centerWidth), and survives SSR by returning `undefined` defaults until mount.
+
+- [ ] **Step 1: Create the file with full implementation**
+
+Create `src/app/(shell)/useResizableColumns.ts`:
+
+```ts
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export const CENTER_MIN = 500;
+export const CENTER_MAX = 1100;
+export const RELATED_MIN = 320;
+export const RELATED_MAX = 700;
+export const DEFAULT_RELATED = 460;
+
+const LS_CENTER = "stacky:centerWidth";
+const LS_RELATED = "stacky:relatedWidth";
+
+function readNumber(key: string): number | undefined {
+  if (typeof window === "undefined") return undefined;
+  const raw = window.localStorage.getItem(key);
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}
+
+export type ColumnWidths = {
+  centerWidth: number | undefined;
+  relatedWidth: number | undefined;
+};
+
+export type UseResizableColumns = {
+  widths: ColumnWidths;
+  setCenterWidth: (w: number | undefined, viewportMax?: number) => void;
+  setRelatedWidth: (w: number | undefined) => void;
+};
+
+export function useResizableColumns(): UseResizableColumns {
+  const [centerWidth, setCenterRaw] = useState<number | undefined>(undefined);
+  const [relatedWidth, setRelatedRaw] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    const c = readNumber(LS_CENTER);
+    const r = readNumber(LS_RELATED);
+    if (c !== undefined) setCenterRaw(clamp(c, CENTER_MIN, CENTER_MAX));
+    if (r !== undefined) setRelatedRaw(clamp(r, RELATED_MIN, RELATED_MAX));
+  }, []);
+
+  const setCenterWidth = useCallback((w: number | undefined, viewportMax?: number) => {
+    if (w === undefined) {
+      setCenterRaw(undefined);
+      if (typeof window !== "undefined") window.localStorage.removeItem(LS_CENTER);
+      return;
+    }
+    const hardMax = viewportMax !== undefined ? Math.min(CENTER_MAX, viewportMax) : CENTER_MAX;
+    const clamped = clamp(w, CENTER_MIN, hardMax);
+    setCenterRaw(clamped);
+    if (typeof window !== "undefined") window.localStorage.setItem(LS_CENTER, String(clamped));
+  }, []);
+
+  const setRelatedWidth = useCallback((w: number | undefined) => {
+    if (w === undefined) {
+      setRelatedRaw(undefined);
+      if (typeof window !== "undefined") window.localStorage.removeItem(LS_RELATED);
+      return;
+    }
+    const clamped = clamp(w, RELATED_MIN, RELATED_MAX);
+    setRelatedRaw(clamped);
+    if (typeof window !== "undefined") window.localStorage.setItem(LS_RELATED, String(clamped));
+  }, []);
+
+  return {
+    widths: { centerWidth, relatedWidth },
+    setCenterWidth,
+    setRelatedWidth,
+  };
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no errors related to this file. (Pre-existing errors elsewhere are fine — note them but don't fix.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/\(shell\)/useResizableColumns.ts
+git commit -m "Add useResizableColumns hook for shell column widths"
+```
+
+---
+
+## Task 2: `ResizableDivider` component
+
+**Files:**
+- Create: `src/app/(shell)/ResizableDivider.tsx`
+
+A single vertical divider with pointer-drag. Caller decides what to do with the delta. The component handles pointer capture, body cursor lock, and double-click.
+
+- [ ] **Step 1: Create the file with full implementation**
+
+Create `src/app/(shell)/ResizableDivider.tsx`:
+
+```tsx
+"use client";
+
+import { CSSProperties, PointerEvent as ReactPointerEvent, useCallback, useRef, useState } from "react";
+
+type Props = {
+  onResize: (deltaPx: number) => void;
+  onDoubleClick?: () => void;
+  /** Inline style — caller supplies `left`/`right` for absolute positioning. */
+  style?: CSSProperties;
+  ariaLabel?: string;
+};
+
+const HIT_WIDTH = 8;
+const LINE_WIDTH = 1;
+const LINE_HOVER_WIDTH = 3;
+const LINE_COLOR = "rgba(0, 0, 0, 0.08)";
+const LINE_HOVER_COLOR = "rgba(0, 0, 0, 0.20)";
+
+export function ResizableDivider({ onResize, onDoubleClick, style, ariaLabel }: Props) {
+  const lastClientX = useRef<number | null>(null);
+  const [hovered, setHovered] = useState(false);
+  const [dragging, setDragging] = useState(false);
+
+  const handlePointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
+    lastClientX.current = e.clientX;
+    setDragging(true);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const handlePointerMove = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    if (lastClientX.current === null) return;
+    const delta = e.clientX - lastClientX.current;
+    if (delta !== 0) {
+      lastClientX.current = e.clientX;
+      onResize(delta);
+    }
+  }, [onResize]);
+
+  const handlePointerUp = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    (e.currentTarget as HTMLDivElement).releasePointerCapture(e.pointerId);
+    lastClientX.current = null;
+    setDragging(false);
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  }, []);
+
+  const lineActive = hovered || dragging;
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={ariaLabel}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onDoubleClick={onDoubleClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        width: HIT_WIDTH,
+        marginLeft: -HIT_WIDTH / 2,
+        cursor: "col-resize",
+        touchAction: "none",
+        zIndex: 250,
+        display: "flex",
+        justifyContent: "center",
+        ...style,
+      }}
+    >
+      <div
+        style={{
+          width: lineActive ? LINE_HOVER_WIDTH : LINE_WIDTH,
+          backgroundColor: lineActive ? LINE_HOVER_COLOR : LINE_COLOR,
+          transition: "width 120ms ease, background-color 120ms ease",
+          height: "100%",
+        }}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no new errors from this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/\(shell\)/ResizableDivider.tsx
+git commit -m "Add ResizableDivider component for column borders"
+```
+
+---
+
+## Task 3: Body background + horizontal overflow guard
+
+**Files:**
+- Modify: `src/styles/globals.css`
+
+Add body background (so gutters show the right color) and `overflow-x: hidden` (so transient column expansion past viewport doesn't introduce horizontal scroll).
+
+- [ ] **Step 1: Append to `src/styles/globals.css`**
+
+Append at the end of the file:
+
+```css
+/* Resizable shell columns: body background = gutter color; suppress horizontal scroll. */
+body {
+    background-color: #FCFBF5;
+    overflow-x: hidden;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/styles/globals.css
+git commit -m "Add body background and horizontal overflow guard for shell gutters"
+```
+
+---
+
+## Task 4: Restructure `Shell.tsx` — desktop branch with custom layout
+
+**Files:**
+- Modify: `src/app/(shell)/Shell.tsx`
+
+This is the largest task. We replace the file with one that renders either the existing AppShell layout (below `lg`) or a new custom three-column layout (`lg+`). The branch is chosen via `useMediaQuery`. The mobile branch is identical to the current code; the desktop branch uses absolute positioning and CSS variables.
+
+The full replacement is provided so you can apply it as one edit. Read the current file first to confirm it matches what's documented below.
+
+- [ ] **Step 1: Read the current `Shell.tsx` for sanity check**
+
+Read: `src/app/(shell)/Shell.tsx`
+Confirm the imports and the structure roughly match what was last committed (RelatedStacksProvider, AppShell with Header/Navbar/Aside/Main, Drawer, HoverTooltip, Burger). If the file has changed materially since this plan was written, surface the diff and stop.
+
+- [ ] **Step 2: Replace the entire file with the new version**
+
+Write `src/app/(shell)/Shell.tsx`:
+
+```tsx
+"use client";
+
+import { AppShell, Burger, Drawer, Group } from "@mantine/core";
+import { useDisclosure, useMediaQuery } from "@mantine/hooks";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Navbar } from "../../components/NavBar/Navbar";
+import StackLogo from "../../utils/StackLogo";
+import { HoverTooltip } from "../../components/HoverTooltip";
+import { RelatedStacksProvider } from "./related-stacks-context";
+import { ResizableDivider } from "./ResizableDivider";
+import {
+    CENTER_MAX,
+    CENTER_MIN,
+    DEFAULT_RELATED,
+    RELATED_MAX,
+    RELATED_MIN,
+    useResizableColumns,
+} from "./useResizableColumns";
+
+const LG_QUERY = "(min-width: 1200px)";
+
+export default function Shell({ children, aside }: { children: React.ReactNode; aside: React.ReactNode }) {
+    const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] = useDisclosure();
+    const [navCollapsed, { toggle: toggleNav }] = useDisclosure(false);
+
+    // useMediaQuery returns `undefined` on SSR and first client render; treat as "not lg" to keep
+    // the AppShell mobile layout during hydration. After mount it resolves to true/false.
+    const isDesktop = useMediaQuery(LG_QUERY) ?? false;
+
+    return (
+        <RelatedStacksProvider>
+            {isDesktop ? (
+                <DesktopShell
+                    aside={aside}
+                    navCollapsed={navCollapsed}
+                    toggleNav={toggleNav}
+                    drawerOpened={drawerOpened}
+                    closeDrawer={closeDrawer}
+                >
+                    {children}
+                </DesktopShell>
+            ) : (
+                <MobileShell
+                    aside={aside}
+                    drawerOpened={drawerOpened}
+                    toggleDrawer={toggleDrawer}
+                    closeDrawer={closeDrawer}
+                    navCollapsed={navCollapsed}
+                    toggleNav={toggleNav}
+                >
+                    {children}
+                </MobileShell>
+            )}
+            <HoverTooltip />
+        </RelatedStacksProvider>
+    );
+}
+
+/* ---------- Mobile / tablet branch: unchanged AppShell behavior ---------- */
+
+function MobileShell({
+    children,
+    aside,
+    drawerOpened,
+    toggleDrawer,
+    closeDrawer,
+    navCollapsed,
+    toggleNav,
+}: {
+    children: React.ReactNode;
+    aside: React.ReactNode;
+    drawerOpened: boolean;
+    toggleDrawer: () => void;
+    closeDrawer: () => void;
+    navCollapsed: boolean;
+    toggleNav: () => void;
+}) {
+    return (
+        <>
+            <AppShell
+                header={{ height: { base: 64, sm: 0 } }}
+                navbar={{
+                    width: navCollapsed ? 0 : "clamp(200px, 22vw, 300px)",
+                    breakpoint: "sm",
+                    collapsed: { mobile: !drawerOpened, desktop: navCollapsed },
+                }}
+                aside={{
+                    width: navCollapsed ? "clamp(400px, 32vw, 600px)" : "clamp(360px, 26vw, 520px)",
+                    breakpoint: "lg",
+                    collapsed: { mobile: true },
+                }}
+                padding="md"
+            >
+                <AppShell.Header hiddenFrom="sm" bg="#FCFBF5">
+                    <Group h="100%" px="md">
+                        <Burger opened={drawerOpened} onClick={toggleDrawer} hiddenFrom="sm" size="sm" />
+                        <StackLogo size={30} />
+                    </Group>
+                </AppShell.Header>
+                <AppShell.Navbar
+                    p="md"
+                    visibleFrom="sm"
+                    style={{
+                        backgroundColor: "#FCFBF5",
+                        overflow: "hidden",
+                        opacity: navCollapsed ? 0 : 1,
+                        transition: "opacity 200ms ease",
+                    }}
+                >
+                    <Navbar />
+                </AppShell.Navbar>
+                <AppShell.Aside
+                    p="md"
+                    pt="0"
+                    withBorder
+                    style={{
+                        background: "#FCFBF5",
+                        overflowY: "auto",
+                        overscrollBehavior: "contain",
+                        scrollbarWidth: "none",
+                    }}
+                >
+                    {aside ?? null}
+                </AppShell.Aside>
+                <Drawer
+                    opened={drawerOpened}
+                    onClose={closeDrawer}
+                    padding="md"
+                    size="xs"
+                    styles={{
+                        content: { backgroundColor: "#FCFBF5" },
+                        header: { backgroundColor: "#FCFBF5" },
+                    }}
+                    lockScroll={false}
+                >
+                    <Navbar />
+                </Drawer>
+                <AppShell.Main miw={500}>{children}</AppShell.Main>
+            </AppShell>
+            <Burger
+                opened={!navCollapsed}
+                onClick={toggleNav}
+                visibleFrom="sm"
+                size="sm"
+                aria-label={navCollapsed ? "Expand navigation" : "Collapse navigation"}
+                style={{
+                    position: "fixed",
+                    left: navCollapsed ? 16 : "calc(clamp(200px, 22vw, 300px) - 42px)",
+                    top: 16,
+                    zIndex: 300,
+                    transition: "left 200ms ease",
+                }}
+            />
+        </>
+    );
+}
+
+/* ---------- Desktop branch: custom three-column layout with resizable borders ---------- */
+
+function DesktopShell({
+    children,
+    aside,
+    navCollapsed,
+    toggleNav,
+    drawerOpened,
+    closeDrawer,
+}: {
+    children: React.ReactNode;
+    aside: React.ReactNode;
+    navCollapsed: boolean;
+    toggleNav: () => void;
+    drawerOpened: boolean;
+    closeDrawer: () => void;
+}) {
+    const { widths, setCenterWidth, setRelatedWidth } = useResizableColumns();
+
+    // Resolve actual nav width by measuring the rendered nav element (clamp(200px, 22vw, 300px)).
+    const navRef = useRef<HTMLDivElement | null>(null);
+    const [navW, setNavW] = useState<number>(260); // fallback before measurement
+    useLayoutEffect(() => {
+        const el = navRef.current;
+        if (!el) return;
+        const measure = () => {
+            const w = el.getBoundingClientRect().width;
+            if (w > 0) setNavW(w);
+        };
+        measure();
+        const ro = new ResizeObserver(measure);
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, []);
+
+    // Viewport width for clamping centerWidth.
+    const [viewportW, setViewportW] = useState<number>(() =>
+        typeof window === "undefined" ? 1440 : window.innerWidth
+    );
+    useEffect(() => {
+        const onResize = () => setViewportW(window.innerWidth);
+        window.addEventListener("resize", onResize);
+        return () => window.removeEventListener("resize", onResize);
+    }, []);
+
+    // Effective values used for layout (defaults applied when state is undefined).
+    const effectiveNavW = navCollapsed ? 0 : navW;
+    const effectiveRelatedW = widths.relatedWidth ?? DEFAULT_RELATED;
+    const viewportCenterMax = viewportW - 2 * Math.max(effectiveNavW, effectiveRelatedW);
+    const defaultCenter = Math.max(
+        CENTER_MIN,
+        Math.min(900, viewportCenterMax > 0 ? viewportCenterMax : 900)
+    );
+    const effectiveCenterW = Math.max(
+        CENTER_MIN,
+        Math.min(
+            widths.centerWidth ?? defaultCenter,
+            Math.min(CENTER_MAX, viewportCenterMax > 0 ? viewportCenterMax : CENTER_MAX)
+        )
+    );
+
+    // Handlers: borders B/C resize center symmetrically; border D resizes related.
+    const onBorderB = (delta: number) => {
+        setCenterWidth(effectiveCenterW - 2 * delta, viewportCenterMax);
+    };
+    const onBorderC = (delta: number) => {
+        setCenterWidth(effectiveCenterW + 2 * delta, viewportCenterMax);
+    };
+    const onBorderD = (delta: number) => {
+        setRelatedWidth(effectiveRelatedW + delta);
+    };
+
+    const resetCenter = () => setCenterWidth(undefined);
+    const resetRelated = () => setRelatedWidth(undefined);
+
+    // Position formulas (in viewport coordinates). Using calc() with CSS vars lets the browser
+    // do the math on each frame without React re-rendering the columns.
+    const wrapperStyle = useMemo(
+        () =>
+            ({
+                "--center-w": `${effectiveCenterW}px`,
+                "--related-w": `${effectiveRelatedW}px`,
+                "--nav-w": `${effectiveNavW}px`,
+            }) as React.CSSProperties,
+        [effectiveCenterW, effectiveRelatedW, effectiveNavW]
+    );
+
+    return (
+        <div style={{ ...wrapperStyle, position: "relative", minHeight: "100vh" }}>
+            {/* Nav column (anchored to left edge of center column) */}
+            <div
+                ref={navRef}
+                style={{
+                    position: "fixed",
+                    top: 0,
+                    bottom: 0,
+                    left: "calc(50vw - var(--center-w) / 2 - var(--nav-w))",
+                    width: "clamp(200px, 22vw, 300px)",
+                    backgroundColor: "#FCFBF5",
+                    padding: 16,
+                    overflow: "hidden",
+                    opacity: navCollapsed ? 0 : 1,
+                    pointerEvents: navCollapsed ? "none" : "auto",
+                    transition: "opacity 200ms ease",
+                    zIndex: 100,
+                }}
+            >
+                <Navbar />
+            </div>
+
+            {/* Center column (flow content) */}
+            <div
+                style={{
+                    position: "relative",
+                    marginLeft: "calc(50vw - var(--center-w) / 2)",
+                    width: "var(--center-w)",
+                    minWidth: CENTER_MIN,
+                    padding: 16,
+                    minHeight: "100vh",
+                }}
+            >
+                {children}
+            </div>
+
+            {/* Related column (anchored to right edge of center column) */}
+            <div
+                style={{
+                    position: "fixed",
+                    top: 0,
+                    bottom: 0,
+                    left: "calc(50vw + var(--center-w) / 2)",
+                    width: "var(--related-w)",
+                    backgroundColor: "#FCFBF5",
+                    borderLeft: "1px solid rgba(0,0,0,0.08)",
+                    overflowY: "auto",
+                    overscrollBehavior: "contain",
+                    scrollbarWidth: "none",
+                    padding: 16,
+                    paddingTop: 0,
+                    zIndex: 100,
+                }}
+            >
+                {aside ?? null}
+            </div>
+
+            {/* Border B: left edge of center column */}
+            <ResizableDivider
+                ariaLabel="Resize center column (left edge)"
+                onResize={onBorderB}
+                onDoubleClick={resetCenter}
+                style={{ left: "calc(50vw - var(--center-w) / 2)", position: "fixed" }}
+            />
+
+            {/* Border C: right edge of center column */}
+            <ResizableDivider
+                ariaLabel="Resize center column (right edge)"
+                onResize={onBorderC}
+                onDoubleClick={resetCenter}
+                style={{ left: "calc(50vw + var(--center-w) / 2)", position: "fixed" }}
+            />
+
+            {/* Border D: right edge of related column */}
+            <ResizableDivider
+                ariaLabel="Resize related column"
+                onResize={onBorderD}
+                onDoubleClick={resetRelated}
+                style={{ left: "calc(50vw + var(--center-w) / 2 + var(--related-w))", position: "fixed" }}
+            />
+
+            {/* Burger for nav collapse */}
+            <Burger
+                opened={!navCollapsed}
+                onClick={toggleNav}
+                size="sm"
+                aria-label={navCollapsed ? "Expand navigation" : "Collapse navigation"}
+                style={{
+                    position: "fixed",
+                    left: navCollapsed
+                        ? 16
+                        : "calc(50vw - var(--center-w) / 2 - var(--nav-w) + 16px)",
+                    top: 16,
+                    zIndex: 300,
+                    transition: "left 200ms ease",
+                }}
+            />
+
+            {/* Mobile drawer not used at lg+, but kept here in case user shrinks window mid-session */}
+            <Drawer
+                opened={drawerOpened}
+                onClose={closeDrawer}
+                padding="md"
+                size="xs"
+                styles={{
+                    content: { backgroundColor: "#FCFBF5" },
+                    header: { backgroundColor: "#FCFBF5" },
+                }}
+                lockScroll={false}
+            >
+                <Navbar />
+            </Drawer>
+        </div>
+    );
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no new errors. If `tsc` complains about missing types from `@mantine/hooks` for `useMediaQuery` or `useDisclosure`, confirm `@mantine/hooks` is in `package.json` (it should be).
+
+- [ ] **Step 4: Start the dev server**
+
+Run: `pnpm dev`
+Expected: Next.js starts on `http://localhost:3000` without errors.
+
+- [ ] **Step 5: Manual verification in a browser ≥ 1200px wide**
+
+Open `http://localhost:3000`. Sign in if needed and navigate to `/home`. Confirm:
+
+1. **Layout looks correct:** nav on left, center column in the middle of the viewport, related column on right, gutters on both sides.
+2. **Center is centered:** the horizontal midpoint of the center column matches the viewport's horizontal midpoint (use the browser ruler or eyeball it against the URL bar).
+3. **Border B (left edge of center) drags:** hover over the line between nav and center — cursor becomes `col-resize`, line thickens. Drag right — center shrinks symmetrically (you see related slide left too). Drag left — center grows symmetrically (related slides right).
+4. **Border C (right edge of center) drags:** same as above, mirrored. Dragging right grows center; dragging left shrinks it.
+5. **Border D (right edge of related) drags:** drag right — related grows. Drag left — related shrinks.
+6. **Min/max bounds:** keep dragging in one direction; the column stops at its limit (center: 500–1100, related: 320–700).
+7. **Double-click any divider:** that column resets to default.
+8. **Reload the page:** non-default widths persist.
+9. **Burger toggle:** click the burger at top-left; navbar fades and slides out, `--nav-w` becomes 0, center stays centered.
+
+- [ ] **Step 6: Manual verification at < 1200px (mobile/tablet)**
+
+Resize the browser to ~1100px wide.
+
+1. **Layout switches:** the custom desktop layout disappears; the original AppShell layout takes over (navbar at left, no related aside, no resize affordance).
+2. **No console errors during the transition.**
+3. **Below ~768px (sm):** mobile header with burger and logo appears; aside is hidden; clicking burger opens drawer with nav.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/\(shell\)/Shell.tsx
+git commit -m "Add desktop custom three-column layout with resizable borders"
+```
+
+---
+
+## Task 5: Verify against the spec's manual test checklist
+
+This is a final sweep against the spec's `Testing (manual)` section to catch anything missed.
+
+- [ ] **Step 1: Open `docs/superpowers/specs/2026-05-13-resizable-shell-columns-design.md`, find the Testing section, and run each numbered item against the dev server.**
+
+The spec has 10 checks. Confirm each one. Pay special attention to:
+- **#4:** center midpoint stays on viewport center across all drags.
+- **#7:** narrow the viewport to a point where the saved center width no longer fits — center should clamp down. Widen again — center should grow back to its saved value.
+- **#9:** burger collapse with various saved center widths — no jank.
+
+- [ ] **Step 2: If any check fails, fix the underlying issue in `Shell.tsx` or the hook. Commit each fix as a separate commit referencing what was broken.**
+
+- [ ] **Step 3: Stop the dev server (Ctrl-C).**
+
+---
+
+## Task 6: Open PR against the listy-injection-main-app branch
+
+**Note:** The user's branching convention (per `CLAUDE.md` and `.claude/rules/`) targets the team's collaborative feature branch, not `dev`.
+
+- [ ] **Step 1: Confirm branch state is clean**
+
+Run: `git status`
+Expected: working tree clean.
+
+Run: `git log --oneline tarcode2004/enhancement/listy-injection-main-app..HEAD`
+Expected: lists the commits added by this plan (5–6 commits).
+
+- [ ] **Step 2: Push the branch**
+
+Run: `git push -u origin claude/suspicious-bhabha-7d24ed`
+Expected: branch pushed.
+
+- [ ] **Step 3: Open the PR with `gh`**
+
+The repo follows `Closes #<number>` convention, but no issue is associated with this work yet — omit that footer or ask the user before opening if they want an issue number.
+
+Run:
+```bash
+gh pr create \
+  --base tarcode2004/enhancement/listy-injection-main-app \
+  --title "Add resizable center and related shell columns" \
+  --body "$(cat <<'EOF'
+## Summary
+- Center column is now pinned to viewport center; nav and related float to its sides.
+- Three draggable borders: left and right of center (symmetric, both adjust centerWidth) and right of related (adjusts relatedWidth).
+- Widths persist in localStorage. Double-click a divider to reset that column.
+- Active at `lg+` (≥1200px). Below `lg`, the existing AppShell mobile/tablet layout is preserved unchanged.
+
+## Spec
+docs/superpowers/specs/2026-05-13-resizable-shell-columns-design.md
+
+## Plan
+docs/superpowers/plans/2026-05-13-resizable-shell-columns.md
+
+## Test plan
+- [ ] Center column visually centered on viewport at ≥1200px
+- [ ] All three borders show col-resize cursor on hover
+- [ ] Border B (left of center) and Border C (right of center) both resize center symmetrically; opposite border mirrors in real time
+- [ ] Border D resizes related independently
+- [ ] Min/max bounds enforced (center: 500–1100, related: 320–700)
+- [ ] Widths persist across reload
+- [ ] Double-click resets that column to default
+- [ ] Burger collapse still works (nav slides out; center stays centered)
+- [ ] Below 1200px reverts to original AppShell layout
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 4: Share the PR URL with the user.**
+
+---
+
+## Self-review notes (for the implementer)
+
+This plan was self-reviewed before publication:
+
+- **Spec coverage:** All 7 goals in the spec map to tasks 1–4. Both bounds (static and viewport-derived) are enforced in Task 1 + Task 4. Drag geometry (symmetric for center) is implemented in Task 4 (`onBorderB`/`onBorderC` apply `±2*delta`).
+- **Placeholders:** none — every code step has full code.
+- **Type consistency:** `useResizableColumns` exports `CENTER_MIN/MAX`, `RELATED_MIN/MAX`, `DEFAULT_RELATED`. Task 4 imports those exact names. The hook returns `widths` (object with `centerWidth`/`relatedWidth`) and Task 4 destructures it with those names.
+- **Known soft spot:** the viewport-derived center bound depends on `navW` which is measured asynchronously via `ResizeObserver`. On the first paint, `navW = 260` (fallback) — the real measurement may shift bounds slightly. This is acceptable for an initial implementation; tighten only if it causes visible jumps.

--- a/docs/superpowers/specs/2026-05-13-resizable-shell-columns-design.md
+++ b/docs/superpowers/specs/2026-05-13-resizable-shell-columns-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-13
 **Target branch:** `tarcode2004/enhancement/listy-injection-main-app`
-**Scope:** Make the center and related-posts columns horizontally resizable via draggable borders. Wrap the shell in a centered, max-width container with viewport-edge gutters (Twitter/X style).
+**Scope:** Make the center and related-posts columns horizontally resizable via draggable borders. The center column is anchored to viewport center; nav and related float to its sides.
 
 ## Problem
 
@@ -10,11 +10,13 @@ The current `Shell` layout uses Mantine's `AppShell` with hard-coded `clamp()` w
 
 ## Goals
 
-1. Users can drag two vertical borders to set the **center column** and **related-posts column** widths independently.
-2. Chosen widths persist across sessions (localStorage).
-3. The whole UI sits in a centered max-width container, with the viewport background visible as gutters on either side.
-4. The navbar (left column) width is **not** affected by either drag.
-5. No resize affordance on mobile/narrow screens (matches existing aside mobile-collapse behavior).
+1. Users can drag three vertical borders to set the **center column** and **related-posts column** widths.
+2. The **center column is always centered on the viewport**. Nav floats to its left; related floats to its right. Resizing center moves nav and related accordingly.
+3. Both borders of the center column (left and right edges) symmetrically control `centerWidth`. Dragging either one resizes center; the opposite edge mirrors automatically.
+4. The right (outer) edge of the related column controls `relatedWidth`.
+5. Chosen widths persist across sessions (localStorage).
+6. The navbar width is **not** changed by any drag (its existing `clamp()` + burger-collapse behavior is preserved).
+7. No resize affordance on mobile/narrow screens.
 
 ## Non-goals
 
@@ -22,44 +24,63 @@ The current `Shell` layout uses Mantine's `AppShell` with hard-coded `clamp()` w
 - Vertical resizing.
 - Touch-drag resizing (covered by "no mobile resize").
 - Per-route width overrides (a single global pair persists across all shell routes).
+- Centering the **whole layout** (nav + center + related) on the viewport. Only the center column is centered.
+- Allowing center column to slide off-center (no left-anchored or right-anchored variant).
 
 ## Layout
 
-After the change, the shell renders inside a centered container:
+The center column is pinned to viewport center. Nav and related are positioned relative to it. The "gutters" (visible viewport background) are whatever space remains on either side after nav and related are placed:
 
 ```
 viewport
-┌──────────────────────────────────────────────────────────────┐
-│ gutter ┌──────────────────────────────────────────┐ gutter   │
-│        │ nav (fixed)   │ center   │ related      │           │
-│        │               ║          ║              │           │
-│        │               ║          ║              │           │
-│        └──────────────────────────────────────────┘           │
-└──────────────────────────────────────────────────────────────┘
-                        ↑ container (max-width ~1600px, centered)
-                        ║ = draggable border
+┌────────────────────────────────────────────────────────────────────┐
+│                              viewport.center                       │
+│                                  ↓                                 │
+│  gutter   ┃ nav  ║  center column  ║  related  ┃  gutter           │
+│           ┃      ║                 ║           ┃                   │
+│           ┃ navW ║     centerW     ║  relatedW ┃                   │
+│           ║      ║                 ║           ┃                   │
+│           A      B                 C           D                   │
+│                                                                    │
+│   A = border between gutter and nav (NOT draggable — nav fixed)    │
+│   B = LEFT BORDER of center (draggable → changes centerW symmetric)│
+│   C = RIGHT BORDER of center (draggable → changes centerW symmetric)│
+│   D = RIGHT BORDER of related (draggable → changes relatedW)       │
 ```
 
-- **Container:** width is **the sum of nav + center + related widths**, capped at a max (~1900px = sum of all maxes). `margin: 0 auto` centers it. Background outside the container shows through (page/body background = the gutter color). The container does not have empty space inside it — it fits its content exactly.
-- **Navbar:** unchanged. Existing `clamp(200px, 22vw, 300px)` and burger-collapse behavior preserved. Width is read at runtime (via ref) to compute container width.
-- **Center column:** width is determined by `centerWidth` state. Because the container width = sum of all three columns, and the aside is explicitly sized, AppShell.Main flex-fills to exactly `centerWidth` without needing a direct width assignment.
-- **Related column:** width = `relatedWidth` from state (default: current `clamp(360px, 26vw, 520px)` baseline value, resolved to a number on first render).
+**Position formulas (in viewport coordinates):**
+
+- `center.left   = viewport.center - centerW / 2`
+- `center.right  = viewport.center + centerW / 2`
+- `nav.right     = center.left`            (nav anchored to center.left)
+- `nav.left      = center.left - navW`
+- `related.left  = center.right`           (related anchored to center.right)
+- `related.right = center.right + relatedW`
+
+**Column behavior:**
+
+- **Navbar:** unchanged width (`clamp(200px, 22vw, 300px)` + burger collapse). Position floats with `center.left`. Width is read at runtime via ref so layout calculations have a number.
+- **Center column:** width = `centerWidth` from state. Always horizontally centered on the viewport. Default value (no saved width): `min(900, viewport - 2 * max(navW, relatedW))` on first paint, clamped to the viewport-derived bound (see Edge Cases).
+- **Related column:** width = `relatedWidth` from state. Default: current baseline `clamp(360px, 26vw, 520px)` resolved to a number.
+- **Gutters:** whatever space remains on either side of the layout. Because `navW` and `relatedW` can differ, the overall layout may sit slightly off-center relative to the viewport even though the center column is perfectly centered. This is intentional — "center column centered" is the contract, not "whole layout centered".
 
 ### Bounds
 
-- `centerWidth`: `min 500px`, `max 900px` (tunable). Existing `AppShell.Main miw={500}` is the hard floor.
+- `centerWidth`: `min 500px`, `max 1100px` (tunable). Existing `AppShell.Main miw={500}` is the hard floor.
 - `relatedWidth`: `min 320px`, `max 700px` (tunable).
+- **Viewport-derived upper bound for centerWidth:** because center is centered, `centerW/2 + max(navW, relatedW)` must fit inside viewport/2. So `centerW ≤ viewport - 2 * max(navW, relatedW)`. Enforced live during drag and on viewport resize.
 
-These bounds are enforced during drag — the divider stops at the limit. No collapsing past minimum.
+These bounds are enforced during drag — the border stops at the limit. No collapsing past minimum.
 
 ## Draggable Borders
 
-Two `<ResizableDivider>` instances:
+Three `<ResizableDivider>` instances. Borders B and C share state — they both edit `centerWidth` symmetrically, so dragging one moves the other in real time:
 
-- **Divider 1 (nav ↔ center):** drag changes `centerWidth`. Drag right → center grows; drag left → center shrinks.
-- **Divider 2 (center ↔ related):** drag changes `relatedWidth`. Drag right → related shrinks; drag left → related grows.
+- **Border B (left edge of center):** drag right by Δ → `centerWidth` shrinks by `2Δ`. Drag left by Δ → `centerWidth` grows by `2Δ`. Border B tracks cursor exactly.
+- **Border C (right edge of center):** drag right by Δ → `centerWidth` grows by `2Δ`. Drag left by Δ → `centerWidth` shrinks by `2Δ`. Border C tracks cursor exactly.
+- **Border D (right edge of related):** drag right by Δ → `relatedWidth` grows by Δ. Drag left by Δ → `relatedWidth` shrinks by Δ. Border D tracks cursor exactly.
 
-`centerWidth` and `relatedWidth` are independent values. Moving one divider does not change the other column's width — instead, the container's total width changes (it grows or shrinks to fit), and the gutters on either side absorb the difference (gutters shrink when columns grow, grow when columns shrink).
+`centerWidth` and `relatedWidth` are two independent persisted values; borders B and C are two handles on the same value.
 
 ### Hover / interaction
 
@@ -67,18 +88,18 @@ Two `<ResizableDivider>` instances:
 - Cursor: `col-resize` on hover.
 - Visual cue on hover: the 1px border line thickens to 3px and shifts to a slightly darker tone (~`#D6D2C0` against the `#FCFBF5` shell background).
 - During drag: body cursor locked to `col-resize`; user-select disabled to prevent text selection.
-- **Double-click resets** that column to its default width (`undefined` in state → falls back to default).
+- **Double-click resets** that column to its default width (`undefined` in state → falls back to default). Double-clicking B or C resets `centerWidth`; double-clicking D resets `relatedWidth`.
 
-### Drag geometry (known trade-off)
+### Drag geometry (resolved)
 
-Because the container is **centered** and **fits content** (its width = sum of column widths), when a column grows, the container also grows, and both gutters shrink equally. This means:
+Because the center column is **anchored to viewport center**, both edges move symmetrically when `centerWidth` changes. This means dragging border B by Δ shifts `center.left` by Δ (since `center.left = viewport.center - centerW/2`, so a Δ-pixel cursor move corresponds to a `centerW` change of `2Δ`, which moves `center.left` by exactly Δ). The border tracks the cursor perfectly — no drift.
 
-- Drag divider 1 right by Δ → `centerWidth` grows by Δ → container grows by Δ → left gutter shrinks by Δ/2 → divider 1 (at `containerLeft + navW`) moves right by only Δ/2 in viewport coords.
-- The divider visually lags the cursor at half-speed.
+Border D is on the outer edge of related and only affects `relatedWidth`, so it also tracks cursor 1:1.
 
-This is a known visual quirk of pairing centered layout with content-fit sizing. Implementation uses simple delta-based dragging (`centerWidth += cursorDelta`) and accepts the drift. The end-state position is what the user cares about — they'll release when the column looks right.
-
-Alternative (deferred): pin the container's left edge during drag, snap back to centered on `pointerup`. More complex; only worth implementing if the drift feels bad in practice.
+Side effects of resizing center:
+- When center grows (border B left or border C right), nav slides left and related slides right (they're anchored to center's edges). Their widths don't change.
+- When center shrinks, nav slides right and related slides left.
+- This is the intended behavior — keeps center anchored visually.
 
 ### Responsive behavior
 
@@ -103,7 +124,7 @@ function useResizableColumns(): {
 ```
 
 - On mount: read `stacky:centerWidth` and `stacky:relatedWidth` from `localStorage`. Parse as numbers; if missing or out of bounds, set to `undefined` (default).
-- On `setCenterWidth(n)`: clamp to `[500, 900]`, write to localStorage, update state.
+- On `setCenterWidth(n)`: clamp to `[500, 1100]` AND to viewport-derived max, write to localStorage, update state.
 - On `setRelatedWidth(n)`: clamp to `[320, 700]`, write to localStorage, update state.
 - On `setX(undefined)`: remove the key from localStorage (used by double-click reset).
 - SSR-safe: read inside `useEffect` so the initial render matches server output, then hydrate.
@@ -114,77 +135,99 @@ function useResizableColumns(): {
 
 ```tsx
 type Props = {
-  onResize: (deltaPx: number) => void;
+  onResize: (deltaPx: number) => void;     // called with cursor delta per frame
   onDoubleClick: () => void;
-  style?: React.CSSProperties;
+  style?: React.CSSProperties;             // for absolute positioning
 };
 ```
 
-- Renders a 8px-wide vertical `<div>` with the 1px border line centered.
+- Renders an 8px-wide vertical `<div>` (full viewport height) with the 1px border line centered.
 - `onPointerDown`: capture pointer, record initial clientX, set `body { cursor: col-resize; user-select: none }`.
 - `onPointerMove` (while captured): call `onResize(currentClientX - lastClientX)`; update lastClientX.
 - `onPointerUp`/`onPointerCancel`: release capture, restore body styles.
 - `onDoubleClick`: forward to prop.
-- Below `lg` breakpoint: `display: none` (Mantine `visibleFrom="lg"` or CSS media query).
+- Below `lg` breakpoint: `display: none` (CSS media query).
+
+The caller maps the raw `deltaPx` to a width change. Borders B and C call `setCenterWidth(prev => prev + sign * 2 * delta)` (where `sign` is `-1` for B and `+1` for C). Border D calls `setRelatedWidth(prev => prev + delta)`.
 
 ### Modified: `Shell.tsx`
 
-- Wrap the entire `<AppShell>` (and the burger trigger) in a centered container `<div style={{ width: navW + centerW + relatedW, maxWidth: 1900, margin: '0 auto', position: 'relative', height: '100vh' }}>`. Container width is computed from current widths; max-width caps it at the sum of all maxes.
-- Body/global CSS gets a background color so the gutter outside the container is visible.
-- Use `useResizableColumns()` to read widths.
-- Use a ref on the navbar element to read its current rendered width (since `clamp(200px, 22vw, 300px)` varies with viewport). Update on `ResizeObserver`.
-- Replace `AppShell` `aside.width` with `widths.relatedWidth ?? defaultRelatedWidth`.
-- Do **not** explicitly set Main's width. Because the container is sized exactly to fit all three columns and Aside is explicit, Main flex-fills to exactly `centerWidth`.
-- Render two `<ResizableDivider>` instances as absolutely-positioned overlays at the column boundaries (positioned at `left = navW` and `left = navW + centerW`).
+The center column must be anchored to viewport center, which AppShell's built-in grid layout doesn't support. We restructure Shell.tsx into two branches based on breakpoint:
+
+- **Below `lg`:** existing AppShell behavior is preserved (mobile header, burger drawer). No resize affordance. The mobile/tablet experience does not change.
+- **At `lg` and above:** a custom three-column layout replaces the AppShell internals. The mobile Header and Drawer components (currently inside AppShell) are extracted so they can be rendered alongside the new desktop layout without depending on AppShell.
+
+Desktop layout structure (lg+):
+
+- Outer wrapper element with CSS custom properties for widths: `style={{ '--center-w': centerW + 'px', '--related-w': relatedW + 'px', '--nav-w': navW + 'px' }}`. The `--nav-w` value is read from a `ResizeObserver` on the rendered nav element (since `clamp(200px, 22vw, 300px)` depends on viewport).
+- Three absolutely-positioned column containers, each `top: 0; bottom: 0`:
+  - Nav: `left: calc(50vw - var(--center-w) / 2 - var(--nav-w)); width: var(--nav-w)`
+  - Center: `left: calc(50vw - var(--center-w) / 2); width: var(--center-w)`
+  - Related: `left: calc(50vw + var(--center-w) / 2); width: var(--related-w)`
+- Three `<ResizableDivider>` overlays positioned via `left: calc(...)` with z-index above the columns:
+  - Border B at `calc(50vw - var(--center-w) / 2 - 4px)` (center.left)
+  - Border C at `calc(50vw + var(--center-w) / 2 - 4px)` (center.right)
+  - Border D at `calc(50vw + var(--center-w) / 2 + var(--related-w) - 4px)` (related.right)
+
+React's job is to set CSS variables and render the column content. CSS handles all positioning math. Width changes only re-set vars — no React re-layout, just a smooth CSS update.
+
+The existing burger button + Drawer (for mobile nav) and the navbar collapse logic still apply at lg+ as well (the same nav can be collapsed via burger). When collapsed, `--nav-w` becomes 0 and the nav element is hidden; center stays centered.
 
 ### Modified: `globals.css` (or equivalent root CSS)
 
-- Set body background to gutter color (the existing `#FCFBF5` cream or a slightly different tone — see open question Q1 below).
+- Set body background to gutter color (`#FCFBF5` to match the shell). Add `overflow-x: hidden` to avoid horizontal scroll if columns briefly exceed viewport.
 
 ## Data Flow
 
 ```
-localStorage  ←→  useResizableColumns hook  →  Shell.tsx
-                                                ├─ Container width (= navW + centerW + relatedW)
-                                                ├─ AppShell.Aside width = relatedW
-                                                ├─ AppShell.Main flex-fills → resolves to centerW
-                                                └─ ResizableDivider × 2
-                                                    └─ onResize → setCenterWidth / setRelatedWidth
+localStorage  ←→  useResizableColumns hook  →  Shell.tsx (desktop wrapper)
+                                                ├─ CSS var --center-w
+                                                ├─ CSS var --related-w
+                                                ├─ CSS var --nav-w (from ResizeObserver)
+                                                └─ ResizableDivider × 3
+                                                    ├─ Border B  → setCenterWidth(prev => prev - 2*Δ)
+                                                    ├─ Border C  → setCenterWidth(prev => prev + 2*Δ)
+                                                    └─ Border D  → setRelatedWidth(prev => prev + Δ)
 ```
 
-No new context provider needed — the hook is called once in `Shell.tsx` and the values flow down by props/inline style. Other components don't need to know widths changed.
+No new context provider needed — the hook is called once in `Shell.tsx` and the values flow down by CSS variables and props. Other components don't need to know widths changed.
 
 ## Edge Cases
 
-- **First render before localStorage hydrated:** widths are `undefined`, columns fall back to current defaults. After hydration, widths update; if a saved value differs from the default, columns visibly shift once. This is acceptable for an enhancement of this kind, but to minimize flash, the hook returns defaults during the SSR/initial render and switches on `useEffect`.
-- **Narrowing the viewport below the sum of column widths:** if `navW + centerW + relatedW > viewportWidth`, container overflows the viewport horizontally. Mitigation: the body has `overflow-x: hidden` and the user can resize back, or double-click to reset. We accept this edge case — alternative is to dynamically shrink columns on resize, which complicates the model.
-- **Nav collapsed via burger:** when `navCollapsed === true`, the navbar width is 0. The left divider's position must update accordingly. Solution: divider positions are computed from current navbar width (0 or clamped value).
-- **Below `lg` breakpoint:** dividers hidden; widths still saved but unused. When user resizes back up to `lg+`, saved widths apply.
+- **First render before localStorage hydrated:** widths are `undefined`, columns fall back to defaults. The hook returns defaults on the initial SSR/client render and updates on `useEffect`. If saved values differ from defaults, columns visibly shift once on hydration.
+- **Viewport too narrow for current center + sides:** if `centerW/2 + max(navW, relatedW) > viewport/2`, the wider side (nav or related) would extend past the viewport edge. On viewport resize, the hook clamps `centerWidth` down to the viewport-derived maximum (`viewport - 2 * max(navW, relatedW)`). On the way back up, saved values are restored if they fit.
+- **Nav collapsed via burger:** when `navCollapsed === true`, navW is 0. Center stays centered; only the left gutter grows. Border B sits at `viewport.center - centerW/2` (still the left edge of center).
+- **Asymmetric gutters:** because `navW` and `relatedW` differ, the left gutter (`= center.left - navW`) and right gutter (`= viewport.width - related.right`) are not equal. This is intentional — center is centered, the rest falls where it falls.
+- **Below `lg` breakpoint:** dividers hidden; existing AppShell mobile behavior takes over. Saved widths are not applied. When user resizes back up to `lg+`, saved widths apply.
 
 ## Testing (manual)
 
 No automated test framework is configured. Manual verification checklist:
 
-1. Drag right divider — related column resizes; center stays the same width; widths persist after reload.
-2. Drag left divider — center column resizes; related stays the same width; widths persist.
-3. Double-click each divider — column resets to default; localStorage key removed.
-4. Drag past min/max — divider stops at the bound.
-5. Narrow viewport below `lg` (≈1200px) — dividers disappear; layout reverts to mobile-aware AppShell behavior.
-6. Toggle navbar collapse (burger) — left divider repositions correctly; resizing still works.
-7. Reload — saved widths restored on page load without flash beyond the one-frame hydration shift.
+1. Drag border B (left edge of center) — center column resizes symmetrically; the opposite border (C) mirrors in real time; cursor tracks border B exactly; widths persist after reload.
+2. Drag border C (right edge of center) — same as above, mirrored.
+3. Drag border D (right edge of related) — related column resizes; center is unaffected; cursor tracks border D exactly; persists after reload.
+4. Verify the center column's horizontal midpoint stays at `viewport.center` (use a ruler or DevTools).
+5. Double-click each border — corresponding column resets to default; localStorage key removed.
+6. Drag past min/max — border stops at the bound; cursor can keep moving but border doesn't.
+7. Resize browser to narrow the viewport — center clamps to viewport-derived max if it was wider; widens back when viewport grows.
+8. Narrow viewport below `lg` (~1200px) — borders disappear; layout reverts to existing AppShell mobile behavior.
+9. Toggle navbar collapse (burger) — nav width becomes 0; center stays centered; borders B/C/D reposition without jank.
+10. Reload — saved widths restored on page load with at most one hydration-frame flash.
 
 ## Open questions (to resolve while writing the plan or during implementation)
 
-1. **Gutter color:** keep gutter = `#FCFBF5` (matches the shell), or use a slightly different tone for visual distinction? Recommendation: same color for now; revisit if it looks too flat.
-2. **Container max-width:** ~1900px = sum of max column widths. If tuned, must stay ≥ nav_max + center_max + related_max or the rightmost column will clip.
-3. **Default center width:** since `centerWidth` is derived from container width minus other columns in the steady state, the "default" stored value is `undefined` until the user drags. The initial render needs a default container width — derive from current viewport at first paint (e.g., `min(viewport, 1600)` minus nav minus default related). Implementation plan should specify this exactly.
+1. **Background color:** the body background (which shows as gutters) is `#FCFBF5` today. We keep it. If the gutters end up looking too flat next to the shell content, consider a subtle tone shift later.
+2. **Default `centerWidth`:** when no saved value exists, what's the initial center width? Recommendation: `min(900, viewport - 2 * max(navW, relatedW))` — wide enough to feel intentional, narrow enough to fit common monitors.
+3. **Default `relatedWidth`:** keep the current `clamp(360px, 26vw, 520px)` baseline by resolving it to a px number at first render. Or pick a fixed default like `460px`. To decide during implementation.
+4. **Header visibility on desktop:** the existing AppShell.Header is `hiddenFrom="sm"` (mobile only). The new layout doesn't introduce a desktop header, so this is unchanged. Just confirming.
 
 ## File diff summary
 
-- `src/app/(shell)/Shell.tsx` — wrap in container; integrate hook + dividers; dynamic widths.
-- `src/app/(shell)/useResizableColumns.ts` *(new)* — state + localStorage.
+- `src/app/(shell)/Shell.tsx` — keep AppShell for mobile (header + drawer); add desktop custom-layout overlay with three absolutely-positioned columns and three dividers. Use CSS variables for widths.
+- `src/app/(shell)/useResizableColumns.ts` *(new)* — state, localStorage, viewport-clamped bounds.
 - `src/app/(shell)/ResizableDivider.tsx` *(new)* — drag UI.
-- `src/app/globals.css` (or equivalent) — body background for gutters.
+- `src/app/globals.css` (or equivalent) — body background; `overflow-x: hidden`.
 
 ## Out of scope (deferred)
 

--- a/docs/superpowers/specs/2026-05-13-resizable-shell-columns-design.md
+++ b/docs/superpowers/specs/2026-05-13-resizable-shell-columns-design.md
@@ -1,0 +1,195 @@
+# Resizable Shell Columns — Design
+
+**Date:** 2026-05-13
+**Target branch:** `tarcode2004/enhancement/listy-injection-main-app`
+**Scope:** Make the center and related-posts columns horizontally resizable via draggable borders. Wrap the shell in a centered, max-width container with viewport-edge gutters (Twitter/X style).
+
+## Problem
+
+The current `Shell` layout uses Mantine's `AppShell` with hard-coded `clamp()` widths for the navbar and aside, and a flexible main area. Users on wide monitors cannot reclaim the gutters for content, and users who want a wider related-posts panel (or a narrower one) have no way to adjust it. The layout also expands to the full viewport, which on very wide displays leaves content edges far apart.
+
+## Goals
+
+1. Users can drag two vertical borders to set the **center column** and **related-posts column** widths independently.
+2. Chosen widths persist across sessions (localStorage).
+3. The whole UI sits in a centered max-width container, with the viewport background visible as gutters on either side.
+4. The navbar (left column) width is **not** affected by either drag.
+5. No resize affordance on mobile/narrow screens (matches existing aside mobile-collapse behavior).
+
+## Non-goals
+
+- Resizing the navbar via a border (it keeps its existing burger collapse + `clamp()` width).
+- Vertical resizing.
+- Touch-drag resizing (covered by "no mobile resize").
+- Per-route width overrides (a single global pair persists across all shell routes).
+
+## Layout
+
+After the change, the shell renders inside a centered container:
+
+```
+viewport
+┌──────────────────────────────────────────────────────────────┐
+│ gutter ┌──────────────────────────────────────────┐ gutter   │
+│        │ nav (fixed)   │ center   │ related      │           │
+│        │               ║          ║              │           │
+│        │               ║          ║              │           │
+│        └──────────────────────────────────────────┘           │
+└──────────────────────────────────────────────────────────────┘
+                        ↑ container (max-width ~1600px, centered)
+                        ║ = draggable border
+```
+
+- **Container:** width is **the sum of nav + center + related widths**, capped at a max (~1900px = sum of all maxes). `margin: 0 auto` centers it. Background outside the container shows through (page/body background = the gutter color). The container does not have empty space inside it — it fits its content exactly.
+- **Navbar:** unchanged. Existing `clamp(200px, 22vw, 300px)` and burger-collapse behavior preserved. Width is read at runtime (via ref) to compute container width.
+- **Center column:** width is determined by `centerWidth` state. Because the container width = sum of all three columns, and the aside is explicitly sized, AppShell.Main flex-fills to exactly `centerWidth` without needing a direct width assignment.
+- **Related column:** width = `relatedWidth` from state (default: current `clamp(360px, 26vw, 520px)` baseline value, resolved to a number on first render).
+
+### Bounds
+
+- `centerWidth`: `min 500px`, `max 900px` (tunable). Existing `AppShell.Main miw={500}` is the hard floor.
+- `relatedWidth`: `min 320px`, `max 700px` (tunable).
+
+These bounds are enforced during drag — the divider stops at the limit. No collapsing past minimum.
+
+## Draggable Borders
+
+Two `<ResizableDivider>` instances:
+
+- **Divider 1 (nav ↔ center):** drag changes `centerWidth`. Drag right → center grows; drag left → center shrinks.
+- **Divider 2 (center ↔ related):** drag changes `relatedWidth`. Drag right → related shrinks; drag left → related grows.
+
+`centerWidth` and `relatedWidth` are independent values. Moving one divider does not change the other column's width — instead, the container's total width changes (it grows or shrinks to fit), and the gutters on either side absorb the difference (gutters shrink when columns grow, grow when columns shrink).
+
+### Hover / interaction
+
+- Hit zone: 8px wide, centered on the visible 1px border line.
+- Cursor: `col-resize` on hover.
+- Visual cue on hover: the 1px border line thickens to 3px and shifts to a slightly darker tone (~`#D6D2C0` against the `#FCFBF5` shell background).
+- During drag: body cursor locked to `col-resize`; user-select disabled to prevent text selection.
+- **Double-click resets** that column to its default width (`undefined` in state → falls back to default).
+
+### Drag geometry (known trade-off)
+
+Because the container is **centered** and **fits content** (its width = sum of column widths), when a column grows, the container also grows, and both gutters shrink equally. This means:
+
+- Drag divider 1 right by Δ → `centerWidth` grows by Δ → container grows by Δ → left gutter shrinks by Δ/2 → divider 1 (at `containerLeft + navW`) moves right by only Δ/2 in viewport coords.
+- The divider visually lags the cursor at half-speed.
+
+This is a known visual quirk of pairing centered layout with content-fit sizing. Implementation uses simple delta-based dragging (`centerWidth += cursorDelta`) and accepts the drift. The end-state position is what the user cares about — they'll release when the column looks right.
+
+Alternative (deferred): pin the container's left edge during drag, snap back to centered on `pointerup`. More complex; only worth implementing if the drift feels bad in practice.
+
+### Responsive behavior
+
+- Hidden below Mantine's `lg` breakpoint (matches existing `aside.breakpoint: "lg"` where the aside is mobile-hidden anyway).
+- Below `lg`, the existing AppShell collapse + mobile drawer behavior takes over unchanged.
+
+## State + Persistence
+
+New hook: `useResizableColumns()` in `src/app/(shell)/useResizableColumns.ts`.
+
+```ts
+type ColumnWidths = {
+  centerWidth: number | undefined;   // undefined = use default
+  relatedWidth: number | undefined;
+};
+
+function useResizableColumns(): {
+  widths: ColumnWidths;
+  setCenterWidth: (w: number | undefined) => void;
+  setRelatedWidth: (w: number | undefined) => void;
+};
+```
+
+- On mount: read `stacky:centerWidth` and `stacky:relatedWidth` from `localStorage`. Parse as numbers; if missing or out of bounds, set to `undefined` (default).
+- On `setCenterWidth(n)`: clamp to `[500, 900]`, write to localStorage, update state.
+- On `setRelatedWidth(n)`: clamp to `[320, 700]`, write to localStorage, update state.
+- On `setX(undefined)`: remove the key from localStorage (used by double-click reset).
+- SSR-safe: read inside `useEffect` so the initial render matches server output, then hydrate.
+
+## Components
+
+### New: `ResizableDivider.tsx`
+
+```tsx
+type Props = {
+  onResize: (deltaPx: number) => void;
+  onDoubleClick: () => void;
+  style?: React.CSSProperties;
+};
+```
+
+- Renders a 8px-wide vertical `<div>` with the 1px border line centered.
+- `onPointerDown`: capture pointer, record initial clientX, set `body { cursor: col-resize; user-select: none }`.
+- `onPointerMove` (while captured): call `onResize(currentClientX - lastClientX)`; update lastClientX.
+- `onPointerUp`/`onPointerCancel`: release capture, restore body styles.
+- `onDoubleClick`: forward to prop.
+- Below `lg` breakpoint: `display: none` (Mantine `visibleFrom="lg"` or CSS media query).
+
+### Modified: `Shell.tsx`
+
+- Wrap the entire `<AppShell>` (and the burger trigger) in a centered container `<div style={{ width: navW + centerW + relatedW, maxWidth: 1900, margin: '0 auto', position: 'relative', height: '100vh' }}>`. Container width is computed from current widths; max-width caps it at the sum of all maxes.
+- Body/global CSS gets a background color so the gutter outside the container is visible.
+- Use `useResizableColumns()` to read widths.
+- Use a ref on the navbar element to read its current rendered width (since `clamp(200px, 22vw, 300px)` varies with viewport). Update on `ResizeObserver`.
+- Replace `AppShell` `aside.width` with `widths.relatedWidth ?? defaultRelatedWidth`.
+- Do **not** explicitly set Main's width. Because the container is sized exactly to fit all three columns and Aside is explicit, Main flex-fills to exactly `centerWidth`.
+- Render two `<ResizableDivider>` instances as absolutely-positioned overlays at the column boundaries (positioned at `left = navW` and `left = navW + centerW`).
+
+### Modified: `globals.css` (or equivalent root CSS)
+
+- Set body background to gutter color (the existing `#FCFBF5` cream or a slightly different tone — see open question Q1 below).
+
+## Data Flow
+
+```
+localStorage  ←→  useResizableColumns hook  →  Shell.tsx
+                                                ├─ Container width (= navW + centerW + relatedW)
+                                                ├─ AppShell.Aside width = relatedW
+                                                ├─ AppShell.Main flex-fills → resolves to centerW
+                                                └─ ResizableDivider × 2
+                                                    └─ onResize → setCenterWidth / setRelatedWidth
+```
+
+No new context provider needed — the hook is called once in `Shell.tsx` and the values flow down by props/inline style. Other components don't need to know widths changed.
+
+## Edge Cases
+
+- **First render before localStorage hydrated:** widths are `undefined`, columns fall back to current defaults. After hydration, widths update; if a saved value differs from the default, columns visibly shift once. This is acceptable for an enhancement of this kind, but to minimize flash, the hook returns defaults during the SSR/initial render and switches on `useEffect`.
+- **Narrowing the viewport below the sum of column widths:** if `navW + centerW + relatedW > viewportWidth`, container overflows the viewport horizontally. Mitigation: the body has `overflow-x: hidden` and the user can resize back, or double-click to reset. We accept this edge case — alternative is to dynamically shrink columns on resize, which complicates the model.
+- **Nav collapsed via burger:** when `navCollapsed === true`, the navbar width is 0. The left divider's position must update accordingly. Solution: divider positions are computed from current navbar width (0 or clamped value).
+- **Below `lg` breakpoint:** dividers hidden; widths still saved but unused. When user resizes back up to `lg+`, saved widths apply.
+
+## Testing (manual)
+
+No automated test framework is configured. Manual verification checklist:
+
+1. Drag right divider — related column resizes; center stays the same width; widths persist after reload.
+2. Drag left divider — center column resizes; related stays the same width; widths persist.
+3. Double-click each divider — column resets to default; localStorage key removed.
+4. Drag past min/max — divider stops at the bound.
+5. Narrow viewport below `lg` (≈1200px) — dividers disappear; layout reverts to mobile-aware AppShell behavior.
+6. Toggle navbar collapse (burger) — left divider repositions correctly; resizing still works.
+7. Reload — saved widths restored on page load without flash beyond the one-frame hydration shift.
+
+## Open questions (to resolve while writing the plan or during implementation)
+
+1. **Gutter color:** keep gutter = `#FCFBF5` (matches the shell), or use a slightly different tone for visual distinction? Recommendation: same color for now; revisit if it looks too flat.
+2. **Container max-width:** ~1900px = sum of max column widths. If tuned, must stay ≥ nav_max + center_max + related_max or the rightmost column will clip.
+3. **Default center width:** since `centerWidth` is derived from container width minus other columns in the steady state, the "default" stored value is `undefined` until the user drags. The initial render needs a default container width — derive from current viewport at first paint (e.g., `min(viewport, 1600)` minus nav minus default related). Implementation plan should specify this exactly.
+
+## File diff summary
+
+- `src/app/(shell)/Shell.tsx` — wrap in container; integrate hook + dividers; dynamic widths.
+- `src/app/(shell)/useResizableColumns.ts` *(new)* — state + localStorage.
+- `src/app/(shell)/ResizableDivider.tsx` *(new)* — drag UI.
+- `src/app/globals.css` (or equivalent) — body background for gutters.
+
+## Out of scope (deferred)
+
+- Resizable navbar.
+- Touch / mobile resize.
+- Per-route width overrides.
+- Animated transitions on width change (instant only).
+- Width sync across tabs (single-tab localStorage is fine).

--- a/src/app/(shell)/ResizableDivider.tsx
+++ b/src/app/(shell)/ResizableDivider.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { CSSProperties, PointerEvent as ReactPointerEvent, useCallback, useRef, useState } from "react";
+
+type Props = {
+  onResize: (deltaPx: number) => void;
+  onDoubleClick?: () => void;
+  style?: CSSProperties;
+  ariaLabel?: string;
+};
+
+const HIT_WIDTH = 8;
+const LINE_WIDTH = 1;
+const LINE_HOVER_WIDTH = 3;
+const LINE_COLOR = "rgba(0, 0, 0, 0.08)";
+const LINE_HOVER_COLOR = "rgba(0, 0, 0, 0.20)";
+
+export function ResizableDivider({ onResize, onDoubleClick, style, ariaLabel }: Props) {
+  const lastClientX = useRef<number | null>(null);
+  const [hovered, setHovered] = useState(false);
+  const [dragging, setDragging] = useState(false);
+
+  const handlePointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
+    lastClientX.current = e.clientX;
+    setDragging(true);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (lastClientX.current === null) return;
+      const delta = e.clientX - lastClientX.current;
+      if (delta !== 0) {
+        lastClientX.current = e.clientX;
+        onResize(delta);
+      }
+    },
+    [onResize]
+  );
+
+  const handlePointerUp = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    (e.currentTarget as HTMLDivElement).releasePointerCapture(e.pointerId);
+    lastClientX.current = null;
+    setDragging(false);
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+  }, []);
+
+  const lineActive = hovered || dragging;
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={ariaLabel}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onDoubleClick={onDoubleClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        width: HIT_WIDTH,
+        marginLeft: -HIT_WIDTH / 2,
+        cursor: "col-resize",
+        touchAction: "none",
+        zIndex: 250,
+        display: "flex",
+        justifyContent: "center",
+        ...style,
+      }}
+    >
+      <div
+        style={{
+          width: lineActive ? LINE_HOVER_WIDTH : LINE_WIDTH,
+          backgroundColor: lineActive ? LINE_HOVER_COLOR : LINE_COLOR,
+          transition: "width 120ms ease, background-color 120ms ease",
+          height: "100%",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(shell)/Shell.tsx
+++ b/src/app/(shell)/Shell.tsx
@@ -1,96 +1,342 @@
-"use client"
+"use client";
 
-import {AppShell, Burger, Group, Drawer, Container} from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
-import { ReactNode } from 'react';
-import {Navbar} from "../../components/NavBar/Navbar";
-import StackLogo from '../../utils/StackLogo';
-import { RelatedStacksProvider } from './related-stacks-context';
-import { HoverTooltip } from '../../components/HoverTooltip';
+import { AppShell, Burger, Drawer, Group } from "@mantine/core";
+import { useDisclosure, useMediaQuery } from "@mantine/hooks";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Navbar } from "../../components/NavBar/Navbar";
+import StackLogo from "../../utils/StackLogo";
+import { HoverTooltip } from "../../components/HoverTooltip";
+import { RelatedStacksProvider } from "./related-stacks-context";
+import { ResizableDivider } from "./ResizableDivider";
+import {
+    CENTER_MAX,
+    CENTER_MIN,
+    DEFAULT_RELATED,
+    useResizableColumns,
+} from "./useResizableColumns";
 
-export default function Shell({ children, aside }: {  children: React.ReactNode; aside: React.ReactNode; }) {
-    const [opened, { toggle }] = useDisclosure();
+const LG_QUERY = "(min-width: 1200px)";
+
+export default function Shell({ children, aside }: { children: React.ReactNode; aside: React.ReactNode }) {
+    const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] = useDisclosure();
     const [navCollapsed, { toggle: toggleNav }] = useDisclosure(false);
+
+    const isDesktop = useMediaQuery(LG_QUERY) ?? false;
 
     return (
         <RelatedStacksProvider>
-        <AppShell
-            header={{ height: { base: 64, sm: 0 } }}
-            navbar={{
-                width: navCollapsed ? 0 : "clamp(200px, 22vw, 300px)",
-                breakpoint: "sm",
-                collapsed: { mobile: !opened, desktop: navCollapsed },
-              }}
-            aside={{
-            width: navCollapsed ? "clamp(400px, 32vw, 600px)" : "clamp(360px, 26vw, 520px)",
-            breakpoint: "lg",
-            collapsed: { mobile: true },
-            }}
-            padding="md"
-        >
-            <AppShell.Header hiddenFrom="sm" bg="#FCFBF5">
-                <Group h="100%" px="md">
-                    <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
-                    <StackLogo size={30} />
-                </Group>
-            </AppShell.Header>
-            <AppShell.Navbar p="md" visibleFrom="sm" style={{
-                backgroundColor: '#FCFBF5',
-                overflow: 'hidden',
-                opacity: navCollapsed ? 0 : 1,
-                transition: 'opacity 200ms ease',
-            }}>
-                <Navbar />
-            </AppShell.Navbar>
-            <AppShell.Aside
-                p="md"
-                pt="0"
-                withBorder
-                style={{ background: "#FCFBF5",
-                    overflowY: 'auto',
-                    overscrollBehavior: 'contain',
-                    scrollbarWidth: 'none',
-                    '-ms-overflow-style': 'none',
+            {isDesktop ? (
+                <DesktopShell
+                    aside={aside}
+                    navCollapsed={navCollapsed}
+                    toggleNav={toggleNav}
+                    drawerOpened={drawerOpened}
+                    closeDrawer={closeDrawer}
+                >
+                    {children}
+                </DesktopShell>
+            ) : (
+                <MobileShell
+                    aside={aside}
+                    drawerOpened={drawerOpened}
+                    toggleDrawer={toggleDrawer}
+                    closeDrawer={closeDrawer}
+                    navCollapsed={navCollapsed}
+                    toggleNav={toggleNav}
+                >
+                    {children}
+                </MobileShell>
+            )}
+            <HoverTooltip />
+        </RelatedStacksProvider>
+    );
+}
+
+/* ---------- Mobile / tablet branch: unchanged AppShell behavior ---------- */
+
+function MobileShell({
+    children,
+    aside,
+    drawerOpened,
+    toggleDrawer,
+    closeDrawer,
+    navCollapsed,
+    toggleNav,
+}: {
+    children: React.ReactNode;
+    aside: React.ReactNode;
+    drawerOpened: boolean;
+    toggleDrawer: () => void;
+    closeDrawer: () => void;
+    navCollapsed: boolean;
+    toggleNav: () => void;
+}) {
+    return (
+        <>
+            <AppShell
+                header={{ height: { base: 64, sm: 0 } }}
+                navbar={{
+                    width: navCollapsed ? 0 : "clamp(200px, 22vw, 300px)",
+                    breakpoint: "sm",
+                    collapsed: { mobile: !drawerOpened, desktop: navCollapsed },
+                }}
+                aside={{
+                    width: navCollapsed ? "clamp(400px, 32vw, 600px)" : "clamp(360px, 26vw, 520px)",
+                    breakpoint: "lg",
+                    collapsed: { mobile: true },
+                }}
+                padding="md"
+            >
+                <AppShell.Header hiddenFrom="sm" bg="#FCFBF5">
+                    <Group h="100%" px="md">
+                        <Burger opened={drawerOpened} onClick={toggleDrawer} hiddenFrom="sm" size="sm" />
+                        <StackLogo size={30} />
+                    </Group>
+                </AppShell.Header>
+                <AppShell.Navbar
+                    p="md"
+                    visibleFrom="sm"
+                    style={{
+                        backgroundColor: "#FCFBF5",
+                        overflow: "hidden",
+                        opacity: navCollapsed ? 0 : 1,
+                        transition: "opacity 200ms ease",
                     }}
+                >
+                    <Navbar />
+                </AppShell.Navbar>
+                <AppShell.Aside
+                    p="md"
+                    pt="0"
+                    withBorder
+                    style={{
+                        background: "#FCFBF5",
+                        overflowY: "auto",
+                        overscrollBehavior: "contain",
+                        scrollbarWidth: "none",
+                    }}
+                >
+                    {aside ?? null}
+                </AppShell.Aside>
+                <Drawer
+                    opened={drawerOpened}
+                    onClose={closeDrawer}
+                    padding="md"
+                    size="xs"
+                    styles={{
+                        content: { backgroundColor: "#FCFBF5" },
+                        header: { backgroundColor: "#FCFBF5" },
+                    }}
+                    lockScroll={false}
+                >
+                    <Navbar />
+                </Drawer>
+                <AppShell.Main miw={500}>{children}</AppShell.Main>
+            </AppShell>
+            <Burger
+                opened={!navCollapsed}
+                onClick={toggleNav}
+                visibleFrom="sm"
+                size="sm"
+                aria-label={navCollapsed ? "Expand navigation" : "Collapse navigation"}
+                style={{
+                    position: "fixed",
+                    left: navCollapsed ? 16 : "calc(clamp(200px, 22vw, 300px) - 42px)",
+                    top: 16,
+                    zIndex: 300,
+                    transition: "left 200ms ease",
+                }}
+            />
+        </>
+    );
+}
+
+/* ---------- Desktop branch: custom three-column layout with resizable borders ---------- */
+
+function DesktopShell({
+    children,
+    aside,
+    navCollapsed,
+    toggleNav,
+    drawerOpened,
+    closeDrawer,
+}: {
+    children: React.ReactNode;
+    aside: React.ReactNode;
+    navCollapsed: boolean;
+    toggleNav: () => void;
+    drawerOpened: boolean;
+    closeDrawer: () => void;
+}) {
+    const { widths, setCenterWidth, setRelatedWidth } = useResizableColumns();
+
+    const navRef = useRef<HTMLDivElement | null>(null);
+    const [navW, setNavW] = useState<number>(260);
+    useLayoutEffect(() => {
+        const el = navRef.current;
+        if (!el) return;
+        const measure = () => {
+            const w = el.getBoundingClientRect().width;
+            if (w > 0) setNavW(w);
+        };
+        measure();
+        const ro = new ResizeObserver(measure);
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, []);
+
+    const [viewportW, setViewportW] = useState<number>(() =>
+        typeof window === "undefined" ? 1440 : window.innerWidth
+    );
+    useEffect(() => {
+        const onResize = () => setViewportW(window.innerWidth);
+        window.addEventListener("resize", onResize);
+        return () => window.removeEventListener("resize", onResize);
+    }, []);
+
+    const effectiveNavW = navCollapsed ? 0 : navW;
+    const effectiveRelatedW = widths.relatedWidth ?? DEFAULT_RELATED;
+    const viewportCenterMax = viewportW - 2 * Math.max(effectiveNavW, effectiveRelatedW);
+    const defaultCenter = Math.max(
+        CENTER_MIN,
+        Math.min(900, viewportCenterMax > 0 ? viewportCenterMax : 900)
+    );
+    const effectiveCenterW = Math.max(
+        CENTER_MIN,
+        Math.min(
+            widths.centerWidth ?? defaultCenter,
+            Math.min(CENTER_MAX, viewportCenterMax > 0 ? viewportCenterMax : CENTER_MAX)
+        )
+    );
+
+    const onBorderB = (delta: number) => {
+        setCenterWidth(effectiveCenterW - 2 * delta, viewportCenterMax);
+    };
+    const onBorderC = (delta: number) => {
+        setCenterWidth(effectiveCenterW + 2 * delta, viewportCenterMax);
+    };
+    const onBorderD = (delta: number) => {
+        setRelatedWidth(effectiveRelatedW + delta);
+    };
+
+    const resetCenter = () => setCenterWidth(undefined);
+    const resetRelated = () => setRelatedWidth(undefined);
+
+    const wrapperStyle = useMemo(
+        () =>
+            ({
+                "--center-w": `${effectiveCenterW}px`,
+                "--related-w": `${effectiveRelatedW}px`,
+                "--nav-w": `${effectiveNavW}px`,
+            }) as React.CSSProperties,
+        [effectiveCenterW, effectiveRelatedW, effectiveNavW]
+    );
+
+    return (
+        <div style={{ ...wrapperStyle, position: "relative", minHeight: "100vh" }}>
+            <div
+                ref={navRef}
+                style={{
+                    position: "fixed",
+                    top: 0,
+                    bottom: 0,
+                    left: "calc(50vw - var(--center-w) / 2 - var(--nav-w))",
+                    width: "clamp(200px, 22vw, 300px)",
+                    backgroundColor: "#FCFBF5",
+                    padding: 16,
+                    overflow: "hidden",
+                    opacity: navCollapsed ? 0 : 1,
+                    pointerEvents: navCollapsed ? "none" : "auto",
+                    transition: "opacity 200ms ease",
+                    zIndex: 100,
+                }}
+            >
+                <Navbar />
+            </div>
+
+            <div
+                style={{
+                    position: "relative",
+                    marginLeft: "calc(50vw - var(--center-w) / 2)",
+                    width: "var(--center-w)",
+                    minWidth: CENTER_MIN,
+                    padding: 16,
+                    minHeight: "100vh",
+                }}
+            >
+                {children}
+            </div>
+
+            <div
+                style={{
+                    position: "fixed",
+                    top: 0,
+                    bottom: 0,
+                    left: "calc(50vw + var(--center-w) / 2)",
+                    width: "var(--related-w)",
+                    backgroundColor: "#FCFBF5",
+                    borderLeft: "1px solid rgba(0,0,0,0.08)",
+                    overflowY: "auto",
+                    overscrollBehavior: "contain",
+                    scrollbarWidth: "none",
+                    padding: 16,
+                    paddingTop: 0,
+                    zIndex: 100,
+                }}
             >
                 {aside ?? null}
-            </AppShell.Aside>
+            </div>
+
+            <ResizableDivider
+                ariaLabel="Resize center column (left edge)"
+                onResize={onBorderB}
+                onDoubleClick={resetCenter}
+                style={{ left: "calc(50vw - var(--center-w) / 2)", position: "fixed" }}
+            />
+
+            <ResizableDivider
+                ariaLabel="Resize center column (right edge)"
+                onResize={onBorderC}
+                onDoubleClick={resetCenter}
+                style={{ left: "calc(50vw + var(--center-w) / 2)", position: "fixed" }}
+            />
+
+            <ResizableDivider
+                ariaLabel="Resize related column"
+                onResize={onBorderD}
+                onDoubleClick={resetRelated}
+                style={{ left: "calc(50vw + var(--center-w) / 2 + var(--related-w))", position: "fixed" }}
+            />
+
+            <Burger
+                opened={!navCollapsed}
+                onClick={toggleNav}
+                size="sm"
+                aria-label={navCollapsed ? "Expand navigation" : "Collapse navigation"}
+                style={{
+                    position: "fixed",
+                    left: navCollapsed
+                        ? 16
+                        : "calc(50vw - var(--center-w) / 2 - var(--nav-w) + 16px)",
+                    top: 16,
+                    zIndex: 300,
+                    transition: "left 200ms ease",
+                }}
+            />
+
             <Drawer
-                opened={opened}
-                onClose={toggle}
+                opened={drawerOpened}
+                onClose={closeDrawer}
                 padding="md"
                 size="xs"
                 styles={{
-                    content: {
-                      backgroundColor: '#FCFBF5',
-                    },
-                    header: {
-                      backgroundColor: '#FCFBF5',
-                    },
-                  }}
-                  lockScroll={false}
+                    content: { backgroundColor: "#FCFBF5" },
+                    header: { backgroundColor: "#FCFBF5" },
+                }}
+                lockScroll={false}
             >
                 <Navbar />
             </Drawer>
-            <AppShell.Main miw={500}>
-                {children}
-            </AppShell.Main>
-        </AppShell>
-        <HoverTooltip />
-        <Burger
-            opened={!navCollapsed}
-            onClick={toggleNav}
-            visibleFrom="sm"
-            size="sm"
-            aria-label={navCollapsed ? "Expand navigation" : "Collapse navigation"}
-            style={{
-                position: 'fixed',
-                left: navCollapsed ? 16 : 'calc(clamp(200px, 22vw, 300px) - 42px)',
-                top: 16,
-                zIndex: 300,
-                transition: 'left 200ms ease',
-            }}
-        />
-        </RelatedStacksProvider>
+        </div>
     );
 }

--- a/src/app/(shell)/useResizableColumns.ts
+++ b/src/app/(shell)/useResizableColumns.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export const CENTER_MIN = 500;
+export const CENTER_MAX = 1100;
+export const RELATED_MIN = 320;
+export const RELATED_MAX = 700;
+export const DEFAULT_RELATED = 460;
+
+const LS_CENTER = "stacky:centerWidth";
+const LS_RELATED = "stacky:relatedWidth";
+
+function readNumber(key: string): number | undefined {
+  if (typeof window === "undefined") return undefined;
+  const raw = window.localStorage.getItem(key);
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}
+
+export type ColumnWidths = {
+  centerWidth: number | undefined;
+  relatedWidth: number | undefined;
+};
+
+export type UseResizableColumns = {
+  widths: ColumnWidths;
+  setCenterWidth: (w: number | undefined, viewportMax?: number) => void;
+  setRelatedWidth: (w: number | undefined) => void;
+};
+
+export function useResizableColumns(): UseResizableColumns {
+  const [centerWidth, setCenterRaw] = useState<number | undefined>(undefined);
+  const [relatedWidth, setRelatedRaw] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    const c = readNumber(LS_CENTER);
+    const r = readNumber(LS_RELATED);
+    if (c !== undefined) setCenterRaw(clamp(c, CENTER_MIN, CENTER_MAX));
+    if (r !== undefined) setRelatedRaw(clamp(r, RELATED_MIN, RELATED_MAX));
+  }, []);
+
+  const setCenterWidth = useCallback((w: number | undefined, viewportMax?: number) => {
+    if (w === undefined) {
+      setCenterRaw(undefined);
+      if (typeof window !== "undefined") window.localStorage.removeItem(LS_CENTER);
+      return;
+    }
+    const hardMax = viewportMax !== undefined ? Math.min(CENTER_MAX, viewportMax) : CENTER_MAX;
+    const clamped = clamp(w, CENTER_MIN, hardMax);
+    setCenterRaw(clamped);
+    if (typeof window !== "undefined") window.localStorage.setItem(LS_CENTER, String(clamped));
+  }, []);
+
+  const setRelatedWidth = useCallback((w: number | undefined) => {
+    if (w === undefined) {
+      setRelatedRaw(undefined);
+      if (typeof window !== "undefined") window.localStorage.removeItem(LS_RELATED);
+      return;
+    }
+    const clamped = clamp(w, RELATED_MIN, RELATED_MAX);
+    setRelatedRaw(clamped);
+    if (typeof window !== "undefined") window.localStorage.setItem(LS_RELATED, String(clamped));
+  }, []);
+
+  return {
+    widths: { centerWidth, relatedWidth },
+    setCenterWidth,
+    setRelatedWidth,
+  };
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -55,3 +55,9 @@ html::-webkit-scrollbar-thumb:hover {
 .avatarHoverDim:hover img {
     filter: brightness(0.95);
 }
+
+/* Resizable shell columns: body background = gutter color; suppress horizontal scroll. */
+body {
+    background-color: #FCFBF5;
+    overflow-x: hidden;
+}


### PR DESCRIPTION
## Summary
- Center column is pinned to viewport center; nav and related float to its sides.
- Three draggable borders: left and right of center (both adjust centerWidth symmetrically) and right of related (adjusts relatedWidth).
- Widths persist in localStorage. Double-click a divider to reset that column.
- Active at lg+ (≥1200px). Below lg, the existing AppShell mobile/tablet layout is preserved unchanged.

## Spec & Plan
- docs/superpowers/specs/2026-05-13-resizable-shell-columns-design.md
- docs/superpowers/plans/2026-05-13-resizable-shell-columns.md

## Test plan
- [ ] Center column visually centered on viewport at ≥1200px
- [ ] All three borders show col-resize cursor on hover
- [ ] Border B (left of center) and Border C (right of center) both resize center symmetrically; opposite border mirrors in real time
- [ ] Border D resizes related independently
- [ ] Min/max bounds enforced (center: 500–1100, related: 320–700)
- [ ] Widths persist across reload
- [ ] Double-click resets that column to default
- [ ] Burger collapse still works (nav slides out; center stays centered)
- [ ] Below 1200px reverts to original AppShell layout