### PR TITLE
Anchor thread line at avatar y; bridge the gap reliably

### DIFF
--- a/src/app/(shell)/listy-injection/posts/[id]/page.tsx
+++ b/src/app/(shell)/listy-injection/posts/[id]/page.tsx
@@ -25,6 +25,10 @@ import type { Relation } from "../../../../../types/PostType";
 // Thread connector line style — mirrors /posts/[id]
 const THREAD_LINE_COLOR = "#ccd1dc";
 const THREAD_LINE_LEFT = 32;
+// Vertical position of the avatar center in the Post component, measured
+// from the Paper top. paddingTop (1rem = 16px) + half-avatar (~19px) ≈ 35px.
+// The line starts here on the first ancestor and ends here on the focus post.
+const THREAD_LINE_AVATAR_Y = 32;
 
 function stripHtmlToPlain(html: string): string {
   if (typeof document !== "undefined") {
@@ -150,24 +154,38 @@ export default function MockPostView({ params }: { params: { id: string } }) {
       <BackButton />
       <div>
         <div style={{ position: "relative" }}>
-          {/* Ancestors */}
+          {/* Ancestors with thread line.
+              The line starts at the avatar's vertical center on the FIRST
+              ancestor (THREAD_LINE_AVATAR_Y), runs down through every
+              ancestor's body, and bridges the marginBottom gap between
+              posts. paddingBottom on the wrapper holds the Post's
+              marginBottom inside the wrapper so the absolute line can
+              extend through the gap without being clipped by margin-collapse. */}
           {ancestors.length > 0 && (
             <div style={{ position: "relative" }}>
               {ancestors.map((a, index) => (
-                <div key={a.id} style={{ position: "relative" }}>
+                <div
+                  key={a.id}
+                  style={{
+                    position: "relative",
+                    // Keep the Post's marginBottom inside this wrapper so the
+                    // line spans the gap, then offset back with negative margin
+                    // so the visible spacing stays unchanged.
+                    paddingBottom: "3rem",
+                    marginBottom: "-3rem",
+                  }}
+                >
                   <div
                     style={{
                       position: "absolute",
                       left: THREAD_LINE_LEFT,
-                      top: index === 0 ? "50%" : 0,
-                      // Extend past the Post wrapper's marginBottom: 3rem so
-                      // the line bridges the visible gap to the next post.
-                      bottom: "-3rem",
+                      top: index === 0 ? THREAD_LINE_AVATAR_Y : 0,
+                      bottom: 0,
                       width: 2,
                       backgroundColor: THREAD_LINE_COLOR,
                       // Above the Post's Paper (zIndex: 5, white bg) so the
-                      // line is visible across the post body and through the
-                      // gap. The line passes through the avatar circle.
+                      // line is visible across each post body and through
+                      // the gap. The line passes through the avatar circle.
                       zIndex: 6,
                     }}
                   />
@@ -177,7 +195,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
             </div>
           )}
 
-          {/* Focus post */}
+          {/* Focus post — line continues from the top down to the focus avatar. */}
           <div style={{ position: "relative" }}>
             {ancestors.length > 0 && (
               <div
@@ -185,7 +203,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
                   position: "absolute",
                   left: THREAD_LINE_LEFT,
                   top: 0,
-                  height: "50%",
+                  height: THREAD_LINE_AVATAR_Y,
                   width: 2,
                   backgroundColor: THREAD_LINE_COLOR,
                   zIndex: 6,

--- a/src/app/(shell)/posts/[id]/page.tsx
+++ b/src/app/(shell)/posts/[id]/page.tsx
@@ -54,6 +54,10 @@ const mapWithStackFields = <T extends object>(x: T) => ({
 // Thread connector line style shared by ancestor + reply connectors
 const THREAD_LINE_COLOR = "#ccd1dc";
 const THREAD_LINE_LEFT = 32; // aligns with avatar center (~16px padding + ~19px half-avatar)
+// Vertical position of the avatar center in the Post component, measured
+// from the Paper top. The line starts here on the first ancestor and ends
+// here on the focus post.
+const THREAD_LINE_AVATAR_Y = 32;
 
 /** Strip HTML tags to produce plain text for span-filter hydration */
 function stripHtmlToPlain(html: string): string {
@@ -503,21 +507,28 @@ export default function PostView({ params }: { params: { id: string } }) {
       <BackButton />
       <div>
         <div style={{ position: "relative" }}>
-          {/* Ancestors with thread line */}
+          {/* Ancestors with thread line.
+              The line starts at the avatar's vertical center on the FIRST
+              ancestor, runs through every ancestor's body, and bridges the
+              marginBottom gap between posts. paddingBottom on the wrapper
+              holds the Post's marginBottom inside so the absolute line can
+              span the gap without being clipped by margin-collapse. */}
           {ancestors.length > 0 && (
             <div style={{ position: "relative" }}>
               {ancestors.map((a, index) => (
-                <div key={a.id} style={{ position: "relative" }}>
-                  {/* Vertical line connecting this ancestor to the next post below.
-                      zIndex: 6 puts it above the Post's Paper (zIndex: 5, white bg)
-                      so the line is visible across the post body. bottom: -3rem
-                      extends it past the Post wrapper's marginBottom so the line
-                      bridges the visible gap between posts. */}
+                <div
+                  key={a.id}
+                  style={{
+                    position: "relative",
+                    paddingBottom: "3rem",
+                    marginBottom: "-3rem",
+                  }}
+                >
                   <div style={{
                     position: "absolute",
                     left: THREAD_LINE_LEFT,
-                    top: index === 0 ? "50%" : 0,
-                    bottom: "-3rem",
+                    top: index === 0 ? THREAD_LINE_AVATAR_Y : 0,
+                    bottom: 0,
                     width: 2,
                     backgroundColor: THREAD_LINE_COLOR,
                     zIndex: 6,
@@ -528,15 +539,14 @@ export default function PostView({ params }: { params: { id: string } }) {
             </div>
           )}
 
-          {/* Current Post */}
+          {/* Current Post — line continues from top down to focus avatar. */}
           <div ref={currentPostRef} style={{ position: "relative" }}>
-            {/* Connector from last ancestor into focal post */}
             {ancestors.length > 0 && (
               <div style={{
                 position: "absolute",
                 left: THREAD_LINE_LEFT,
                 top: 0,
-                height: "50%",
+                height: THREAD_LINE_AVATAR_Y,
                 width: 2,
                 backgroundColor: THREAD_LINE_COLOR,
                 zIndex: 6,

--- a/src/components/ListyInjection/ListyInjectionShell.tsx
+++ b/src/components/ListyInjection/ListyInjectionShell.tsx
@@ -26,6 +26,8 @@ import InteractionControl from "../InteractionControl";
 
 const THREAD_LINE_COLOR = "#ccd1dc";
 const THREAD_LINE_LEFT = 32;
+// Vertical avatar-center offset inside FocusPost — used as line endpoints.
+const THREAD_LINE_AVATAR_Y = 24;
 
 /** Convert a RelatedPostMock into a synthetic ListyInjectionEntry */
 function syntheticEntry(
@@ -203,9 +205,9 @@ export default function ListyInjectionShell({ entries }: ListyInjectionShellProp
         </button>
 
         {/* Ancestor chain with thread lines.
-            zIndex: 2 puts the line above the FocusPost wrap (zIndex: 1, which
-            contains FocusPost's white background). The line passes through
-            the avatar circle but stays visible across the post body. */}
+            Line starts at avatar y on the first ancestor and runs through
+            each post body + gap below. zIndex: 2 puts it above the FocusPost
+            wrap (zIndex: 1, which contains FocusPost's white background). */}
         {ancestorEntries.map((entry, index) => (
           <div
             key={entry.focusPost.id}
@@ -216,8 +218,8 @@ export default function ListyInjectionShell({ entries }: ListyInjectionShellProp
               style={{
                 position: "absolute",
                 left: THREAD_LINE_LEFT,
-                top: index === 0 ? "50%" : 0,
-                bottom: "-0.5rem",
+                top: index === 0 ? THREAD_LINE_AVATAR_Y : 0,
+                bottom: 0,
                 width: 2,
                 backgroundColor: THREAD_LINE_COLOR,
                 zIndex: 2,
@@ -250,7 +252,7 @@ export default function ListyInjectionShell({ entries }: ListyInjectionShellProp
                 position: "absolute",
                 left: THREAD_LINE_LEFT,
                 top: 0,
-                height: "50%",
+                height: THREAD_LINE_AVATAR_Y,
                 width: 2,
                 backgroundColor: THREAD_LINE_COLOR,
                 zIndex: 2,


### PR DESCRIPTION
## Summary

Two follow-ups to #176 spotted in your screenshot:

1. **Line was broken in the gap between posts.** The previous attempt used `bottom: -3rem` to extend each ancestor's line through the marginBottom gap to the next post. That's unreliable: the Post wrapper's `marginBottom: 3rem` collapses *out of* the ancestor wrapper, so the wrapper's bounding box never includes the gap and the negative-bottom child wasn't reaching where I thought.
2. **Line started at `top: 50%`** — far below the avatar. You wanted it to start at the ancestor's profile.

Fix:

- Each ancestor wrapper now uses `paddingBottom: 3rem; marginBottom: -3rem`. The padding holds the Post's `marginBottom: 3rem` inside the wrapper (margin-collapse no longer escapes), so the absolute line with `top: X; bottom: 0` actually spans through the gap. The negative margin cancels the extra height for layout flow, so the *visible* spacing between posts is unchanged.
- Introduced `THREAD_LINE_AVATAR_Y` (32px in Post, 24px in FocusPost) as the y where the line starts (first ancestor) and ends (focus post). Replaces the old `'50%'` value.

## Test plan

- [ ] `/listy-injection/posts/<id>` — line is one continuous segment from the first ancestor's avatar through every ancestor and into the focus avatar.
- [ ] `/posts/<id>` standard route — same.
- [ ] `/listy-injection` feed with thread mode — same.

https://claude.ai/code/session_018NWD8ob4L9p2uJPSbFnxrH

---
_Generated by [Claude Code](https://claude.ai/code/session_018NWD8ob4L9p2uJPSbFnxrH)_