### PR TITLE
Fix tag tooltip topic, listy URL sync, and ancestor rendering

### DIFF
--- a/src/app/(shell)/listy-injection/page.tsx
+++ b/src/app/(shell)/listy-injection/page.tsx
@@ -214,6 +214,7 @@ export default function ListyInjectionPage() {
 
   /**
    * Global parent map (childId → parentId) derived from inherent thread hierarchy:
+   *  - `entry.ancestors` is an oldest-first chain; the last element is focusPost's parent.
    *  - Each post in `entry.replies` is a comment to that entry's focusPost
    *  - Any post (focus, related, reply) with an explicit `inReplyToId` overrides
    * Posts with no inherent parent are roots and have no ancestors.
@@ -221,7 +222,18 @@ export default function ListyInjectionPage() {
   const parentMap = useMemo(() => {
     const map = new Map<string, string>();
     for (const e of entries) {
-      // Focus post may declare a parent
+      // entry.ancestors: oldest-first chain. Each consecutive pair is parent → child,
+      // and the last ancestor is the immediate parent of focusPost.
+      const ancestors = e.ancestors ?? [];
+      for (let i = 1; i < ancestors.length; i++) {
+        if (!map.has(ancestors[i].id)) {
+          map.set(ancestors[i].id, ancestors[i - 1].id);
+        }
+      }
+      if (ancestors.length > 0 && !map.has(e.focusPost.id)) {
+        map.set(e.focusPost.id, ancestors[ancestors.length - 1].id);
+      }
+      // Focus post may declare an explicit parent (overrides ancestor-derived link)
       if (e.focusPost.inReplyToId) {
         map.set(e.focusPost.id, e.focusPost.inReplyToId);
       }
@@ -260,6 +272,9 @@ export default function ListyInjectionPage() {
     const map = new Map<string, FocusPostMock>();
     for (const e of entries) {
       map.set(e.focusPost.id, e.focusPost);
+      for (const ancestor of e.ancestors ?? []) {
+        if (!map.has(ancestor.id)) map.set(ancestor.id, ancestor);
+      }
       for (const reply of e.replies ?? []) {
         if (!map.has(reply.id)) map.set(reply.id, reply);
       }
@@ -341,6 +356,13 @@ export default function ListyInjectionPage() {
     setActivePostId(postId);
     activePostIdRef.current = postId;
     window.scrollTo(0, 0);
+
+    // Bug 2: reflect focused post in URL. Native pushState avoids Next.js router
+    // re-rendering (which can interfere with AnimatePresence transitions).
+    const targetSearch = `?focus=${postId}`;
+    if (typeof window !== "undefined" && window.location.search !== targetSearch) {
+      window.history.pushState({ focus: postId }, "", `/listy-injection${targetSearch}`);
+    }
   }, [historyStack, getRelatedStacks]);
 
   const navigateBack = useCallback(() => {
@@ -364,6 +386,16 @@ export default function ListyInjectionPage() {
         window.scrollTo(0, savedY);
       });
 
+      // Bug 2: keep URL in sync with the new top-of-stack focus (or clear ?focus on return to feed)
+      const targetSearch = restoreId ? `?focus=${restoreId}` : "";
+      if (typeof window !== "undefined" && window.location.search !== targetSearch) {
+        window.history.pushState(
+          restoreId ? { focus: restoreId } : null,
+          "",
+          `/listy-injection${targetSearch}`,
+        );
+      }
+
       return next;
     });
   }, [getRelatedStacks]);
@@ -373,6 +405,35 @@ export default function ListyInjectionPage() {
     registerNavigateCallback(navigateToPost);
     return () => registerNavigateCallback(null);
   }, [navigateToPost]);
+
+  // Bug 2: on mount, if URL has ?focus=<postId>, enter thread mode for that post.
+  const hydratedFocusRef = useRef(false);
+  useEffect(() => {
+    if (hydratedFocusRef.current) return;
+    if (typeof window === "undefined") return;
+    const focusId = new URLSearchParams(window.location.search).get("focus");
+    if (!focusId) { hydratedFocusRef.current = true; return; }
+    hydratedFocusRef.current = true;
+    requestAnimationFrame(() => navigateToPost(focusId));
+  }, [navigateToPost]);
+
+  // Bug 2: browser back/forward — re-sync historyStack from URL when popstate fires.
+  useEffect(() => {
+    const onPopState = () => {
+      const focusId = new URLSearchParams(window.location.search).get("focus");
+      if (focusId) {
+        setHistoryStack([focusId]);
+        const stacks = getRelatedStacks(focusId);
+        setFromPostRef.current(stacks, focusId, { force: true });
+        setActivePostId(focusId);
+        activePostIdRef.current = focusId;
+      } else {
+        setHistoryStack([]);
+      }
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [getRelatedStacks]);
 
   // ── Feed mode posts ────────────────────────────────────────────────────────
   const posts = useMemo(() => entries.map(toPostData), []);
@@ -652,17 +713,21 @@ export default function ListyInjectionPage() {
   const enterX = navDirection === 'forward' ? 40 : -40;
   const exitX = navDirection === 'forward' ? -40 : 40;
 
+  // NOTE: Previous version wrapped this in <AnimatePresence mode="wait"> with
+  // x-slide enter/exit animations. That blocked the feed→thread mode transition
+  // — the exit animation never released, leaving the page stuck in feed mode
+  // even when historyStack was populated. We render directly here; revisit
+  // animation later if needed (Group's UX polish can re-add it without
+  // mode="wait", e.g. via layout-aware mode="popLayout" or by animating the
+  // whole tree at the layout level).
   return (
-    <AnimatePresence mode="wait" initial={false}>
-      <motion.div
-        key={inThreadMode ? threadKey : 'feed'}
-        initial={{ opacity: 0, x: enterX }}
-        animate={{ opacity: 1, x: 0 }}
-        exit={{ opacity: 0, x: exitX }}
-        transition={{ duration: 0.25, ease: [0.2, 0.8, 0.2, 1] }}
-      >
-        {inThreadMode ? threadContent : feedContent}
-      </motion.div>
-    </AnimatePresence>
+    <motion.div
+      key={inThreadMode ? threadKey : 'feed'}
+      initial={{ opacity: 0, x: enterX }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.25, ease: [0.2, 0.8, 0.2, 1] }}
+    >
+      {inThreadMode ? threadContent : feedContent}
+    </motion.div>
   );
 }

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -1680,11 +1680,15 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                       const tc = getCategoryColors(cat);
                       const anyDirected = hri !== null || hcat !== null;
                       const tagBright = !anyDirected || indices.includes(hri ?? -1) || hcat === cat;
-                      const categoryLabel = CATEGORY_LABELS[cat] ?? cat;
-                      const otherCount = Math.max(0, (categoryStackCount.get(cat) ?? 0) - 1);
+                      // Tag tooltip should match the highlight-text tooltip: show the
+                      // TOPIC of the first relation of this category (the same relation
+                      // a click would anchor on), and the count for THAT topic.
+                      const tagRangeIdx = indices[0];
+                      const tagTopic = topicOf(rels[tagRangeIdx], stack.stackId, tagRangeIdx);
+                      const otherCount = Math.max(0, (topicTotal.get(tagTopic) ?? 0) - 1);
                       const tagHover = (clientX: number, clientY: number) => {
                         showTooltip({
-                          content: buildTooltipLabel(categoryLabel, otherCount, tc.text),
+                          content: buildTooltipLabel(tagTopic, otherCount, tc.text),
                           colors: { text: tc.text, border: tc.border },
                           x: clientX,
                           y: clientY,

--- a/src/types/PostType.tsx
+++ b/src/types/PostType.tsx
@@ -122,6 +122,11 @@ export interface RelatedPostMock {
 export interface ListyInjectionEntry {
   focusPost: FocusPostMock;
   relatedPosts: RelatedPostMock[];
+  /**
+   * Optional oldest-first chain of ancestor posts. `ancestors[ancestors.length - 1]`
+   * is the immediate parent of `focusPost`. See LISTY-INJECTION-SCHEMA.md.
+   */
+  ancestors?: FocusPostMock[];
   replies?: FocusPostMock[];
 }
 


### PR DESCRIPTION
Three fixes against the listy-injection feature line.

## 1. Tag-pill tooltip shows TOPIC, not category

Previously the tooltip on a relation-tag pill (\`Connections\`, \`Agree\`, \`Disagree\`, …) showed the category label, e.g. \"Connections\". Hovering the related-text highlight on the same card showed the topic (e.g. \"Tariffs\"). Same card, same relation, two different tooltips.

Fix in [src/components/RelatedStacks.tsx:1685-1696](src/components/RelatedStacks.tsx:1685): use \`topicOf(rels[indices[0]], stack.stackId, indices[0])\` for the tooltip content and \`topicTotal.get(tagTopic)\` for the count — the same topic and count the highlight tooltip uses, and the same relation the tag's click anchors on.

## 2. Listy page now writes \`?focus=<postId>\` to the URL on navigation

\`navigateToPost\` and \`navigateBack\` push to the URL via native \`window.history.pushState\` (avoiding Next.js's router so the page doesn't re-render and reset local state). A mount-time hydration effect enters thread mode automatically when \`?focus=…\` is in the URL on load, and a \`popstate\` listener re-syncs \`historyStack\` for browser back/forward.

Used \`window.history.pushState\` rather than \`router.push\` because the latter triggered a Next router re-render that interfered with the page's local navigation state.

## 3. Ancestors now show in thread mode

\`entry.ancestors\` (oldest-first chain from the listy-injection schema) was not wired into \`parentMap\` or \`postById\`. The thread-mode renderer walks \`parentMap\` via \`getAncestorChain\`, so every focus post appeared as a root with no parent.

Fix in [src/app/(shell)/listy-injection/page.tsx](src/app/(shell)/listy-injection/page.tsx):
- \`parentMap\` (line ~221) now links each entry's ancestor chain (\`ancestors[i+1].parent = ancestors[i]\`) and points each focus post's parent at \`ancestors[last]\`.
- \`postById\` (line ~272) now includes ancestor posts so \`resolveEntry\` can render them.
- \`ListyInjectionEntry\` in \`src/types/PostType.tsx\` gets the \`ancestors?\` field that the schema doc already documents.

Replies still come from \`entry.replies\` / \`childrenByParent\` — the current mock dataset has empty \`replies\` arrays, so none render. The path is wired; data is the limiting factor.

## Bonus: AnimatePresence mode=\"wait\" blocked the feed→thread transition

While verifying the URL/ancestor fixes I observed that thread mode would never visually engage (Back button missing, ancestor not shown) even though \`historyStack\` updated correctly. Root cause: the outer \`<AnimatePresence mode=\"wait\">\` exit animation on the \`feed\` key was getting stuck, so the new \`thread-<id>\` motion.div never mounted.

Removed the wrapper and kept a single \`<motion.div key={…}>\` for the enter animation. Exit animation can be re-added with \`mode=\"popLayout\"\` if desired.

## Test plan

Verified manually at \`/listy-injection\`:

- [x] Click a related post's body → URL becomes \`?focus=<postId>\`, ancestor (e.g. marklandler_3 for student_3) appears above the focus, focus post renders, Back button visible.
- [x] Click Back → URL clears to \`/listy-injection\`, feed mode restored.
- [x] Refresh on \`?focus=<id>\` → page enters thread mode automatically.
- [x] Browser back/forward → \`popstate\` listener syncs internal state to URL.
- [x] Filter sidebar chips at top of the panel still filter (Bug 2 didn't break unrelated behavior).
- [x] F-indicator click still anchors and clusters (previous PR).
- [x] \`pnpm tsc --noEmit\` passes.

Targets \`tarcode2004/enhancement/listy-injection-main-app\`, not \`dev\`.