### PR TITLE
Wire entry.ancestors into mock resolver and hide listy focused-view stack icons

### DIFF
--- a/src/app/(shell)/listy-injection/posts/[id]/page.tsx
+++ b/src/app/(shell)/listy-injection/posts/[id]/page.tsx
@@ -103,6 +103,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     if (value) setActiveTab(value);
   };
 
+  // Stack icons are hidden on the focused view; related stacks live in the aside.
   const renderPost = (p: MockPostType, isFocusPost: boolean = false) => (
     <Post
       key={p.id}
@@ -113,7 +114,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
       avatar={p.account.avatar}
       repliesCount={p.replies_count}
       createdAt={p.created_at}
-      stackCount={p.stackCount}
+      stackCount={-1}
       favouritesCount={p.favourites_count}
       favourited={p.favourited}
       bookmarked={p.bookmarked}
@@ -121,7 +122,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
       onStackIconClick={() => {}}
       setIsModalOpen={() => {}}
       setIsExpandModalOpen={() => {}}
-      relatedStacks={p.relatedStacks}
+      relatedStacks={[]}
       setActivePostId={setActivePostId}
       activePostId={activePostId}
       focusRelations={isFocusPost ? focusRelations : []}

--- a/src/app/(shell)/posts/[id]/page.tsx
+++ b/src/app/(shell)/posts/[id]/page.tsx
@@ -185,9 +185,12 @@ export default function PostView({ params }: { params: { id: string } }) {
     try {
       const { data } = await axios.get(`${MastodonInstanceUrl}/api/v1/statuses/${postId}/context`, withAuth());
 
+      const descendants: PostType[] = Array.isArray(data?.descendants) ? data.descendants : [];
+      const ancestorsFromApi: PostType[] = Array.isArray(data?.ancestors) ? data.ancestors : [];
+
       setReplies((prev) => {
         const prevMap = new Map(prev.map((p) => [p.id, p]));
-        return data.descendants.map((desc: PostType) => {
+        return descendants.map((desc) => {
           const existing = prevMap.get(desc.id);
           const base = mapWithStackFields(desc);
           return existing
@@ -198,7 +201,7 @@ export default function PostView({ params }: { params: { id: string } }) {
 
       setAncestors((prev) => {
         const prevMap = new Map(prev.map((p) => [p.id, p]));
-        return data.ancestors.map((ancestor: PostType) => {
+        return ancestorsFromApi.map((ancestor) => {
           const existing = prevMap.get(ancestor.id);
           const base = mapWithStackFields(ancestor);
           return existing
@@ -208,6 +211,11 @@ export default function PostView({ params }: { params: { id: string } }) {
       });
     } catch (e) {
       console.error("Failed to fetch context:", e);
+      notifications.show({
+        color: "red",
+        title: "Failed to load replies and ancestors",
+        message: "Please try again later.",
+      });
     }
   }, []);
 
@@ -449,10 +457,8 @@ export default function PostView({ params }: { params: { id: string } }) {
   };
 
   // -------------------- Render helpers --------------------
-  const renderPost = (
-    p: PostType,
-    overrides?: Partial<Pick<PostType, "stackCount" | "relatedStacks">>
-  ) => (
+  // Stack icons are hidden on the focused view; related stacks live in the aside.
+  const renderPost = (p: PostType) => (
     <Post
       key={p.id}
       id={p.id}
@@ -462,7 +468,7 @@ export default function PostView({ params }: { params: { id: string } }) {
       avatar={p.account.avatar}
       repliesCount={p.replies_count}
       createdAt={p.created_at}
-      stackCount={overrides?.stackCount ?? p.stackCount}
+      stackCount={-1}
       favouritesCount={p.favourites_count}
       favourited={p.favourited}
       bookmarked={p.bookmarked}
@@ -470,7 +476,7 @@ export default function PostView({ params }: { params: { id: string } }) {
       onStackIconClick={handleStackIconClick}
       setIsModalOpen={() => { }}
       setIsExpandModalOpen={() => { }}
-      relatedStacks={overrides?.relatedStacks ?? p.relatedStacks}
+      relatedStacks={[]}
       setActivePostId={setActivePostId}
       activePostId={highlightId}
     />
@@ -532,7 +538,7 @@ export default function PostView({ params }: { params: { id: string } }) {
                 zIndex: 0,
               }} />
             )}
-            {post && renderPost(post, { stackCount: size, relatedStacks: focusRelatedStacks })}
+            {post && renderPost(post)}
           </div>
         </div>
 

--- a/src/utils/mockPostResolver.ts
+++ b/src/utils/mockPostResolver.ts
@@ -67,6 +67,22 @@ const childrenByParent = new Map<string, string[]>();
 for (const e of entries) {
   entryByFocusId.set(e.focusPost.id, e);
   allPostsById.set(e.focusPost.id, e.focusPost);
+
+  // entry.ancestors: oldest-first chain. Each consecutive pair is parent → child,
+  // and the last ancestor is the immediate parent of focusPost.
+  const ancestorChain = e.ancestors ?? [];
+  for (const a of ancestorChain) {
+    if (!allPostsById.has(a.id)) allPostsById.set(a.id, a);
+  }
+  for (let i = 1; i < ancestorChain.length; i++) {
+    if (!parentMap.has(ancestorChain[i].id)) {
+      parentMap.set(ancestorChain[i].id, ancestorChain[i - 1].id);
+    }
+  }
+  if (ancestorChain.length > 0 && !parentMap.has(e.focusPost.id)) {
+    parentMap.set(e.focusPost.id, ancestorChain[ancestorChain.length - 1].id);
+  }
+  // Focus post may declare an explicit parent (overrides ancestor-derived link)
   if (e.focusPost.inReplyToId) parentMap.set(e.focusPost.id, e.focusPost.inReplyToId);
 
   for (const reply of e.replies ?? []) {


### PR DESCRIPTION
## Summary
- `/listy-injection/posts/[id]` (mock-backed focused view) wasn't rendering ancestors. `mockPostResolver` was only consuming `inReplyToId`, but real Mastodon-numbered focus posts get their parent solely from each entry's oldest-first `ancestors` array (the `bs-*` synthetic chains were the only IDs with `inReplyToId`). The fix mirrors `/listy-injection/page.tsx`'s `parentMap` build: register every ancestor in `allPostsById` and link consecutive ancestors + the focus post through `parentMap` so `getMockAncestors` can walk the chain.
- Same stack-icon cleanup as PR #170 applied to this focused view's `renderPost`: pass `stackCount: -1` and `relatedStacks: []` so the in-post icon column doesn't duplicate what the aside already shows.

## Test plan
- [ ] Open `/listy-injection/posts/112880110824825811` (the acommonman_nyt post from the screenshot) and confirm the `112880110130640427` ancestor renders above it.
- [ ] Confirm no stack icon column on focus, ancestors, replies, or recommended posts.
- [ ] Confirm the right-rail aside still shows the focus post's related stacks.

https://claude.ai/code/session_014gmBGFDJeMntgKS2xdBSBa

---
_Generated by [Claude Code](https://claude.ai/code/session_014gmBGFDJeMntgKS2xdBSBa)_