### PR TITLE
Restore the thread connector line on focused-post views

### DIFF
--- a/src/app/(shell)/listy-injection/posts/[id]/page.tsx
+++ b/src/app/(shell)/listy-injection/posts/[id]/page.tsx
@@ -160,10 +160,15 @@ export default function MockPostView({ params }: { params: { id: string } }) {
                       position: "absolute",
                       left: THREAD_LINE_LEFT,
                       top: index === 0 ? "50%" : 0,
-                      bottom: 0,
+                      // Extend past the Post wrapper's marginBottom: 3rem so
+                      // the line bridges the visible gap to the next post.
+                      bottom: "-3rem",
                       width: 2,
                       backgroundColor: THREAD_LINE_COLOR,
-                      zIndex: 0,
+                      // Above the Post's Paper (zIndex: 5, white bg) so the
+                      // line is visible across the post body and through the
+                      // gap. The line passes through the avatar circle.
+                      zIndex: 6,
                     }}
                   />
                   {renderPost(a)}
@@ -183,7 +188,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
                   height: "50%",
                   width: 2,
                   backgroundColor: THREAD_LINE_COLOR,
-                  zIndex: 0,
+                  zIndex: 6,
                 }}
               />
             )}

--- a/src/app/(shell)/posts/[id]/page.tsx
+++ b/src/app/(shell)/posts/[id]/page.tsx
@@ -508,15 +508,19 @@ export default function PostView({ params }: { params: { id: string } }) {
             <div style={{ position: "relative" }}>
               {ancestors.map((a, index) => (
                 <div key={a.id} style={{ position: "relative" }}>
-                  {/* Vertical line connecting this ancestor to the next post below */}
+                  {/* Vertical line connecting this ancestor to the next post below.
+                      zIndex: 6 puts it above the Post's Paper (zIndex: 5, white bg)
+                      so the line is visible across the post body. bottom: -3rem
+                      extends it past the Post wrapper's marginBottom so the line
+                      bridges the visible gap between posts. */}
                   <div style={{
                     position: "absolute",
                     left: THREAD_LINE_LEFT,
                     top: index === 0 ? "50%" : 0,
-                    bottom: 0,
+                    bottom: "-3rem",
                     width: 2,
                     backgroundColor: THREAD_LINE_COLOR,
-                    zIndex: 0,
+                    zIndex: 6,
                   }} />
                   {renderPost(a)}
                 </div>
@@ -535,7 +539,7 @@ export default function PostView({ params }: { params: { id: string } }) {
                 height: "50%",
                 width: 2,
                 backgroundColor: THREAD_LINE_COLOR,
-                zIndex: 0,
+                zIndex: 6,
               }} />
             )}
             {post && renderPost(post)}

--- a/src/components/ListyInjection/ListyInjectionShell.tsx
+++ b/src/components/ListyInjection/ListyInjectionShell.tsx
@@ -202,7 +202,10 @@ export default function ListyInjectionShell({ entries }: ListyInjectionShellProp
           Back
         </button>
 
-        {/* Ancestor chain with thread lines */}
+        {/* Ancestor chain with thread lines.
+            zIndex: 2 puts the line above the FocusPost wrap (zIndex: 1, which
+            contains FocusPost's white background). The line passes through
+            the avatar circle but stays visible across the post body. */}
         {ancestorEntries.map((entry, index) => (
           <div
             key={entry.focusPost.id}
@@ -214,10 +217,10 @@ export default function ListyInjectionShell({ entries }: ListyInjectionShellProp
                 position: "absolute",
                 left: THREAD_LINE_LEFT,
                 top: index === 0 ? "50%" : 0,
-                bottom: 0,
+                bottom: "-0.5rem",
                 width: 2,
                 backgroundColor: THREAD_LINE_COLOR,
-                zIndex: 0,
+                zIndex: 2,
               }}
             />
             <div style={{ position: "relative", zIndex: 1 }}>
@@ -250,7 +253,7 @@ export default function ListyInjectionShell({ entries }: ListyInjectionShellProp
                 height: "50%",
                 width: 2,
                 backgroundColor: THREAD_LINE_COLOR,
-                zIndex: 0,
+                zIndex: 2,
               }}
             />
           )}


### PR DESCRIPTION
## Summary

Restore the thread connector line on focused-post views. The JSX for the line was still in place but two things made it invisible:

1. The line was rendered at `zIndex: 0`, behind the `Post`'s `<Paper>` (which has `zIndex: 5; backgroundColor: '#fff'`). The white background covered the line across every post body.
2. The line's `bottom: 0` stopped at the bottom of the ancestor wrapper, *above* the `Post` wrapper's `marginBottom: 3rem`. So even with a higher z-index the line wouldn't reach the gap between posts.

This commit:

- Bumps the line to `zIndex: 6` in both `/posts/[id]` and `/listy-injection/posts/[id]`, putting it above the `Post`'s Paper. The line passes through the avatar circle — typical thread-line visual idiom.
- Extends ancestor lines' `bottom` to `-3rem` so the line reaches into the marginBottom gap and meets the next post's segment at the avatar level.
- Same treatment in `ListyInjectionShell` for the feed-side ancestor chain (which uses `FocusPost`, wrapped at `zIndex: 1`, so the line is set to `zIndex: 2` and extended past the wrapper's `paddingBottom: 0.5rem`).

Verified on the user-provided URL `/listy-injection/posts/112880124583497150` — the connector line is now visible from the ancestor's avatar through the gap into the focused post's avatar.

## Test plan

- [ ] `/listy-injection/posts/<id>` with one or more ancestors — connector line visible from ancestor avatar(s) through the focused post's avatar.
- [ ] `/posts/<id>` standard route — same.
- [ ] `/listy-injection` feed with thread-mode (`ancestorEntries.length > 0`) — connector visible.

https://claude.ai/code/session_018NWD8ob4L9p2uJPSbFnxrH

---
_Generated by [Claude Code](https://claude.ai/code/session_018NWD8ob4L9p2uJPSbFnxrH)_