### PR TITLE
Twitter-style thread line: behind cards, centered on avatar

### DIFF
--- a/src/app/(shell)/listy-injection/posts/[id]/page.tsx
+++ b/src/app/(shell)/listy-injection/posts/[id]/page.tsx
@@ -24,11 +24,9 @@ import type { Relation } from "../../../../../types/PostType";
 
 // Thread connector line style — mirrors /posts/[id]
 const THREAD_LINE_COLOR = "#ccd1dc";
-const THREAD_LINE_LEFT = 32;
-// Vertical position of the avatar center in the Post component, measured
-// from the Paper top. paddingTop (1rem = 16px) + half-avatar (~19px) ≈ 35px.
-// The line starts here on the first ancestor and ends here on the focus post.
-const THREAD_LINE_AVATAR_Y = 32;
+// Avatar center x = Paper.border (2) + paddingLeft (16) + half-avatar (19) = 37.
+// Subtract 1 (half line width) so the 2px line is centered on the avatar.
+const THREAD_LINE_LEFT = 36;
 
 function stripHtmlToPlain(html: string): string {
   if (typeof document !== "undefined") {
@@ -154,39 +152,36 @@ export default function MockPostView({ params }: { params: { id: string } }) {
       <BackButton />
       <div>
         <div style={{ position: "relative" }}>
-          {/* Ancestors with thread line.
-              The line starts at the avatar's vertical center on the FIRST
-              ancestor (THREAD_LINE_AVATAR_Y), runs down through every
-              ancestor's body, and bridges the marginBottom gap between
-              posts. paddingBottom on the wrapper holds the Post's
-              marginBottom inside the wrapper so the absolute line can
-              extend through the gap without being clipped by margin-collapse. */}
+          {/* Ancestors — thread connector line runs at the avatar column,
+              BEHIND the Post's Paper (zIndex 0 < Paper's zIndex 5). The line
+              is hidden inside each card and visible only in the gap between
+              cards, matching the Twitter-style thread look (line connects
+              cards without cutting across post bodies).
+
+              paddingBottom on each wrapper holds the Post's marginBottom
+              inside so the absolute line can span through to the next post;
+              negative marginBottom cancels the extra height for layout. */}
           {ancestors.length > 0 && (
             <div style={{ position: "relative" }}>
-              {ancestors.map((a, index) => (
+              {ancestors.map((a) => (
                 <div
                   key={a.id}
                   style={{
                     position: "relative",
-                    // Keep the Post's marginBottom inside this wrapper so the
-                    // line spans the gap, then offset back with negative margin
-                    // so the visible spacing stays unchanged.
                     paddingBottom: "3rem",
                     marginBottom: "-3rem",
                   }}
                 >
                   <div
+                    aria-hidden
                     style={{
                       position: "absolute",
                       left: THREAD_LINE_LEFT,
-                      top: index === 0 ? THREAD_LINE_AVATAR_Y : 0,
+                      top: 0,
                       bottom: 0,
                       width: 2,
                       backgroundColor: THREAD_LINE_COLOR,
-                      // Above the Post's Paper (zIndex: 5, white bg) so the
-                      // line is visible across each post body and through
-                      // the gap. The line passes through the avatar circle.
-                      zIndex: 6,
+                      zIndex: 0,
                     }}
                   />
                   {renderPost(a)}
@@ -195,21 +190,8 @@ export default function MockPostView({ params }: { params: { id: string } }) {
             </div>
           )}
 
-          {/* Focus post — line continues from the top down to the focus avatar. */}
+          {/* Focus post */}
           <div style={{ position: "relative" }}>
-            {ancestors.length > 0 && (
-              <div
-                style={{
-                  position: "absolute",
-                  left: THREAD_LINE_LEFT,
-                  top: 0,
-                  height: THREAD_LINE_AVATAR_Y,
-                  width: 2,
-                  backgroundColor: THREAD_LINE_COLOR,
-                  zIndex: 6,
-                }}
-              />
-            )}
             {renderPost(post, /* isFocusPost */ true)}
           </div>
         </div>

--- a/src/app/(shell)/posts/[id]/page.tsx
+++ b/src/app/(shell)/posts/[id]/page.tsx
@@ -53,11 +53,9 @@ const mapWithStackFields = <T extends object>(x: T) => ({
 
 // Thread connector line style shared by ancestor + reply connectors
 const THREAD_LINE_COLOR = "#ccd1dc";
-const THREAD_LINE_LEFT = 32; // aligns with avatar center (~16px padding + ~19px half-avatar)
-// Vertical position of the avatar center in the Post component, measured
-// from the Paper top. The line starts here on the first ancestor and ends
-// here on the focus post.
-const THREAD_LINE_AVATAR_Y = 32;
+// Avatar center x = Paper.border (2) + paddingLeft (16) + half-avatar (19) = 37.
+// Subtract 1 (half line width) so the 2px line is centered on the avatar.
+const THREAD_LINE_LEFT = 36;
 
 /** Strip HTML tags to produce plain text for span-filter hydration */
 function stripHtmlToPlain(html: string): string {
@@ -507,15 +505,15 @@ export default function PostView({ params }: { params: { id: string } }) {
       <BackButton />
       <div>
         <div style={{ position: "relative" }}>
-          {/* Ancestors with thread line.
-              The line starts at the avatar's vertical center on the FIRST
-              ancestor, runs through every ancestor's body, and bridges the
-              marginBottom gap between posts. paddingBottom on the wrapper
-              holds the Post's marginBottom inside so the absolute line can
-              span the gap without being clipped by margin-collapse. */}
+          {/* Ancestors — thread connector line runs at the avatar column,
+              BEHIND the Post's Paper (zIndex 0 < Paper's zIndex 5). Visible
+              only in the gap between cards, matching the Twitter-style thread
+              look. paddingBottom holds the Post's marginBottom inside the
+              wrapper so the absolute line spans through to the next post;
+              negative marginBottom cancels the extra height for layout. */}
           {ancestors.length > 0 && (
             <div style={{ position: "relative" }}>
-              {ancestors.map((a, index) => (
+              {ancestors.map((a) => (
                 <div
                   key={a.id}
                   style={{
@@ -524,14 +522,14 @@ export default function PostView({ params }: { params: { id: string } }) {
                     marginBottom: "-3rem",
                   }}
                 >
-                  <div style={{
+                  <div aria-hidden style={{
                     position: "absolute",
                     left: THREAD_LINE_LEFT,
-                    top: index === 0 ? THREAD_LINE_AVATAR_Y : 0,
+                    top: 0,
                     bottom: 0,
                     width: 2,
                     backgroundColor: THREAD_LINE_COLOR,
-                    zIndex: 6,
+                    zIndex: 0,
                   }} />
                   {renderPost(a)}
                 </div>
@@ -539,19 +537,8 @@ export default function PostView({ params }: { params: { id: string } }) {
             </div>
           )}
 
-          {/* Current Post — line continues from top down to focus avatar. */}
+          {/* Current Post */}
           <div ref={currentPostRef} style={{ position: "relative" }}>
-            {ancestors.length > 0 && (
-              <div style={{
-                position: "absolute",
-                left: THREAD_LINE_LEFT,
-                top: 0,
-                height: THREAD_LINE_AVATAR_Y,
-                width: 2,
-                backgroundColor: THREAD_LINE_COLOR,
-                zIndex: 6,
-              }} />
-            )}
             {post && renderPost(post)}
           </div>
         </div>

--- a/src/components/ListyInjection/ListyInjectionShell.tsx
+++ b/src/components/ListyInjection/ListyInjectionShell.tsx
@@ -25,9 +25,9 @@ import InteractionControl from "../InteractionControl";
 // ── Thread line constants (matches posts/[id]/page.tsx) ─────────────────────
 
 const THREAD_LINE_COLOR = "#ccd1dc";
-const THREAD_LINE_LEFT = 32;
-// Vertical avatar-center offset inside FocusPost — used as line endpoints.
-const THREAD_LINE_AVATAR_Y = 24;
+// Avatar center x for FocusPost — padding 1rem (16) + half-avatar (16) ≈ 32,
+// minus 1 (half line width) so the 2px line is centered on the avatar.
+const THREAD_LINE_LEFT = 31;
 
 /** Convert a RelatedPostMock into a synthetic ListyInjectionEntry */
 function syntheticEntry(
@@ -204,11 +204,10 @@ export default function ListyInjectionShell({ entries }: ListyInjectionShellProp
           Back
         </button>
 
-        {/* Ancestor chain with thread lines.
-            Line starts at avatar y on the first ancestor and runs through
-            each post body + gap below. zIndex: 2 puts it above the FocusPost
-            wrap (zIndex: 1, which contains FocusPost's white background). */}
-        {ancestorEntries.map((entry, index) => (
+        {/* Ancestor chain — thread connector line BEHIND each FocusPost
+            (zIndex 0 < FocusPost wrap zIndex 1) so it's only visible in
+            the gap between posts, like Twitter. */}
+        {ancestorEntries.map((entry) => (
           <div
             key={entry.focusPost.id}
             style={{ position: "relative", paddingBottom: "0.5rem" }}
@@ -218,11 +217,11 @@ export default function ListyInjectionShell({ entries }: ListyInjectionShellProp
               style={{
                 position: "absolute",
                 left: THREAD_LINE_LEFT,
-                top: index === 0 ? THREAD_LINE_AVATAR_Y : 0,
+                top: 0,
                 bottom: 0,
                 width: 2,
                 backgroundColor: THREAD_LINE_COLOR,
-                zIndex: 2,
+                zIndex: 0,
               }}
             />
             <div style={{ position: "relative", zIndex: 1 }}>
@@ -243,22 +242,9 @@ export default function ListyInjectionShell({ entries }: ListyInjectionShellProp
           </div>
         ))}
 
-        {/* Current focus post with connector from ancestors */}
+        {/* Current focus post */}
         <div style={{ position: "relative", marginBottom: "1.5rem" }}>
-          {ancestorEntries.length > 0 && (
-            <div
-              aria-hidden
-              style={{
-                position: "absolute",
-                left: THREAD_LINE_LEFT,
-                top: 0,
-                height: THREAD_LINE_AVATAR_Y,
-                width: 2,
-                backgroundColor: THREAD_LINE_COLOR,
-                zIndex: 2,
-              }}
-            />
-          )}
+
           <div style={{ position: "relative", zIndex: 1 }}>
             <FocusPost
               post={currentEntry.focusPost}


### PR DESCRIPTION
## Summary

Per your Twitter reference: the line should be **behind** the cards/avatars (visible only in the gap between posts) and **centered** on the avatar column. The previous fix had `zIndex: 6` (above the Paper), so the line was cutting across the upper-left of each post body — that's the visual you didn't want.

Twitter draws the line at the very back; their posts don't have card backgrounds, so it's visible everywhere except where the avatar covers it. The closest mimic for our card-style posts is to put the line **behind** the `Paper` so it's hidden inside each card and only visible in the inter-card gap.

**Changes:**

- `zIndex: 6 → 0` for the connector line (`zIndex: 2 → 0` in `ListyInjectionShell` because its FocusPost wrap is at `zIndex: 1`). Line now sits behind the Paper.
- `THREAD_LINE_LEFT: 32 → 36` so the 2px line centers on the avatar. Math: Paper border (2) + paddingLeft (16) + half-avatar (19) = 37; subtract 1 to center the 2px line. `FocusPost` uses 31 (smaller avatar in the feed shell).
- Dropped the focal post's separate line (it was hidden behind its own Paper anyway, no purpose).
- Dropped `THREAD_LINE_AVATAR_Y` — irrelevant now that the line spans the full wrapper height (hidden inside the Paper regardless of top value).

`paddingBottom: 3rem / marginBottom: -3rem` on each ancestor wrapper is kept — that's what lets the line extend through the inter-card gap.

## Test plan

- [ ] `/listy-injection/posts/<id>` — line visible only in the gap between posts, centered on the avatar column, not cutting across any post body.
- [ ] `/posts/<id>` standard route — same.
- [ ] `/listy-injection` feed thread mode — same.

https://claude.ai/code/session_018NWD8ob4L9p2uJPSbFnxrH

---
_Generated by [Claude Code](https://claude.ai/code/session_018NWD8ob4L9p2uJPSbFnxrH)_