### PR TITLE
Use neutral border on related post cards

### DIFF
--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -1653,7 +1653,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                 style={{
                   position: 'relative', width: '100%', backgroundColor: '#ffffff', zIndex: 5,
                   borderRadius: '10px', margin: '0 auto', paddingTop: '40px',
-                  border: `2px solid ${colors.border}`,
+                  border: `2px solid #e2e8f0`,
                   boxShadow: stack.size > 1 ? 'none' : '0 2px 12px rgba(0,0,0,0.06)',
                   transition: 'box-shadow 150ms ease, border-color 150ms ease, transform 150ms ease',
                   cursor: 'pointer',
@@ -1911,7 +1911,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                       position: 'absolute', inset: 0,
                       transform: `translate(${6 - 3 * idx}px, ${12 - 6 * idx + (isCardHovered ? 20 - (idx * 10) : 0)}px)`,
                       width: '100%', backgroundColor: '#ffffff', borderRadius: '10px',
-                      zIndex: idx + 1, pointerEvents: 'none', border: `2px solid ${colors.border}`,
+                      zIndex: idx + 1, pointerEvents: 'none', border: `2px solid #e2e8f0`,
                       boxShadow: idx === 0 ? '0 12px 24px rgba(0,0,0,0.18), 0 6px 12px rgba(0,0,0,0.12)' : 'none',
                       transition: 'box-shadow 150ms ease, border-color 150ms ease, transform 200ms ease',
                     }} />


### PR DESCRIPTION
## Summary

Cherry-picks `e900325` from the orphan branch `claude/musing-hellman-e4a68b` (open PR #159) onto the listy-injection feature line where the change is actually needed.

Replaces the category-colored card border with neutral `#e2e8f0` on the two related-stack card render sites in `RelatedStacks.tsx` (the main card and the stacked-cards underlay).

## Test plan

- [x] Both occurrences of `border: \`2px solid ${colors.border}\`` are now `border: \`2px solid #e2e8f0\``
- [x] `tsc --noEmit` passes
- [ ] Manual: related-post cards render with grey borders, no per-category color leak

Targets `tarcode2004/enhancement/listy-injection-main-app`, not \`dev\`. Once merged, PR #159 against the orphan branch can be closed.