### PR TITLE
Baby Stacky: mock-backed /listy-injection/posts/[id] route + back-nav restore

### DIFF
--- a/src/app/(shell)/@aside/listy-injection/posts/[id]/page.tsx
+++ b/src/app/(shell)/@aside/listy-injection/posts/[id]/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import RelatedStacks from "../../../../../../components/RelatedStacks";
+import { useRelatedStacks } from "../../../../related-stacks-context";
+
+export default function MockPostAside() {
+  const { relatedStacks, showUpdate } = useRelatedStacks();
+  const params = useParams();
+  const router = useRouter();
+  const focusPostId = typeof params?.id === "string" ? params.id : undefined;
+
+  if (!relatedStacks || relatedStacks.length === 0) return null;
+
+  // Override the default /posts/[id] navigation so we stay on the mock-backed route.
+  // Manually attaches ?from= to preserve the back-link source.
+  const onPostNavigate = (postId: string) => {
+    const params = new URLSearchParams();
+    if (focusPostId) params.set("from", focusPostId);
+    const search = params.toString();
+    const url = `/listy-injection/posts/${postId}${search ? "?" + search : ""}`;
+    sessionStorage.setItem(`previousPath:/listy-injection/posts/${postId}`, window.location.pathname + window.location.search);
+    sessionStorage.setItem(`scrollY:${window.location.pathname}`, String(window.scrollY));
+    router.push(url);
+  };
+
+  return (
+    <div style={{ width: "100%" }}>
+      <RelatedStacks
+        relatedStacks={relatedStacks}
+        cardWidth={"100%"}
+        onStackClick={() => {}}
+        showupdate={showUpdate}
+        sourcePostId={focusPostId}
+        onPostNavigate={onPostNavigate}
+      />
+    </div>
+  );
+}

--- a/src/app/(shell)/listy-injection/URL_SCHEMA.md
+++ b/src/app/(shell)/listy-injection/URL_SCHEMA.md
@@ -1,0 +1,61 @@
+# Baby Stacky — URL schema
+
+The `/listy-injection/*` routes are the research prototype ("baby stacky") for the future production Stacky system. This doc defines the URL contract so studies, deep-links, and the eventual production routes stay consistent.
+
+## Routes
+
+| Path | Purpose | Data source |
+|---|---|---|
+| `/listy-injection` | Feed view (hashtag stream + per-post in-page thread) | `src/app/FakeData/listy-injection.json` |
+| `/listy-injection/posts/[id]` | Post-detail with threaded replies + related-post aside | Same JSON, resolver in `src/utils/mockPostResolver.ts` |
+
+The post-detail route mirrors the future `/posts/[id]` route. The same React components are shared (`Post`, `ThreadedReplyList`, `RelatedStacks`, `BackButton`, `ReplySection`) and the same URL-sync hook (`useUrlSync`) is reused, so the URL contract carries over verbatim.
+
+## Search params
+
+All params are managed by [`useUrlSync`](../../../utils/useUrlSync.ts) unless noted.
+
+| Param | Type / format | Default | Hydration | Write | Purpose |
+|---|---|---|---|---|---|
+| `tab` | `time \| recommended \| stacked \| summary` | `time` (omitted from URL) | yes | yes | Active reply tab |
+| `fc` | CSV of category keys, sorted alpha | empty | yes | yes | Active filter chips (AND semantics) |
+| `fs` | `start-end` (numeric offsets into focus-post plaintext) | none | deferred until post content loads | yes | Focus-span filter from clicking a mark on the focus post |
+| `from` | `{post-id}` | none | one-shot on mount (seeds `previousPath`) | no | Back-link source — sets `sessionStorage['previousPath:/.../posts/{current}']` so BackButton can render |
+| `stackId` | `{stack-id}` | none | pass-through | pass-through | Preserved across navigation; not modified by `useUrlSync` |
+
+### Reserved (not yet wired)
+
+These are intentionally absent today but reserved for forward compatibility:
+
+| Param | Intended use | Why not wired yet |
+|---|---|---|
+| `anchor` | Active see-more anchor (single `reRankAnchorIds[0]`) | Open call #6 — sharing of see-more cluster state. Restore would also need `show={n}` for `shownByAnchor` pagination. |
+| `aside` | Explicit aside post id (when different from route's focus post) | Open call #7 — aside currently derives from route id; deep-link to a non-default aside post is not yet a use case. |
+
+If/when these land, follow the same patterns as `fc` and `fs`: hydrate once per pathname, write back debounced, and respect the `from`/`stackId` pass-through contract.
+
+## Hydration semantics
+
+1. **Read direction (mount):** the first effect under a given `pathname` reads `?tab` / `?fc` / `?fs` once and applies to local state. A `hydratedRef` guards against re-application until the route changes.
+2. **Write direction (state change):** any change to `activeTab`, `filterCategories`, or `filterFocusSpan` schedules a `router.replace()` with a 300 ms debounce. `router.replace` (not `push`) — filter toggles don't pollute history.
+3. **Span text reconstruction:** `?fs=12-89` carries offsets only. The `text` field of `filterFocusSpan` is reconstructed from `plainPostText.slice(start, end)` after the post loads. Hand-edited URLs need to know the post's exact text.
+4. **`?from` is one-shot:** seeded into `sessionStorage` on mount, never written. The `BackButton` reads from `sessionStorage['previousPath:{pathname}']` on its own mount. Navigating away clears the read but the storage entry stays until next session.
+
+## How a study deep-link reconstructs
+
+A URL like:
+
+```
+/listy-injection/posts/112880124583497150?fc=connections,framing&fs=12-89&tab=recommended&from=112854373877034288
+```
+
+reconstructs:
+- Focus post `112880124583497150`
+- Connections + Framing filter chips active
+- Focus-span filter on plaintext offsets `12..89`
+- Recommended tab active (with `onHydratedTab` triggering the data fetch in the real route)
+- Back-button labeled "Back" pointing to post `112854373877034288`
+
+## Compatibility with the future production route
+
+When the real Stacky platform exposes `/posts/[id]`, it can adopt the same schema unchanged — `useUrlSync` is shared. Differences will live only in the **data layer** (live Mastodon API vs. `mockPostResolver`).

--- a/src/app/(shell)/listy-injection/page.tsx
+++ b/src/app/(shell)/listy-injection/page.tsx
@@ -194,7 +194,7 @@ function replyToPostData(reply: FocusPostMock) {
 
 export default function ListyInjectionPage() {
   const router = useRouter();
-  const { setFromPost } = useRelatedStacks();
+  const { setFromPost, activePostId: ctxActivePostId } = useRelatedStacks();
   const [activePostId, setActivePostId] = useState<string | null>(null);
   const activePostIdRef = useRef<string | null>(null);
   const setFromPostRef = useRef(setFromPost);
@@ -325,13 +325,22 @@ export default function ListyInjectionPage() {
   // does not artificially make the previously focused post an ancestor.
   const [historyStack, setHistoryStack] = useState<string[]>([]);
   const inThreadMode = historyStack.length > 0;
+  /** True while back-nav restoration is in progress — used to suppress the
+   *  scroll listener's mount-time onScroll() so it doesn't override the
+   *  restored active post before scrollTo lands. Cleared after the RAFs fire. */
+  const isRestoringRef = useRef(false);
   const savedScrollRef = useRef<Map<string, number>>(new Map());
   // Direction of the last navigation — drives the slide animation in AnimatePresence.
   const [navDirection, setNavDirection] = useState<'forward' | 'backward'>('forward');
 
   const navigateToPost = useCallback((postId: string) => {
-    // Save current feed scroll so a Back navigation can restore it.
+    // Save feed state for back-nav restoration: scroll position and the
+    // post the user clicked (which is what should re-focus on return).
+    // Direct feed clicks pass the clicked feed-post id. Aside clicks may
+    // pass a related-post id that isn't a feed entry — the restore effect
+    // handles that by leaving the aside alone if the id isn't found in posts.
     sessionStorage.setItem(`scrollY:/listy-injection`, String(window.scrollY));
+    sessionStorage.setItem(`activeFeedPost:/listy-injection`, postId);
     // Seed BackButton's previousPath so the post-detail route shows "Back".
     sessionStorage.setItem(
       `previousPath:/listy-injection/posts/${postId}`,
@@ -380,12 +389,64 @@ export default function ListyInjectionPage() {
     return () => { resetHighlightStore(); registerNavigateCallback(null); };
   }, []);
 
-  // Auto-activate first post
+  // Auto-activate first post — but skip if:
+  //   - we're restoring from a back-nav (restore effect handles it)
+  //   - the context already remembers an active post (carried over from a
+  //     detail-page visit). Surviving React Strict Mode's double-mount in dev
+  //     depends on this check: by the second mount, sessionStorage has been
+  //     cleared but context still holds the restored post.
   useEffect(() => {
-    if (posts.length > 0 && !activePostId) {
-      const first = posts[0];
-      setActivePostId(first.postId);
-      setFromPost(first.relatedStacks, first.postId, { force: true });
+    if (posts.length === 0 || activePostId) return;
+    const hasRestore =
+      typeof window !== "undefined" &&
+      (sessionStorage.getItem("scrollY:/listy-injection") !== null ||
+        sessionStorage.getItem("activeFeedPost:/listy-injection") !== null);
+    if (hasRestore) return;
+    if (ctxActivePostId) return;
+    const first = posts[0];
+    setActivePostId(first.postId);
+    setFromPost(first.relatedStacks, first.postId, { force: true });
+  }, []);
+
+  // Restore feed state when returning from a post detail page.
+  // `navigateToPost` saved scrollY + the active feed post id; replay both
+  // here so the focus + aside match what the user left, without waiting on
+  // the scroll listener to maybe-fire after scrollTo.
+  useEffect(() => {
+    const savedY = sessionStorage.getItem("scrollY:/listy-injection");
+    const savedActiveId = sessionStorage.getItem("activeFeedPost:/listy-injection");
+    if (!savedY && !savedActiveId) return;
+
+    isRestoringRef.current = true;
+
+    // Restore active post + aside immediately (independent of scroll layout).
+    if (savedActiveId) {
+      const target = posts.find((p) => p.postId === savedActiveId);
+      if (target) {
+        setActivePostId(target.postId);
+        activePostIdRef.current = target.postId;
+        setFromPost(target.relatedStacks, target.postId, { force: true });
+      }
+    }
+
+    // Restore scroll after two RAFs so feed posts settle at their final heights.
+    // sessionStorage cleanup is deferred until after the RAFs so a React
+    // Strict Mode second-mount re-runs the restore and ends in the same
+    // state instead of falling through to auto-activate.
+    const y = savedY ? parseInt(savedY, 10) : 0;
+    if (!Number.isNaN(y) && y > 0) {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          window.scrollTo(0, y);
+          isRestoringRef.current = false;
+          sessionStorage.removeItem("scrollY:/listy-injection");
+          sessionStorage.removeItem("activeFeedPost:/listy-injection");
+        });
+      });
+    } else {
+      isRestoringRef.current = false;
+      sessionStorage.removeItem("scrollY:/listy-injection");
+      sessionStorage.removeItem("activeFeedPost:/listy-injection");
     }
   }, []);
 
@@ -430,7 +491,11 @@ export default function ListyInjectionPage() {
         }
       });
     };
-    onScroll();
+    // Skip the mount-time onScroll() while a back-nav restoration is in
+    // flight — the restore effect has already set the right active post,
+    // and we don't want to clobber it with bestIdx=0 (top of feed) before
+    // scrollTo lands. Subsequent scroll events still fire normally.
+    if (!isRestoringRef.current) onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
     return () => { window.removeEventListener("scroll", onScroll); cancelAnimationFrame(rafId); };
   }, [posts, inThreadMode]);

--- a/src/app/(shell)/listy-injection/page.tsx
+++ b/src/app/(shell)/listy-injection/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from "react"
 import { Text, Paper, Box, Group, Divider, Button } from "@mantine/core";
 import { IconArrowLeft } from "@tabler/icons-react";
 import { motion, AnimatePresence } from "framer-motion";
+import { useRouter } from "next/navigation";
 import Post from "../../../components/Posts/Post";
 import mockData from "../../FakeData/listy-injection.json";
 import type { ListyInjectionData, ListyInjectionEntry, RelatedPostMock, FocusPostMock, Relation, CategoryKey } from "../../../types/PostType";
@@ -192,6 +193,7 @@ function replyToPostData(reply: FocusPostMock) {
 // ── Component ────────────────────────────────────────────────────────────────
 
 export default function ListyInjectionPage() {
+  const router = useRouter();
   const { setFromPost } = useRelatedStacks();
   const [activePostId, setActivePostId] = useState<string | null>(null);
   const activePostIdRef = useRef<string | null>(null);
@@ -328,20 +330,15 @@ export default function ListyInjectionPage() {
   const [navDirection, setNavDirection] = useState<'forward' | 'backward'>('forward');
 
   const navigateToPost = useCallback((postId: string) => {
-    // Save current scroll
-    const key = historyStack.length > 0 ? historyStack[historyStack.length - 1] : "__feed__";
-    savedScrollRef.current.set(key, window.scrollY);
-
-    setNavDirection('forward');
-    setHistoryStack(prev => [...prev, postId]);
-
-    // Update sidebar to show this post's related stacks
-    const stacks = getRelatedStacks(postId);
-    setFromPostRef.current(stacks, postId, { force: true });
-    setActivePostId(postId);
-    activePostIdRef.current = postId;
-    window.scrollTo(0, 0);
-  }, [historyStack, getRelatedStacks]);
+    // Save current feed scroll so a Back navigation can restore it.
+    sessionStorage.setItem(`scrollY:/listy-injection`, String(window.scrollY));
+    // Seed BackButton's previousPath so the post-detail route shows "Back".
+    sessionStorage.setItem(
+      `previousPath:/listy-injection/posts/${postId}`,
+      "/listy-injection",
+    );
+    router.push(`/listy-injection/posts/${postId}`);
+  }, [router]);
 
   const navigateBack = useCallback(() => {
     setNavDirection('backward');

--- a/src/app/(shell)/listy-injection/page.tsx
+++ b/src/app/(shell)/listy-injection/page.tsx
@@ -389,52 +389,47 @@ export default function ListyInjectionPage() {
     return () => { resetHighlightStore(); registerNavigateCallback(null); };
   }, []);
 
-  // Auto-activate first post — but skip if:
-  //   - we're restoring from a back-nav (restore effect handles it)
-  //   - the context already remembers an active post (carried over from a
-  //     detail-page visit). Surviving React Strict Mode's double-mount in dev
-  //     depends on this check: by the second mount, sessionStorage has been
-  //     cleared but context still holds the restored post.
+  // Unified mount-time focus + scroll restoration.
+  //
+  // Three cases handled in priority order:
+  //   1. Saved state in sessionStorage (came back from a post detail page via
+  //      browser-back or our UI BackButton — both pop history and remount
+  //      this route). Restore the active feed post + scroll position; aside
+  //      repopulates from setFromPost.
+  //   2. Context already has an active post (typical for React Strict Mode's
+  //      2nd mount in dev, where sessionStorage was cleared by the 1st mount's
+  //      RAF). Sync local state from context so the Post highlight reappears.
+  //   3. Fresh visit with no prior state — auto-activate the first feed post.
+  //
+  // All three end with: local activePostId set, activePostIdRef synced,
+  // and aside populated. The scroll listener's mount-time onScroll() is
+  // suppressed while isRestoringRef is true so it can't override the
+  // restored post with bestIdx=0 before scrollTo lands.
   useEffect(() => {
     if (posts.length === 0 || activePostId) return;
-    const hasRestore =
-      typeof window !== "undefined" &&
-      (sessionStorage.getItem("scrollY:/listy-injection") !== null ||
-        sessionStorage.getItem("activeFeedPost:/listy-injection") !== null);
-    if (hasRestore) return;
-    if (ctxActivePostId) return;
-    const first = posts[0];
-    setActivePostId(first.postId);
-    setFromPost(first.relatedStacks, first.postId, { force: true });
-  }, []);
 
-  // Restore feed state when returning from a post detail page.
-  // `navigateToPost` saved scrollY + the active feed post id; replay both
-  // here so the focus + aside match what the user left, without waiting on
-  // the scroll listener to maybe-fire after scrollTo.
-  useEffect(() => {
-    const savedY = sessionStorage.getItem("scrollY:/listy-injection");
-    const savedActiveId = sessionStorage.getItem("activeFeedPost:/listy-injection");
-    if (!savedY && !savedActiveId) return;
+    const savedY = typeof window !== "undefined"
+      ? sessionStorage.getItem("scrollY:/listy-injection")
+      : null;
+    const savedActiveId = typeof window !== "undefined"
+      ? sessionStorage.getItem("activeFeedPost:/listy-injection")
+      : null;
 
-    isRestoringRef.current = true;
+    // Pick the post to focus, in priority order. Falls back to first feed post.
+    const candidateId = savedActiveId ?? ctxActivePostId ?? posts[0].postId;
+    const target = posts.find((p) => p.postId === candidateId) ?? posts[0];
 
-    // Restore active post + aside immediately (independent of scroll layout).
-    if (savedActiveId) {
-      const target = posts.find((p) => p.postId === savedActiveId);
-      if (target) {
-        setActivePostId(target.postId);
-        activePostIdRef.current = target.postId;
-        setFromPost(target.relatedStacks, target.postId, { force: true });
-      }
-    }
+    // Apply focus + aside synchronously so the Post highlight is in place
+    // before the user sees the page paint.
+    setActivePostId(target.postId);
+    activePostIdRef.current = target.postId;
+    setFromPost(target.relatedStacks, target.postId, { force: true });
 
-    // Restore scroll after two RAFs so feed posts settle at their final heights.
-    // sessionStorage cleanup is deferred until after the RAFs so a React
-    // Strict Mode second-mount re-runs the restore and ends in the same
-    // state instead of falling through to auto-activate.
-    const y = savedY ? parseInt(savedY, 10) : 0;
+    // Schedule scroll restoration if we have a saved position.
+    const y = savedY ? parseInt(savedY, 10) : NaN;
     if (!Number.isNaN(y) && y > 0) {
+      isRestoringRef.current = true;
+      // Two RAFs so feed posts settle to their final laid-out heights.
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           window.scrollTo(0, y);
@@ -444,7 +439,6 @@ export default function ListyInjectionPage() {
         });
       });
     } else {
-      isRestoringRef.current = false;
       sessionStorage.removeItem("scrollY:/listy-injection");
       sessionStorage.removeItem("activeFeedPost:/listy-injection");
     }

--- a/src/app/(shell)/listy-injection/posts/[id]/page.tsx
+++ b/src/app/(shell)/listy-injection/posts/[id]/page.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Button, Divider, Loader, Paper, Tabs, Text } from "@mantine/core";
+import Post from "../../../../../components/Posts/Post";
+import ReplySection from "../../../../../components/ReplySection";
+import BackButton from "../../../../../components/BackButton";
+import ThreadedReplyList from "../../../../../components/ThreadedReplyList";
+import { useRelatedStacks } from "../../../related-stacks-context";
+import { useUrlSync } from "../../../../../utils/useUrlSync";
+import {
+  getMockPost,
+  getMockAncestors,
+  getMockReplies,
+  getMockRelatedStacks,
+  getMockRecommended,
+  getMockFocusRelations,
+  getMockPlainText,
+  mockHasPost,
+  type MockPostType,
+} from "../../../../../utils/mockPostResolver";
+import type { Relation } from "../../../../../types/PostType";
+
+// Thread connector line style — mirrors /posts/[id]
+const THREAD_LINE_COLOR = "#ccd1dc";
+const THREAD_LINE_LEFT = 32;
+
+function stripHtmlToPlain(html: string): string {
+  if (typeof document !== "undefined") {
+    const el = document.createElement("div");
+    el.innerHTML = html;
+    return el.textContent ?? el.innerText ?? "";
+  }
+  return html.replace(/<[^>]*>/g, "");
+}
+
+export default function MockPostView({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const searchParamsObj = useSearchParams();
+  const { id } = params;
+  const { setFromPost } = useRelatedStacks();
+
+  const [post, setPost] = useState<MockPostType | null>(null);
+  const [ancestors, setAncestors] = useState<MockPostType[]>([]);
+  const [replies, setReplies] = useState<MockPostType[]>([]);
+  const [recommendedPosts, setRecommendedPosts] = useState<MockPostType[]>([]);
+  const [focusRelations, setFocusRelations] = useState<Relation[]>([]);
+  const [activeTab, setActiveTab] = useState<string>("time");
+  const [visibleTopLevelReplies, setVisibleTopLevelReplies] = useState(5);
+  const [activePostId, setActivePostId] = useState<string | null>(null);
+  const [currentUser, setCurrentUser] = useState<any | null>(null);
+
+  const plainPostText = post ? stripHtmlToPlain(post.content) : null;
+
+  const filteredReplies = useMemo(() => replies.filter((r) => r.in_reply_to_id === id), [replies, id]);
+  const totalTopLevelReplies = filteredReplies.length;
+
+  // -------------------- Load mock data --------------------
+  useEffect(() => {
+    if (!mockHasPost(id)) {
+      setPost(null);
+      return;
+    }
+    const p = getMockPost(id);
+    setPost(p);
+    setAncestors(getMockAncestors(id));
+    setReplies(getMockReplies(id));
+    setRecommendedPosts(getMockRecommended(id));
+    setFocusRelations(getMockFocusRelations(id));
+    if (p) {
+      setFromPost(p.relatedStacks, id, { force: true });
+      setActivePostId(id);
+    }
+    // Read currentUser from localStorage if present (ReplySection wants it; mock allows null).
+    try {
+      const raw = localStorage.getItem("currentUser");
+      if (raw) setCurrentUser(JSON.parse(raw));
+    } catch {}
+  }, [id]);
+
+  // -------------------- URL sync (H1/H2/H4/H5) --------------------
+  useUrlSync({
+    activeTab,
+    setActiveTab,
+    plainPostText,
+    // Mock mode: tab switches don't require data fetches (data is already loaded).
+    onHydratedTab: () => {},
+  });
+
+  // H5: seed BackButton sessionStorage from ?from= when opening a shared link
+  useEffect(() => {
+    const fromId = searchParamsObj?.get("from");
+    if (!fromId) return;
+    const key = `previousPath:${window.location.pathname}`;
+    if (!sessionStorage.getItem(key)) {
+      sessionStorage.setItem(key, `/listy-injection/posts/${fromId}`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleTabChange = (value: string | null) => {
+    if (value) setActiveTab(value);
+  };
+
+  const renderPost = (p: MockPostType, isFocusPost: boolean = false) => (
+    <Post
+      key={p.id}
+      id={p.id}
+      text={p.content}
+      author={p.account.username}
+      account={p.account.acct || p.account.acc || p.account.username}
+      avatar={p.account.avatar}
+      repliesCount={p.replies_count}
+      createdAt={p.created_at}
+      stackCount={p.stackCount}
+      favouritesCount={p.favourites_count}
+      favourited={p.favourited}
+      bookmarked={p.bookmarked}
+      mediaAttachments={[]}
+      onStackIconClick={() => {}}
+      setIsModalOpen={() => {}}
+      setIsExpandModalOpen={() => {}}
+      relatedStacks={p.relatedStacks}
+      setActivePostId={setActivePostId}
+      activePostId={activePostId}
+      focusRelations={isFocusPost ? focusRelations : []}
+    />
+  );
+
+  if (!mockHasPost(id)) {
+    return (
+      <Paper withBorder radius="md" mt={20} p="lg">
+        <Text size="sm">
+          Post <code>{id}</code> not found in mock data.
+        </Text>
+        <Text size="xs" c="dimmed" mt="xs">
+          This route is the mock-backed mirror of <code>/posts/[id]</code> for H/G verification.
+          Try a post id that exists in <code>FakeData/listy-injection.json</code>.
+        </Text>
+      </Paper>
+    );
+  }
+
+  if (!post) return <Loader size="lg" />;
+
+  return (
+    <div style={{ position: "relative" }}>
+      <BackButton />
+      <div>
+        <div style={{ position: "relative" }}>
+          {/* Ancestors */}
+          {ancestors.length > 0 && (
+            <div style={{ position: "relative" }}>
+              {ancestors.map((a, index) => (
+                <div key={a.id} style={{ position: "relative" }}>
+                  <div
+                    style={{
+                      position: "absolute",
+                      left: THREAD_LINE_LEFT,
+                      top: index === 0 ? "50%" : 0,
+                      bottom: 0,
+                      width: 2,
+                      backgroundColor: THREAD_LINE_COLOR,
+                      zIndex: 0,
+                    }}
+                  />
+                  {renderPost(a)}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Focus post */}
+          <div style={{ position: "relative" }}>
+            {ancestors.length > 0 && (
+              <div
+                style={{
+                  position: "absolute",
+                  left: THREAD_LINE_LEFT,
+                  top: 0,
+                  height: "50%",
+                  width: 2,
+                  backgroundColor: THREAD_LINE_COLOR,
+                  zIndex: 0,
+                }}
+              />
+            )}
+            {renderPost(post, /* isFocusPost */ true)}
+          </div>
+        </div>
+
+        <Divider my="md" />
+
+        <ReplySection postId={id} currentUser={currentUser} fetchPostAndReplies={() => {}} />
+
+        {replies.length > 0 && (
+          <Paper
+            style={{
+              borderRadius: "0 0 8px 8px",
+              fontFamily: "Roboto, sans-serif",
+              fontSize: 14,
+              marginTop: "1rem",
+              width: "100%",
+            }}
+          >
+            <Tabs color="#002379" defaultValue="time" value={activeTab} onChange={handleTabChange}>
+              <Tabs.List style={{ marginBottom: "1rem" }}>
+                {(["time", "recommended", "stacked", "summary"] as const).map((tab) => (
+                  <Tabs.Tab
+                    key={tab}
+                    value={tab}
+                    style={{ fontWeight: activeTab === tab ? "bold" : "normal" }}
+                  >
+                    {tab[0].toUpperCase() + tab.slice(1)}
+                  </Tabs.Tab>
+                ))}
+              </Tabs.List>
+
+              <Tabs.Panel value="time">
+                <ThreadedReplyList
+                  replies={replies as any}
+                  rootId={id}
+                  renderPost={renderPost as any}
+                  visibleTopLevelCount={visibleTopLevelReplies}
+                />
+                {visibleTopLevelReplies < totalTopLevelReplies && (
+                  <Button
+                    onClick={() =>
+                      setVisibleTopLevelReplies((v) => Math.min(v + 5, totalTopLevelReplies))
+                    }
+                    variant="outline"
+                    fullWidth
+                    style={{ marginTop: 10 }}
+                  >
+                    {totalTopLevelReplies - visibleTopLevelReplies} more{" "}
+                    {totalTopLevelReplies - visibleTopLevelReplies === 1 ? "reply" : "replies"}
+                  </Button>
+                )}
+              </Tabs.Panel>
+
+              <Tabs.Panel value="recommended">
+                {recommendedPosts.length > 0
+                  ? recommendedPosts.map((p) => renderPost(p))
+                  : <Text size="sm" c="dimmed" p="md">No recommended posts in mock data for this id.</Text>}
+              </Tabs.Panel>
+
+              <Tabs.Panel value="stacked">
+                <Text size="sm" c="dimmed" p="md">
+                  Stacked view is API-backed in the default route — not available in mock mode.
+                </Text>
+              </Tabs.Panel>
+
+              <Tabs.Panel value="summary">
+                <Text size="sm" c="dimmed" p="md">
+                  Summary view is API-backed in the default route — not available in mock mode.
+                </Text>
+              </Tabs.Panel>
+            </Tabs>
+          </Paper>
+        )}
+
+        <div style={{ height: "100vh" }} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/FakeData/listy-injection.json
+++ b/src/app/FakeData/listy-injection.json
@@ -11,7 +11,7 @@
       },
       "created_at": "2024-07-31T08:20:10.368Z",
       "favourites_count": 0,
-      "replies_count": 1,
+      "replies_count": 8,
       "favourited": false,
       "bookmarked": false
     },
@@ -33,7 +33,7 @@
             "contentCommentStart": 430,
             "contentCommentEnd": 486,
             "category": "framing",
-            "topic": "Consumer costs"
+            "topic": "Climate and tradeoffs"
           },
           {
             "focusStart": 1215,
@@ -45,7 +45,7 @@
             "contentCommentStart": 29,
             "contentCommentEnd": 56,
             "category": "framing",
-            "topic": "Industrial strategy"
+            "topic": "Industrial policy"
           }
         ],
         "account": {
@@ -119,7 +119,7 @@
             "contentCommentStart": 669,
             "contentCommentEnd": 737,
             "category": "values",
-            "topic": "Economic readiness"
+            "topic": "Industrial policy"
           },
           {
             "focusStart": 327,
@@ -131,7 +131,7 @@
             "contentCommentStart": 589,
             "contentCommentEnd": 655,
             "category": "values",
-            "topic": "Workers and pricing"
+            "topic": "Manufacturing"
           }
         ],
         "account": {
@@ -162,7 +162,7 @@
             "contentCommentStart": 805,
             "contentCommentEnd": 824,
             "category": "agree",
-            "topic": "Tariffs and consumers"
+            "topic": "Tariffs"
           },
           {
             "focusStart": 679,
@@ -174,7 +174,7 @@
             "contentCommentStart": 112,
             "contentCommentEnd": 157,
             "category": "agree",
-            "topic": "Global EV market"
+            "topic": "Manufacturing"
           }
         ],
         "account": {
@@ -205,7 +205,7 @@
             "contentCommentStart": 586,
             "contentCommentEnd": 622,
             "category": "disagree",
-            "topic": "Blame narrative"
+            "topic": "Consumers"
           },
           {
             "focusStart": 1072,
@@ -217,7 +217,7 @@
             "contentCommentStart": 541,
             "contentCommentEnd": 584,
             "category": "agree",
-            "topic": "Market access"
+            "topic": "Climate and tradeoffs"
           }
         ],
         "account": {
@@ -248,7 +248,7 @@
             "contentCommentStart": 393,
             "contentCommentEnd": 450,
             "category": "predictions",
-            "topic": "Short-term incentives"
+            "topic": "Consumers"
           },
           {
             "focusStart": 327,
@@ -291,7 +291,7 @@
             "contentCommentStart": 668,
             "contentCommentEnd": 712,
             "category": "proposals",
-            "topic": "Trade policy"
+            "topic": "Tariffs"
           },
           {
             "focusStart": 679,
@@ -303,7 +303,7 @@
             "contentCommentStart": 469,
             "contentCommentEnd": 515,
             "category": "proposals",
-            "topic": "Industrial renewal"
+            "topic": "Industrial policy"
           }
         ],
         "account": {
@@ -334,7 +334,7 @@
             "contentCommentStart": 92,
             "contentCommentEnd": 122,
             "category": "questions",
-            "topic": "Supply chains"
+            "topic": "Tariffs"
           },
           {
             "focusStart": 0,
@@ -346,7 +346,7 @@
             "contentCommentStart": 759,
             "contentCommentEnd": 819,
             "category": "questions",
-            "topic": "Blame framing"
+            "topic": "Industrial policy"
           }
         ],
         "account": {
@@ -377,7 +377,7 @@
             "contentCommentStart": 630,
             "contentCommentEnd": 701,
             "category": "evidence_personal",
-            "topic": "Tariffs and competitiveness"
+            "topic": "Tariffs"
           },
           {
             "focusStart": 679,
@@ -389,7 +389,7 @@
             "contentCommentStart": 460,
             "contentCommentEnd": 479,
             "category": "evidence_personal",
-            "topic": "Product quality"
+            "topic": "Manufacturing"
           }
         ],
         "account": {
@@ -420,7 +420,7 @@
             "contentCommentStart": 137,
             "contentCommentEnd": 206,
             "category": "evidence_public",
-            "topic": "Industry competitiveness"
+            "topic": "Manufacturing"
           },
           {
             "focusStart": 0,
@@ -494,7 +494,7 @@
             "contentCommentStart": 234,
             "contentCommentEnd": 265,
             "category": "framing",
-            "topic": "Consumers"
+            "topic": "Industrial policy"
           }
         ],
         "account": {
@@ -627,6 +627,248 @@
         "created_at": "2024-07-31T08:16:29.838Z",
         "favourites_count": 0,
         "replies_count": 108,
+        "favourited": false,
+        "bookmarked": false
+      }
+    ],
+    "replies": [
+      {
+        "id": "bs-001",
+        "inReplyToId": "112880124583497150",
+        "content": "<p>Strong claim, and the manufacturing-inferiority framing is the right starting point. But consumer welfare also matters here — cheap EVs would benefit millions.</p>",
+        "plainText": "Strong claim, and the manufacturing-inferiority framing is the right starting point. But consumer welfare also matters here — cheap EVs would benefit millions.",
+        "account": {
+          "display_name": "Jane Dev",
+          "acct": "jane_dev",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T09:01:00.000Z",
+        "favourites_count": 12,
+        "replies_count": 2,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-002",
+        "inReplyToId": "bs-001",
+        "content": "<p>Agree on welfare, but at what cost to long-term jobs? Short-term gain vs. structural loss.</p>",
+        "plainText": "Agree on welfare, but at what cost to long-term jobs? Short-term gain vs. structural loss.",
+        "account": {
+          "display_name": "Tony P",
+          "acct": "tony_p",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T09:14:00.000Z",
+        "favourites_count": 4,
+        "replies_count": 1,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-002a",
+        "inReplyToId": "bs-002",
+        "content": "<p>Trade adjustment assistance has been historically weak. That is the real failure, not the imports.</p>",
+        "plainText": "Trade adjustment assistance has been historically weak. That is the real failure, not the imports.",
+        "account": {
+          "display_name": "Jane Dev",
+          "acct": "jane_dev",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T09:31:00.000Z",
+        "favourites_count": 3,
+        "replies_count": 1,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-002a1",
+        "inReplyToId": "bs-002a",
+        "content": "<p>Fair. But weak TAA does not justify ignoring the loss column.</p>",
+        "plainText": "Fair. But weak TAA does not justify ignoring the loss column.",
+        "account": {
+          "display_name": "Tony P",
+          "acct": "tony_p",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T09:44:00.000Z",
+        "favourites_count": 1,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-003",
+        "inReplyToId": "bs-001",
+        "content": "<p>There is also the climate side — every BYD sold is a US gas car not sold. Hard to argue against that math.</p>",
+        "plainText": "There is also the climate side — every BYD sold is a US gas car not sold. Hard to argue against that math.",
+        "account": {
+          "display_name": "Jane Dev",
+          "acct": "jane_dev",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T09:18:00.000Z",
+        "favourites_count": 7,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-004",
+        "inReplyToId": "112880124583497150",
+        "content": "<p>Lived through the steel decline. Same playbook? Cheap imports, towns hollowed out, then nobody around to buy the cheap stuff anyway.</p>",
+        "plainText": "Lived through the steel decline. Same playbook? Cheap imports, towns hollowed out, then nobody around to buy the cheap stuff anyway.",
+        "account": {
+          "display_name": "Rural Voice",
+          "acct": "rural_voice",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T10:02:00.000Z",
+        "favourites_count": 18,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-005",
+        "inReplyToId": "112880124583497150",
+        "content": "<p>Two papers worth reading: Autor 2013 on the China shock, and Pierce-Schott 2016 on PNTR. Both nuance the \"manufacturing inferiority\" framing.</p>",
+        "plainText": "Two papers worth reading: Autor 2013 on the China shock, and Pierce-Schott 2016 on PNTR. Both nuance the \"manufacturing inferiority\" framing.",
+        "account": {
+          "display_name": "Econ PhD",
+          "acct": "econ_phd",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T10:15:00.000Z",
+        "favourites_count": 22,
+        "replies_count": 1,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-006",
+        "inReplyToId": "bs-005",
+        "content": "<p>Pierce-Schott focuses on PNTR, which is a specific policy shift. Not quite the same dynamic as BYD undercutting on price.</p>",
+        "plainText": "Pierce-Schott focuses on PNTR, which is a specific policy shift. Not quite the same dynamic as BYD undercutting on price.",
+        "account": {
+          "display_name": "Tony P",
+          "acct": "tony_p",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T10:33:00.000Z",
+        "favourites_count": 5,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-007",
+        "inReplyToId": "112880124583497150",
+        "content": "<p>Climate is the missing axis here. The fastest path to fleet electrification is the cheapest EV, not the patriotic one.</p>",
+        "plainText": "Climate is the missing axis here. The fastest path to fleet electrification is the cheapest EV, not the patriotic one.",
+        "account": {
+          "display_name": "Climate Now",
+          "acct": "climate_now",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T10:48:00.000Z",
+        "favourites_count": 31,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-008",
+        "inReplyToId": "112880124583497150",
+        "content": "<p>From the engineering side: BYD vertical integration is the story. They control the battery cell, the pack, the motor, and the platform. That is not a subsidy, that is a strategy.</p>",
+        "plainText": "From the engineering side: BYD vertical integration is the story. They control the battery cell, the pack, the motor, and the platform. That is not a subsidy, that is a strategy.",
+        "account": {
+          "display_name": "MC Engineer",
+          "acct": "mc_engineer",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T11:01:00.000Z",
+        "favourites_count": 26,
+        "replies_count": 2,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-009",
+        "inReplyToId": "bs-008",
+        "content": "<p>Saw a BYD Atto 3 in person, build quality was a notch above what I expected.</p>",
+        "plainText": "Saw a BYD Atto 3 in person, build quality was a notch above what I expected.",
+        "account": {
+          "display_name": "Newdriver",
+          "acct": "newdriver",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T11:12:00.000Z",
+        "favourites_count": 8,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-010",
+        "inReplyToId": "bs-008",
+        "content": "<p>Cost engineering does not equal corner cutting. Different design philosophy, that is the part US automakers refuse to learn.</p>",
+        "plainText": "Cost engineering does not equal corner cutting. Different design philosophy, that is the part US automakers refuse to learn.",
+        "account": {
+          "display_name": "MC Engineer",
+          "acct": "mc_engineer",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T11:25:00.000Z",
+        "favourites_count": 9,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-011",
+        "inReplyToId": "112880124583497150",
+        "content": "<p>We learned this lesson with shipping containers and consumer electronics. Each time the answer was \"retrain workers\" and each time the retraining money never showed up.</p>",
+        "plainText": "We learned this lesson with shipping containers and consumer electronics. Each time the answer was \"retrain workers\" and each time the retraining money never showed up.",
+        "account": {
+          "display_name": "Union Rep",
+          "acct": "union_rep",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T11:40:00.000Z",
+        "favourites_count": 14,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-012",
+        "inReplyToId": "112880124583497150",
+        "content": "<p>What is the over/under on a US tariff exemption for EV battery components? Hard to imagine the IRA tax credits surviving a full tariff wall.</p>",
+        "plainText": "What is the over/under on a US tariff exemption for EV battery components? Hard to imagine the IRA tax credits surviving a full tariff wall.",
+        "account": {
+          "display_name": "Analyst B",
+          "acct": "analyst_b",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T12:02:00.000Z",
+        "favourites_count": 6,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-013",
+        "inReplyToId": "112880124583497150",
+        "content": "<p>Worth re-reading every quarter.</p>",
+        "plainText": "Worth re-reading every quarter.",
+        "account": {
+          "display_name": "Quietreader",
+          "acct": "quietreader",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T12:15:00.000Z",
+        "favourites_count": 3,
+        "replies_count": 0,
         "favourited": false,
         "bookmarked": false
       }

--- a/src/utils/mockPostResolver.ts
+++ b/src/utils/mockPostResolver.ts
@@ -1,0 +1,225 @@
+"use client";
+
+import mockData from "../app/FakeData/listy-injection.json";
+import type {
+  ListyInjectionData,
+  ListyInjectionEntry,
+  FocusPostMock,
+  RelatedPostMock,
+  CategoryKey,
+  Relation,
+} from "../types/PostType";
+
+const entries = mockData as unknown as ListyInjectionData;
+
+export interface MockPostType {
+  id: string;
+  content: string;
+  account: { username: string; acc?: string; acct?: string; avatar: string };
+  replies_count: number;
+  created_at: string;
+  stackCount: number | null;
+  favourites_count: number;
+  favourited: boolean;
+  bookmarked: boolean;
+  media_attachments: any[];
+  relatedStacks: any[];
+  in_reply_to_id?: string | null;
+}
+
+function htmlContent(p: FocusPostMock | RelatedPostMock): string {
+  if ("plainText" in p && p.content.trim().startsWith("<")) return p.content;
+  return `<p>${(p as any).content}</p>`;
+}
+
+function toMockPostType(p: FocusPostMock | RelatedPostMock, relatedStacks: any[] = [], stackCount: number | null = null): MockPostType {
+  return {
+    id: p.id,
+    content: htmlContent(p),
+    account: {
+      username: p.account.display_name,
+      acct: p.account.acct,
+      avatar: p.account.avatar,
+    },
+    replies_count: p.replies_count,
+    created_at: p.created_at,
+    stackCount,
+    favourites_count: p.favourites_count,
+    favourited: p.favourited,
+    bookmarked: p.bookmarked,
+    media_attachments: [],
+    relatedStacks,
+    in_reply_to_id: p.inReplyToId ?? null,
+  };
+}
+
+// ─── Lookup maps (built once at module load) ─────────────────────────────────
+
+const entryByFocusId = new Map<string, ListyInjectionEntry>();
+const relatedById = new Map<string, { rp: RelatedPostMock; parent: ListyInjectionEntry }>();
+const replyById = new Map<string, { reply: FocusPostMock; parent: ListyInjectionEntry }>();
+const allPostsById = new Map<string, FocusPostMock | RelatedPostMock>();
+/** child id → parent id (inherent thread hierarchy) */
+const parentMap = new Map<string, string>();
+/** parent id → child ids */
+const childrenByParent = new Map<string, string[]>();
+
+for (const e of entries) {
+  entryByFocusId.set(e.focusPost.id, e);
+  allPostsById.set(e.focusPost.id, e.focusPost);
+  if (e.focusPost.inReplyToId) parentMap.set(e.focusPost.id, e.focusPost.inReplyToId);
+
+  for (const reply of e.replies ?? []) {
+    if (!replyById.has(reply.id)) replyById.set(reply.id, { reply, parent: e });
+    if (!allPostsById.has(reply.id)) allPostsById.set(reply.id, reply);
+    const parentId = reply.inReplyToId ?? e.focusPost.id;
+    if (!parentMap.has(reply.id)) parentMap.set(reply.id, parentId);
+  }
+
+  for (const rp of e.relatedPosts) {
+    if (!relatedById.has(rp.id)) relatedById.set(rp.id, { rp, parent: e });
+    if (!allPostsById.has(rp.id)) allPostsById.set(rp.id, rp);
+    if (rp.inReplyToId && !parentMap.has(rp.id)) parentMap.set(rp.id, rp.inReplyToId);
+  }
+}
+
+parentMap.forEach((parentId, childId) => {
+  const arr = childrenByParent.get(parentId) ?? [];
+  arr.push(childId);
+  childrenByParent.set(parentId, arr);
+});
+
+// ─── Public resolver API ─────────────────────────────────────────────────────
+
+/** Get the focus PostType for a given id. Returns null if the id is not in the mock. */
+export function getMockPost(id: string): MockPostType | null {
+  const post = allPostsById.get(id);
+  if (!post) return null;
+  const stacks = getMockRelatedStacks(id);
+  return toMockPostType(post, stacks, stacks.length || null);
+}
+
+/** Plain text of the post — for useUrlSync ?fs= hydration. */
+export function getMockPlainText(id: string): string | null {
+  const post = allPostsById.get(id);
+  if (!post) return null;
+  if ("plainText" in post) return post.plainText;
+  return (post as RelatedPostMock).content;
+}
+
+/** Ancestor chain (oldest → direct parent). Walks parentMap. */
+export function getMockAncestors(id: string): MockPostType[] {
+  const chain: string[] = [];
+  let cursor = parentMap.get(id);
+  const seen = new Set<string>([id]);
+  while (cursor && !seen.has(cursor)) {
+    chain.unshift(cursor);
+    seen.add(cursor);
+    cursor = parentMap.get(cursor);
+  }
+  return chain
+    .map((aid) => {
+      const post = allPostsById.get(aid);
+      return post ? toMockPostType(post) : null;
+    })
+    .filter((p): p is MockPostType => p !== null);
+}
+
+/** All descendant posts (flat). ThreadedReplyList rebuilds the tree from in_reply_to_id. */
+export function getMockReplies(id: string): MockPostType[] {
+  const out: MockPostType[] = [];
+  const stack: string[] = [...(childrenByParent.get(id) ?? [])];
+  const seen = new Set<string>();
+  while (stack.length) {
+    const cid = stack.shift()!;
+    if (seen.has(cid)) continue;
+    seen.add(cid);
+    const post = allPostsById.get(cid);
+    if (post) out.push(toMockPostType(post));
+    const grand = childrenByParent.get(cid);
+    if (grand) stack.push(...grand);
+  }
+  return out;
+}
+
+/** Build the focusRelations array for a given focus id — used by the Post
+ *  component to render dimmed marks on the focus post (research-only signal).
+ *  Mirrors /listy-injection/page.tsx line 53. Returns empty array when the
+ *  post has no entry (synthetic / reply-only ids). */
+export function getMockFocusRelations(id: string): Relation[] {
+  const entry = entryByFocusId.get(id);
+  if (!entry) return [];
+  return entry.relatedPosts.flatMap((rp) => rp.relations ?? []);
+}
+
+/** Build aside-format related stacks (one per related post) for a given focus id.
+ *  Mirrors the logic in /listy-injection/page.tsx::toPostData (flat stacks). */
+export function getMockRelatedStacks(id: string): any[] {
+  const entry = entryByFocusId.get(id);
+  if (!entry) {
+    // Synthetic: this id is a related post or reply in some other entry.
+    // Build a synthetic sibling set from its parent entry (same logic as
+    // syntheticEntryFromRelated in /listy-injection/page.tsx, simplified).
+    const fromRelated = relatedById.get(id);
+    if (!fromRelated) return [];
+    const { rp, parent } = fromRelated;
+    return parent.relatedPosts
+      .filter((p) => p.id !== rp.id)
+      .map((p) => ({
+        stackId: `synthetic-${id}-${p.id}`,
+        rel: p.category,
+        size: 1,
+        topPost: {
+          id: p.id,
+          created_at: p.created_at,
+          replies_count: p.replies_count,
+          favourites_count: p.favourites_count,
+          favourited: p.favourited,
+          bookmarked: p.bookmarked,
+          content: `<p>${p.content}</p>`,
+          account: {
+            avatar: p.account.avatar,
+            display_name: p.account.display_name,
+            acct: p.account.acct,
+          },
+          content_rewritten: "",
+          rewrite: { content: p.rewrite?.content ?? p.content, significant: p.rewrite?.significant ?? false },
+          relations: p.relations,
+        },
+      }));
+  }
+  return entry.relatedPosts.map((rp) => ({
+    stackId: `stack-${rp.id}`,
+    rel: rp.category,
+    size: 1,
+    topPost: {
+      id: rp.id,
+      created_at: rp.created_at,
+      replies_count: rp.replies_count,
+      favourites_count: rp.favourites_count,
+      favourited: rp.favourited,
+      bookmarked: rp.bookmarked,
+      content: `<p>${rp.content}</p>`,
+      account: {
+        avatar: rp.account.avatar,
+        display_name: rp.account.display_name,
+        acct: rp.account.acct,
+      },
+      content_rewritten: "",
+      rewrite: { content: rp.rewrite?.content ?? rp.content, significant: rp.rewrite?.significant ?? false },
+      relations: rp.relations,
+    },
+  }));
+}
+
+/** For the Recommended tab — show all related posts of this focus as flat MockPostType list. */
+export function getMockRecommended(id: string): MockPostType[] {
+  const entry = entryByFocusId.get(id);
+  if (!entry) return [];
+  return entry.relatedPosts.map((rp) => toMockPostType(rp));
+}
+
+/** True if the id exists anywhere in the mock data. */
+export function mockHasPost(id: string): boolean {
+  return allPostsById.has(id);
+}

--- a/src/utils/mockPostResolver.ts
+++ b/src/utils/mockPostResolver.ts
@@ -148,8 +148,10 @@ export function getMockReplies(id: string): MockPostType[] {
  *  post has no entry (synthetic / reply-only ids). */
 export function getMockFocusRelations(id: string): Relation[] {
   const entry = entryByFocusId.get(id);
-  if (!entry) return [];
-  return entry.relatedPosts.flatMap((rp) => rp.relations ?? []);
+  if (entry) return entry.relatedPosts.flatMap((rp) => rp.relations ?? []);
+  // Replies have no own relations (they aren't part of NLP analysis); leave empty
+  // so the reply text renders cleanly without misaligned marks from the parent.
+  return [];
 }
 
 /** Build aside-format related stacks (one per related post) for a given focus id.
@@ -157,9 +159,13 @@ export function getMockFocusRelations(id: string): Relation[] {
 export function getMockRelatedStacks(id: string): any[] {
   const entry = entryByFocusId.get(id);
   if (!entry) {
-    // Synthetic: this id is a related post or reply in some other entry.
-    // Build a synthetic sibling set from its parent entry (same logic as
-    // syntheticEntryFromRelated in /listy-injection/page.tsx, simplified).
+    // Replies inherit the parent entry's related stacks ("discussion context").
+    // This keeps the aside populated when the user navigates into a reply thread.
+    const fromReply = replyById.get(id);
+    if (fromReply) return getMockRelatedStacks(fromReply.parent.focusPost.id);
+    // Synthetic: this id is a related post in another entry. Build a synthetic
+    // sibling set from its parent entry (mirrors syntheticEntryFromRelated in
+    // /listy-injection/page.tsx, simplified).
     const fromRelated = relatedById.get(id);
     if (!fromRelated) return [];
     const { rp, parent } = fromRelated;


### PR DESCRIPTION
## Summary

Adds a mock-data-backed mirror of the future production `/posts/[id]` route under `/listy-injection/posts/[id]`, so the URL contract, threaded replies, focus marks, and back-navigation can all be exercised without a Mastodon access token. Wires `/listy-injection` feed clicks through the new route so URLs become shareable.

## Commits

- `Add mock-backed /listy-injection/posts/[id] route and URL schema` — resolver (`src/utils/mockPostResolver.ts`), the route page, its `@aside` slot, and `URL_SCHEMA.md` documenting `tab` / `fc` / `fs` / `from` / `stackId` and the reserved `anchor` / `aside` params.
- `Expand listy-injection mock with reply tree and richer topic overlap` — 15 fake replies under nickl_nyt (8 top-level branches, depth 3), plus topic distribution boosted so see-more clustering and "N more" pagination are visible (Tariffs 7, Industrial policy 6, Manufacturing 5, Climate 3, Consumers 3).
- `Route /listy-injection feed clicks through /posts/[id]` — clicking a feed post now `router.push`es to `/listy-injection/posts/[id]` instead of entering in-page thread mode; URLs are shareable and the in-page thread mode is left dead.
- `Inherit parent entry's related stacks for reply posts` — navigating to a reply (e.g. `bs-002a1`) shows the parent entry's aside as discussion context instead of an empty panel.
- `Restore feed scroll + active post on back-nav from post detail` — `navigateToPost` saves `scrollY` + the clicked post id to sessionStorage; mount-time restore replays both.
- `Unify back-nav restore for robustness across Strict Mode + paths` — one mount effect handles three cases: saved sessionStorage state, `ctxActivePostId` fallback (Strict Mode 2nd mount), and fresh visit. Chrome back and the in-page BackButton converge on the same path (`router.back()`).

## URLs to try

- `/listy-injection` — feed (click any post: URL changes to `/listy-injection/posts/[id]`)
- `/listy-injection/posts/112880124583497150` — nickl_nyt (15 aside cards, threaded replies, focus marks)
- `/listy-injection/posts/bs-002a1` — deep reply with 4 ancestors

## Test plan

- [ ] Open `/listy-injection`, scroll to a middle-of-feed post, click into it. URL changes to `/listy-injection/posts/[id]`.
- [ ] Hit the in-page Back button. Land back at same scroll position; the post you clicked is focused (blue border); the aside shows that post's related stacks.
- [ ] Repeat with Chrome's back button — identical behavior.
- [ ] Anchor on a top-of-cluster post (e.g. adrin_nyt for Tariffs). "3 more Tariffs" button appears; clicking it expands the cluster.
- [ ] Click a filter chip → URL gets `?fc=...` after ~300ms. Reload → chip stays pressed.
- [ ] Click a mark in the focus post → URL gets `?fs=start-end`.
- [ ] Navigate to `/listy-injection/posts/bs-002a1` → 4 ancestors render, aside has 15 inherited stacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)