### PR TITLE
Group A robustness fixes for listy-injection user study

### DIFF
--- a/src/app/(shell)/@aside/default.tsx
+++ b/src/app/(shell)/@aside/default.tsx
@@ -3,9 +3,32 @@ import RelatedStacks from "../../../components/RelatedStacks";
 import { useRelatedStacks } from "../related-stacks-context";
 
 export default function DefaultAside() {
-    const { relatedStacks, showUpdate } = useRelatedStacks();
+    const { relatedStacks, activePostId, showUpdate } = useRelatedStacks();
 
-    if (!relatedStacks || relatedStacks.length === 0) return null;
+    // No focus post selected — aside has nothing to anchor against.
+    if (!activePostId) return null;
+
+    // Focus post exists but no related stacks — keep the panel visible so the
+    // user knows their selection registered. Dropping the aside entirely makes
+    // it look like the click was lost.
+    if (!relatedStacks || relatedStacks.length === 0) {
+        return (
+            <div
+                style={{ width: "100%", paddingTop: "0.5rem" }}
+                role="status"
+                aria-live="polite"
+            >
+                <div style={{ padding: "1rem 0" }}>
+                    <div style={{ fontSize: 14, fontWeight: 700, color: "#374151", marginBottom: 6 }}>
+                        Related responses
+                    </div>
+                    <div style={{ fontSize: 12, color: "#94a3b8", lineHeight: 1.45 }}>
+                        No related posts found for this thread yet.
+                    </div>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div style={{ width: "100%" }}>

--- a/src/app/(shell)/@aside/listy-injection/page.tsx
+++ b/src/app/(shell)/@aside/listy-injection/page.tsx
@@ -5,9 +5,32 @@ import { useRelatedStacks } from "../../related-stacks-context";
 import { triggerNavigate } from "../../../../utils/highlightStore";
 
 export default function ListyInjectionAside() {
-  const { relatedStacks, showUpdate } = useRelatedStacks();
+  const { relatedStacks, activePostId, showUpdate } = useRelatedStacks();
 
-  if (!relatedStacks || relatedStacks.length === 0) return null;
+  // No focus post selected — aside has nothing to anchor against.
+  if (!activePostId) return null;
+
+  // Focus post exists but no related stacks — keep the panel visible so the
+  // user knows their selection registered. Dropping the aside entirely makes
+  // it look like the click was lost (study-session crash).
+  if (!relatedStacks || relatedStacks.length === 0) {
+    return (
+      <div
+        style={{ width: "100%", paddingTop: "0.5rem" }}
+        role="status"
+        aria-live="polite"
+      >
+        <div style={{ padding: "1rem 0" }}>
+          <div style={{ fontSize: 14, fontWeight: 700, color: "#374151", marginBottom: 6 }}>
+            Related responses
+          </div>
+          <div style={{ fontSize: 12, color: "#94a3b8", lineHeight: 1.45 }}>
+            No related posts found for this thread yet.
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div style={{ width: "100%", paddingTop: "0.5rem" }}>

--- a/src/app/(shell)/listy-injection/page.tsx
+++ b/src/app/(shell)/listy-injection/page.tsx
@@ -327,7 +327,63 @@ export default function ListyInjectionPage() {
   // Direction of the last navigation — drives the slide animation in AnimatePresence.
   const [navDirection, setNavDirection] = useState<'forward' | 'backward'>('forward');
 
+  /** Marker we push onto window.history when entering thread mode so the
+   *  browser back button is captured by the popstate handler below. Without
+   *  this, a browser-back press tears the user off /listy-injection entirely,
+   *  losing their thread context (A4). */
+  const browserBackInstalledRef = useRef(false);
+  // Forward-declared ref so popInPageOnly can re-seed the aside with the first
+  // post's stacks when returning to feed mode. `posts` is declared after this
+  // block; the ref is populated by the effect below once it's available.
+  const postsRef = useRef<ReturnType<typeof toPostData>[]>([]);
+
+  /** Pops the in-page historyStack without triggering window.history.back()
+   *  (used when popstate fires — the browser already did the URL pop). */
+  const popInPageOnly = useCallback(() => {
+    setNavDirection('backward');
+    setHistoryStack(prev => {
+      if (prev.length === 0) return prev;
+      const next = prev.slice(0, -1);
+      const restoreKey = next.length > 0 ? next[next.length - 1] : "__feed__";
+      const restoreId = next.length > 0 ? next[next.length - 1] : null;
+
+      if (restoreId) {
+        const stacks = getRelatedStacks(restoreId);
+        setFromPostRef.current(stacks, restoreId, { force: true });
+        setActivePostId(restoreId);
+        activePostIdRef.current = restoreId;
+      } else {
+        // Returning to feed mode — re-activate the first post so the aside has
+        // something to display instead of going empty.
+        const first = postsRef.current[0];
+        if (first) {
+          setFromPostRef.current(first.relatedStacks, first.postId, { force: true });
+          setActivePostId(first.postId);
+          activePostIdRef.current = first.postId;
+        }
+      }
+
+      if (next.length === 0) browserBackInstalledRef.current = false;
+
+      requestAnimationFrame(() => {
+        const savedY = savedScrollRef.current.get(restoreKey) ?? 0;
+        window.scrollTo(0, savedY);
+      });
+      return next;
+    });
+  }, [getRelatedStacks]);
+
   const navigateToPost = useCallback((postId: string) => {
+    // A1 guard: refuse to navigate to a post we cannot resolve. Without this,
+    // entering thread mode for an unknown ID renders an empty container with
+    // no recovery affordance, which reads as a study-session crash. Logging
+    // makes the data-integrity gap visible without swallowing it silently.
+    if (!postId || !resolveEntry(postId)) {
+      // eslint-disable-next-line no-console
+      console.warn('[listy-injection] navigateToPost: unknown postId, ignoring', { postId });
+      return;
+    }
+
     // Save current scroll
     const key = historyStack.length > 0 ? historyStack[historyStack.length - 1] : "__feed__";
     savedScrollRef.current.set(key, window.scrollY);
@@ -341,32 +397,28 @@ export default function ListyInjectionPage() {
     setActivePostId(postId);
     activePostIdRef.current = postId;
     window.scrollTo(0, 0);
-  }, [historyStack, getRelatedStacks]);
+
+    // A4: Push a marker onto the browser history stack so a browser-back press
+    // is captured by the popstate handler and routed through our in-page back.
+    // We only push the FIRST time we enter thread mode — subsequent forward
+    // navigations stay inside the same browser-history entry.
+    if (typeof window !== 'undefined' && !browserBackInstalledRef.current) {
+      window.history.pushState({ __listyThread: true }, '', window.location.href);
+      browserBackInstalledRef.current = true;
+    }
+  }, [historyStack, getRelatedStacks, resolveEntry]);
 
   const navigateBack = useCallback(() => {
-    setNavDirection('backward');
-    setHistoryStack(prev => {
-      const next = prev.slice(0, -1);
-      const restoreKey = next.length > 0 ? next[next.length - 1] : "__feed__";
-      const restoreId = next.length > 0 ? next[next.length - 1] : null;
-
-      // Update sidebar
-      if (restoreId) {
-        const stacks = getRelatedStacks(restoreId);
-        setFromPostRef.current(stacks, restoreId, { force: true });
-        setActivePostId(restoreId);
-        activePostIdRef.current = restoreId;
-      }
-
-      // Restore scroll after React re-renders
-      requestAnimationFrame(() => {
-        const savedY = savedScrollRef.current.get(restoreKey) ?? 0;
-        window.scrollTo(0, savedY);
-      });
-
-      return next;
-    });
-  }, [getRelatedStacks]);
+    // If the user clicks our Back button while we still own a browser-history
+    // marker, consume it via history.back() so popstate fires and we don't
+    // diverge from the browser stack. The popstate handler will then call
+    // popInPageOnly to update React state.
+    if (browserBackInstalledRef.current && typeof window !== 'undefined') {
+      window.history.back();
+    } else {
+      popInPageOnly();
+    }
+  }, [popInPageOnly]);
 
   // Register the navigate callback so the aside's RelatedStacks can trigger it
   useEffect(() => {
@@ -374,8 +426,29 @@ export default function ListyInjectionPage() {
     return () => registerNavigateCallback(null);
   }, [navigateToPost]);
 
+  // A4: Capture browser back-button presses while in thread mode so the user
+  // doesn't get yanked off /listy-injection mid-study-session.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onPop = () => {
+      // Only intervene if we still have an in-page thread stack to pop. If the
+      // stack is empty the popstate is a normal navigation (e.g. away from the
+      // page) and we let it through.
+      if (historyStack.length === 0) {
+        browserBackInstalledRef.current = false;
+        return;
+      }
+      popInPageOnly();
+    };
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, [historyStack, popInPageOnly]);
+
   // ── Feed mode posts ────────────────────────────────────────────────────────
   const posts = useMemo(() => entries.map(toPostData), []);
+  // Keep postsRef in sync so the popstate-driven back path can re-seed feed
+  // mode without `posts` having to be declared above it.
+  postsRef.current = posts;
 
   // Reset on mount/unmount
   useEffect(() => {
@@ -546,7 +619,7 @@ export default function ListyInjectionPage() {
         })}
 
         {/* Current focus post with connector */}
-        {currentPost && (
+        {currentPost ? (
           <div style={{ position: "relative", marginBottom: "1.5rem" }}>
             {ancestorIds.length > 0 && (
               <div aria-hidden style={{
@@ -558,6 +631,28 @@ export default function ListyInjectionPage() {
               {renderPost(currentPost)}
             </div>
           </div>
+        ) : (
+          // A1 fallback: we entered thread mode for a post that couldn't be
+          // resolved. Show an explicit empty state with a recovery affordance
+          // instead of an invisible page that looks crashed to a study subject.
+          <Paper
+            withBorder
+            role="status"
+            aria-live="polite"
+            style={{
+              backgroundColor: "#fff",
+              borderRadius: 8,
+              padding: 20,
+              marginBottom: "1.5rem",
+            }}
+          >
+            <Text size="sm" fw={600} c="#374151" mb={6}>
+              Post unavailable
+            </Text>
+            <Text size="xs" c="dimmed">
+              This post couldn&apos;t be loaded. Press <strong>Back</strong> to return.
+            </Text>
+          </Paper>
         )}
 
         {/* Comment input — right under the focus post, before replies */}

--- a/src/app/(shell)/posts/[id]/@aside/page.tsx
+++ b/src/app/(shell)/posts/[id]/@aside/page.tsx
@@ -4,11 +4,35 @@ import RelatedStacks from "../../../../../components/RelatedStacks";
 import { useRelatedStacks } from "../../../related-stacks-context";
 
 export default function PostAside() {
-    const { relatedStacks, showUpdate } = useRelatedStacks();
+    const { relatedStacks, activePostId, showUpdate } = useRelatedStacks();
     const params = useParams();
     // H5: pass focus post ID so RelatedStacks can append ?from= on related-post navigation
     const focusPostId = typeof params?.id === "string" ? params.id : undefined;
-    if (!relatedStacks || relatedStacks.length === 0) return null;
+
+    // No focus post — aside has nothing to anchor against.
+    if (!activePostId && !focusPostId) return null;
+
+    // Focus post known but no related stacks — render an empty state instead
+    // of dropping the entire aside, so the user knows the click registered.
+    if (!relatedStacks || relatedStacks.length === 0) {
+        return (
+            <div
+                style={{ width: "100%", paddingTop: "0.5rem" }}
+                role="status"
+                aria-live="polite"
+            >
+                <div style={{ padding: "1rem 0" }}>
+                    <div style={{ fontSize: 14, fontWeight: 700, color: "#374151", marginBottom: 6 }}>
+                        Related responses
+                    </div>
+                    <div style={{ fontSize: 12, color: "#94a3b8", lineHeight: 1.45 }}>
+                        No related posts found for this thread yet.
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div style={{ width: "100%" }}>
             <RelatedStacks

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -1282,8 +1282,19 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
             </Text>
             <button
               type="button"
-              onClick={() => clearFilterFocusSpan()}
-              style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#94a3b8', fontSize: '14px', lineHeight: 1, padding: '0 2px', marginLeft: 'auto' }}
+              onClick={(e) => { e.stopPropagation(); clearFilterFocusSpan(); }}
+              // A5: 24px minimum hit target. Larger transparent zone around the
+              // glyph so the close button can actually be clicked reliably.
+              style={{
+                background: 'none', border: 'none', cursor: 'pointer',
+                color: '#94a3b8', fontSize: '16px', lineHeight: 1,
+                padding: '6px 8px', marginLeft: 'auto',
+                minWidth: 24, minHeight: 24,
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                borderRadius: 4,
+              }}
+              onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = '#475569'; (e.currentTarget as HTMLElement).style.background = '#e2e8f0'; }}
+              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = '#94a3b8'; (e.currentTarget as HTMLElement).style.background = 'none'; }}
               aria-label="Clear span filter"
             >×</button>
           </div>
@@ -1306,12 +1317,25 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                 ? topicOf(rel, a!.stackId, rangeIdx ?? 0)
                 : (a?.topPost.account.display_name ?? id);
               return (
-                <span key={id} style={{
-                  background: '#dce4f5', borderRadius: '4px', padding: '1px 6px',
-                  fontSize: '10px', fontWeight: 600, color: '#3b5998', cursor: 'pointer',
-                }} onClick={() => handleToggleAnchor(id)} title="Click to remove this anchor">
-                  {topic} ×
-                </span>
+                <button
+                  type="button"
+                  key={id}
+                  // A5: real <button> with bigger hit area + visible affordance so
+                  // the dismiss target doesn't get missed in study sessions.
+                  style={{
+                    background: '#dce4f5', borderRadius: '4px',
+                    padding: '4px 8px', minHeight: 24,
+                    fontSize: '10px', fontWeight: 600, color: '#3b5998',
+                    cursor: 'pointer', border: 'none',
+                    display: 'inline-flex', alignItems: 'center', gap: 4,
+                  }}
+                  onClick={(e) => { e.stopPropagation(); handleToggleAnchor(id); }}
+                  aria-label={`Remove ${topic} grouping`}
+                  title="Click to remove this anchor"
+                >
+                  <span>{topic}</span>
+                  <span aria-hidden style={{ fontSize: 14, lineHeight: 1, color: '#5b71a8' }}>×</span>
+                </button>
               );
             })}
           </div>
@@ -1569,10 +1593,18 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                   handleToggleAnchor(anchorForThisCard);
                 }}
                 aria-label={`Dismiss ${anchorTopic ?? 'group'}`}
+                // A5: 24px hit target. Background appears on hover so the click
+                // affordance is obvious.
                 style={{
                   background: 'none', border: 'none', cursor: 'pointer',
-                  color: '#94a3b8', fontSize: '14px', lineHeight: 1, padding: '0 2px',
+                  color: '#94a3b8', fontSize: '16px', lineHeight: 1,
+                  padding: '6px 8px',
+                  minWidth: 24, minHeight: 24,
+                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                  borderRadius: 4,
                 }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = '#475569'; (e.currentTarget as HTMLElement).style.background = '#e2e8f0'; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = '#94a3b8'; (e.currentTarget as HTMLElement).style.background = 'none'; }}
               >
                 ×
               </button>
@@ -1645,8 +1677,19 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                   setHoveredCardIndex(index);
                   setHoveredSidebarPost(stack.topPost.id, stack.topPost.relations);
                 }}
-                onMouseLeave={() => {
+                onMouseLeave={(e) => {
                   if (isTouch) return;
+                  // A6: ignore Paper-leave events where the mouse went to a
+                  // sibling that is still part of the SAME card container
+                  // (bottom-edge zone, stack-shadow layers). Without this guard
+                  // the cross-highlight/dim breaks every time the cursor brushes
+                  // those zones mid-interaction.
+                  const next = (e.relatedTarget as Node | null);
+                  if (next && (e.currentTarget as HTMLElement)
+                      .closest('[data-related-card]')
+                      ?.contains(next)) {
+                    return;
+                  }
                   setHoveredCardIndex(null); setHoveredSidebarPost(null);
                   setHoveredHighlightRangeIndex(null); setHoveredCategory(null);
                 }}


### PR DESCRIPTION
## Summary

Robustness pass on the `/listy-injection` study route — addresses items A1–A7 of the Group A bug list. Each commit is one issue (or a small cluster), and all fixes stay scoped to the aside / related-stacks panel and the listy-injection page itself.

- **A2 + A3 — empty-state aside.** The three aside slots (`/listy-injection`, `/posts/[id]`, default) all bailed out with `return null` when `relatedStacks.length === 0`, which made the panel vanish whenever a focus post had no relations. Replace that with an explicit empty-state card and an `activePostId` guard so we still hide the panel when nothing is focused.
- **A4 — browser back in thread mode.** The page kept its thread state purely in React (no URL change), so the browser back button used to yank study subjects off `/listy-injection` entirely. Push a history marker on entering thread mode, intercept `popstate`, and route browser-back through the same in-page handler as our Back button. Also re-seeds the aside with the first feed post when we land back in feed mode.
- **A1 — defensive fallback.** Guard `navigateToPost` against unresolvable ids (warns instead of entering an empty thread mode), and render an explicit "Post unavailable" card with a Back affordance if `currentPost` is null in thread mode — so a data gap reads as a recoverable empty state instead of a crash.
- **A5 — close button hit area.** Three `×` dismiss controls in `RelatedStacks` (span-filter clear, "Grouped by" chip, per-group dismiss) had ~14 px hit targets and one wasn't even a `<button>`. Bumped to 24 px min hit area, added hover backgrounds, switched the "Grouped by" chip to a real button, and added `stopPropagation` so the click can't bubble into a card navigation.
- **A6 — cross-highlight dim drops mid-interaction.** `Paper.onMouseLeave` fired any time the cursor moved into the card's own bottom-edge hover zone, clearing `hoveredCardIndex` and breaking the cross-card dim. Guard the leave handler with a `relatedTarget` check against the parent `[data-related-card]` so we only clear when the mouse really has left the card.
- **A7 — verified working.** The F PR (#155) overhaul already wires the F-indicator (`Topic (N)`) click correctly. Confirmed in the running app: clicking the indicator toggles the anchor and the cluster expands; the `MORE [topic]` pagination link calls `handleShowMore` as expected.
- **A8 — deferred.** macOS-only environment for this session; no Linux-Chrome-specific change was made. The A6 fix is the most plausible cross-browser candidate, but I didn't reproduce on the user's reported environment.

## Files changed

- `src/app/(shell)/@aside/default.tsx`
- `src/app/(shell)/@aside/listy-injection/page.tsx`
- `src/app/(shell)/posts/[id]/@aside/page.tsx`
- `src/app/(shell)/listy-injection/page.tsx`
- `src/components/RelatedStacks.tsx`

Diff is ~246 lines across 5 files, well under the project's 400-line PR limit.

## Notes for the reviewer

- I could not reproduce A1 (the "page crash on clicking a related post") with synthetic React event invocation or `preview_click`. The defensive guards I added are belt-and-braces, not a confirmed root-cause fix — if you have an actual reproduction we should add a more targeted fix and surface the original error rather than swallow it. The A1 changes log a `console.warn` when they fire so the data-integrity gap will be visible in study logs.
- The two untracked WIP routes (`src/app/(shell)/listy-injection/posts/*` and the mock resolver) are left alone — they're part of an in-flight branch and not in scope for this PR.

## Test plan

- [ ] `/listy-injection` loads with 15 related cards in the aside.
- [ ] Hover the first card slowly, then drag the cursor into the bottom-edge zone of the same card — other cards stay dimmed the whole time.
- [ ] Click a `<mark>` to set an anchor, then click the small `×` on the "Grouped by" chip and the per-group `×` — both targets are easy to hit and the anchor clears.
- [ ] Click into a related post (enter thread mode), press the browser back button — you stay on `/listy-injection` and return to feed mode with the aside re-populated.
- [ ] `pnpm build` still passes (verified locally).