### PR TITLE
Thread display: filtering, grouping, pinned post, reply threading

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/scripts/generate-reply-relations.mjs
+++ b/scripts/generate-reply-relations.mjs
@@ -228,8 +228,50 @@ for (const r of SMALL_REPLIES) {
   });
 }
 
+// ─── Nested-thread depth: 7 extra children under bs-002a ─────────────────────
+// Exercises the per-parent "See N more replies" pagination (5 shown at a time)
+// inside a branch: bs-002a ends up with 8 children (bs-002a1 + these).
+
+const NESTED_PARENT = 'bs-002a';
+const NESTED_REPLIES = [
+  { id: 'bs-002a-r1', display_name: 'Econ PhD', acct: 'econ_phd', created_at: '2024-07-31T13:50:00.000Z', favourites_count: 6,
+    text: 'TAA take-up rates hover around a quarter of eligible workers. The program design is the failure mode, not the concept.' },
+  { id: 'bs-002a-r2', display_name: 'Union Rep', acct: 'union_rep', created_at: '2024-07-31T13:56:00.000Z', favourites_count: 4,
+    text: 'Design AND funding. Every renewal cycle it gets trimmed before it reaches a single shop floor.' },
+  { id: 'bs-002a-r3', display_name: 'Garage Skeptic', acct: 'garage_skeptic', created_at: '2024-07-31T14:02:00.000Z', favourites_count: 2,
+    text: 'Retraining a 55-year-old machinist into "software" was always a brochure fantasy.' },
+  { id: 'bs-002a-r4', display_name: 'Jane Dev', acct: 'jane_dev', created_at: '2024-07-31T14:11:00.000Z', favourites_count: 3,
+    text: 'Denmark manages it with flexicurity. It is not impossible, it is just not what we fund.' },
+  { id: 'bs-002a-r5', display_name: 'Tony P', acct: 'tony_p', created_at: '2024-07-31T14:19:00.000Z', favourites_count: 1,
+    text: 'Denmark is five million people with sectoral bargaining. Scale matters.' },
+  { id: 'bs-002a-r6', display_name: 'Quietreader', acct: 'quietreader', created_at: '2024-07-31T14:24:00.000Z', favourites_count: 0,
+    text: 'Following this thread.' },
+  { id: 'bs-002a-r7', display_name: 'Analyst B', acct: 'analyst_b', created_at: '2024-07-31T14:31:00.000Z', favourites_count: 2,
+    text: 'Wage insurance pilots polled better than retraining in every evaluation I have seen.' },
+];
+if (!(entry.replies ?? []).some((x) => x.id === NESTED_PARENT)) {
+  throw new Error(`nested parent ${NESTED_PARENT} not found`);
+}
+for (const r of NESTED_REPLIES) {
+  if (entry.replies.some((x) => x.id === r.id)) continue;
+  entry.replies.push({
+    id: r.id,
+    inReplyToId: NESTED_PARENT,
+    content: wrapsHtml ? `<p>${r.text}</p>` : r.text,
+    plainText: r.text,
+    account: { ...templateAccount, display_name: r.display_name, acct: r.acct },
+    created_at: r.created_at,
+    favourites_count: r.favourites_count,
+    replies_count: 0,
+    favourited: false,
+    bookmarked: false,
+  });
+}
+
 writeFileSync(DATA_PATH, JSON.stringify(data, null, 2) + '\n');
 
+const nestedCount = entry.replies.filter((r) => r.inReplyToId === NESTED_PARENT).length;
 const relCount = (entry.replies ?? []).reduce((n, r) => n + (r.relations?.length ?? 0), 0);
 console.log(`ok: ${REPLY_DEFS.length} replies annotated (${relCount} relations), ` +
-  `${DUAL_ROLE_RELATED_IDS.length} dual-role posts, small entry has ${small.replies.length} replies`);
+  `${DUAL_ROLE_RELATED_IDS.length} dual-role posts, small entry has ${small.replies.length} replies, ` +
+  `${NESTED_PARENT} has ${nestedCount} children`);

--- a/scripts/generate-reply-relations.mjs
+++ b/scripts/generate-reply-relations.mjs
@@ -1,0 +1,235 @@
+// Generates reply relations, reply ranks, dual-role posts, and the small-entry
+// replies for the listy-injection mock dataset. Offsets are COMPUTED against the
+// real strings (never hand-typed): each relation is declared as exact snippets,
+// located with indexOf, and the script throws on missing/ambiguous snippets.
+// Idempotent — safe to re-run; it overwrites what it owns and touches nothing else.
+//
+// Run: node scripts/generate-reply-relations.mjs
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DATA_PATH = join(here, '../src/app/FakeData/listy-injection.json');
+
+const BIG_ENTRY_ID = '112880124583497150';
+const SMALL_ENTRY_ID = '112880110824825811';
+/** Related posts that are ALSO replies to the focus post (suppression demo).
+ *  Chosen to avoid ids that are another entry's focus post — those would
+ *  corrupt the other entry's ancestor chain via the global parentMap. */
+const DUAL_ROLE_RELATED_IDS = ['112880118820779624', '112880115863645226'];
+
+const data = JSON.parse(readFileSync(DATA_PATH, 'utf8'));
+const entry = data.find((e) => e.focusPost.id === BIG_ENTRY_ID);
+if (!entry) throw new Error(`entry ${BIG_ENTRY_ID} not found`);
+const focusPlain = entry.focusPost.plainText;
+
+/** Locate `snippet` in `hay`; throw when absent or ambiguous. Returns [start, end). */
+function spanIn(hay, snippet, label) {
+  const i = hay.indexOf(snippet);
+  if (i < 0) throw new Error(`snippet not found (${label}): ${JSON.stringify(snippet)}`);
+  if (hay.indexOf(snippet, i + 1) >= 0) throw new Error(`snippet ambiguous (${label}): ${JSON.stringify(snippet)}`);
+  return [i, i + snippet.length];
+}
+
+/** Optional comment sub-snippet located INSIDE the span; zero-length at span start when omitted. */
+function commentSpan(hay, spanStart, spanEnd, sub, label) {
+  if (!sub) return [spanStart, spanStart];
+  const region = hay.slice(spanStart, spanEnd);
+  const j = region.indexOf(sub);
+  if (j < 0) throw new Error(`comment not inside span (${label}): ${JSON.stringify(sub)}`);
+  return [spanStart + j, spanStart + j + sub.length];
+}
+
+// ─── Relation definitions ─────────────────────────────────────────────────────
+// topic values reuse the entry's related-post topics wherever a cross-pane
+// intersection is wanted; 'Build quality' is deliberately replies-only.
+
+const REPLY_DEFS = [
+  {
+    id: 'bs-001', rank: 4, relations: [
+      { category: 'framing', topic: 'Manufacturing',
+        focus: 'The problem is ours, not theirs.',
+        focusComment: 'ours, not theirs',
+        content: 'the manufacturing-inferiority framing is the right starting point',
+        contentComment: 'right starting point' },
+      { category: 'values', topic: 'Affordable EV access',
+        focus: 'By resorting to tariffs we’re only making consumers pay more',
+        content: 'cheap EVs would benefit millions' },
+    ],
+  },
+  {
+    id: 'bs-002', rank: 9, relations: [
+      { category: 'questions', topic: 'Industrial policy',
+        focus: 'The fastest way a manufacturing company can boost its profits is to cut costs.',
+        content: 'at what cost to long-term jobs?',
+        contentComment: 'long-term jobs' },
+    ],
+  },
+  {
+    id: 'bs-003', rank: 7, relations: [
+      { category: 'connections', topic: 'Climate and tradeoffs',
+        focus: 'Cars, iPhones, solar panels, wind turbines, batteries, all of which we rely on China to make for us.',
+        focusComment: 'solar panels, wind turbines, batteries',
+        content: 'every BYD sold is a US gas car not sold' },
+    ],
+  },
+  {
+    id: 'bs-004', rank: 6, relations: [
+      { category: 'evidence_personal', topic: 'Manufacturing',
+        focus: 'Mortgage the future for the sake of a few more dollars today.',
+        content: 'Cheap imports, towns hollowed out, then nobody around to buy the cheap stuff anyway' },
+    ],
+  },
+  {
+    id: 'bs-005', rank: 3, relations: [
+      { category: 'evidence_public', topic: 'Industrial policy',
+        focus: 'we blame China for our own manufacturing inferiority',
+        content: 'Autor 2013 on the China shock, and Pierce-Schott 2016 on PNTR',
+        contentComment: 'China shock' },
+    ],
+  },
+  {
+    id: 'bs-007', rank: 2, relations: [
+      { category: 'framing', topic: 'Climate and tradeoffs',
+        focus: 'our money obsessed culture that prizes profits above all else',
+        content: 'Climate is the missing axis here' },
+      { category: 'proposals', topic: 'Affordable EV access',
+        focus: 'making consumers pay more for things that we can’t manufacture as well or as inexpensively as others can',
+        content: 'The fastest path to fleet electrification is the cheapest EV, not the patriotic one',
+        contentComment: 'cheapest EV' },
+    ],
+  },
+  {
+    id: 'bs-008', rank: 1, relations: [
+      { category: 'evidence_personal', topic: 'Manufacturing',
+        focus: 'Chinese manufacturers are adept at mass-producing electric vehicles.',
+        focusComment: 'adept at mass-producing',
+        content: 'BYD vertical integration is the story. They control the battery cell, the pack, the motor, and the platform.',
+        contentComment: 'vertical integration' },
+    ],
+  },
+  {
+    id: 'bs-009', rank: 11, relations: [
+      { category: 'evidence_personal', topic: 'Build quality',
+        focus: 'can make EVs, and most other manufactured goods, better than we can',
+        content: 'build quality was a notch above what I expected' },
+    ],
+  },
+  {
+    id: 'bs-010', rank: 10, relations: [
+      { category: 'framing', topic: 'Build quality',
+        focus: 'The fastest way a manufacturing company can boost its profits is to cut costs.',
+        content: 'Cost engineering does not equal corner cutting',
+        contentComment: 'corner cutting' },
+    ],
+  },
+  {
+    id: 'bs-011', rank: 5, relations: [
+      { category: 'connections', topic: 'Industrial policy',
+        focus: 'Over the past few decades we’ve rationalized becoming',
+        content: 'the retraining money never showed up' },
+    ],
+  },
+  {
+    id: 'bs-012', rank: 8, relations: [
+      { category: 'questions', topic: 'Tariffs',
+        focus: 'By resorting to tariffs we’re only making consumers pay more',
+        content: 'What is the over/under on a US tariff exemption for EV battery components?' },
+      { category: 'predictions', topic: 'Industrial policy',
+        focus: 'Our laws and court actions have repeatedly reaffirmed a company’s highest responsibility',
+        content: 'Hard to imagine the IRA tax credits surviving a full tariff wall.' },
+    ],
+  },
+  // bs-002a, bs-002a1, bs-006, bs-013 stay relation-free on purpose:
+  // substantive-but-unlinked and "me too" replies must render plain.
+];
+
+// ─── Apply reply relations + ranks ────────────────────────────────────────────
+
+for (const def of REPLY_DEFS) {
+  const reply = (entry.replies ?? []).find((r) => r.id === def.id);
+  if (!reply) throw new Error(`reply ${def.id} not found`);
+  const plain = reply.plainText ?? reply.content;
+  reply.relations = def.relations.map((d, i) => {
+    const label = `${def.id}[${i}]`;
+    const [focusStart, focusEnd] = spanIn(focusPlain, d.focus, `${label}.focus`);
+    const [contentStart, contentEnd] = spanIn(plain, d.content, `${label}.content`);
+    const [focusCommentStart, focusCommentEnd] = commentSpan(focusPlain, focusStart, focusEnd, d.focusComment, `${label}.focusComment`);
+    const [contentCommentStart, contentCommentEnd] = commentSpan(plain, contentStart, contentEnd, d.contentComment, `${label}.contentComment`);
+    return {
+      focusStart, focusEnd, focusCommentStart, focusCommentEnd,
+      contentStart, contentEnd, contentCommentStart, contentCommentEnd,
+      category: d.category, topic: d.topic,
+    };
+  });
+  reply.rank = def.rank;
+}
+
+// Overlap guard: content spans within one reply must not overlap (renderer assumption).
+for (const reply of entry.replies ?? []) {
+  const spans = (reply.relations ?? []).map((r) => [r.contentStart, r.contentEnd]).sort((a, b) => a[0] - b[0]);
+  for (let i = 1; i < spans.length; i++) {
+    if (spans[i][0] < spans[i - 1][1]) throw new Error(`content spans overlap in ${reply.id}`);
+  }
+}
+
+// Topic sanity: shared topics must exist among related posts; Build quality must not.
+const relatedTopics = new Set(entry.relatedPosts.flatMap((rp) => (rp.relations ?? []).map((r) => r.topic)));
+for (const def of REPLY_DEFS) {
+  for (const d of def.relations) {
+    if (d.topic === 'Build quality') {
+      if (relatedTopics.has(d.topic)) throw new Error('Build quality unexpectedly present in related posts');
+    } else if (!relatedTopics.has(d.topic)) {
+      throw new Error(`topic ${d.topic} not present in related posts — cross-pane demo would be dead`);
+    }
+  }
+}
+
+// ─── Dual-role related posts (suppression demo) ───────────────────────────────
+
+for (const id of DUAL_ROLE_RELATED_IDS) {
+  const rp = entry.relatedPosts.find((p) => p.id === id);
+  if (!rp) throw new Error(`dual-role related post ${id} not found`);
+  const isFocusElsewhere = data.some((e) => e.focusPost.id === id);
+  if (isFocusElsewhere) throw new Error(`dual-role pick ${id} is another entry's focus post`);
+  rp.inReplyToId = BIG_ENTRY_ID;
+}
+
+// ─── Small entry: 3 relation-free replies (tabs-suppressed state) ─────────────
+
+const small = data.find((e) => e.focusPost.id === SMALL_ENTRY_ID);
+if (!small) throw new Error(`entry ${SMALL_ENTRY_ID} not found`);
+small.replies = small.replies ?? [];
+const templateAccount = entry.replies[0].account;
+const SMALL_REPLIES = [
+  { id: 'bs2-001', display_name: 'Garage Skeptic', acct: 'garage_skeptic', created_at: '2024-07-31T13:05:00.000Z', favourites_count: 2,
+    text: 'The Ford numbers get repeated a lot but they fold fixed R&D into per-unit loss. Still bad, just not 50k-per-car bad.' },
+  { id: 'bs2-002', display_name: 'Tony P', acct: 'tony_p', created_at: '2024-07-31T13:22:00.000Z', favourites_count: 1,
+    text: 'Point 4 is the sleeper issue. No sales tax parity means the incentives push in opposite directions.' },
+  { id: 'bs2-003', display_name: 'Quietreader', acct: 'quietreader', created_at: '2024-07-31T13:41:00.000Z', favourites_count: 0,
+    text: 'Same.' },
+];
+const wrapsHtml = typeof entry.replies[0].content === 'string' && entry.replies[0].content.trim().startsWith('<');
+for (const r of SMALL_REPLIES) {
+  if (small.replies.some((x) => x.id === r.id)) continue;
+  small.replies.push({
+    id: r.id,
+    inReplyToId: SMALL_ENTRY_ID,
+    content: wrapsHtml ? `<p>${r.text}</p>` : r.text,
+    plainText: r.text,
+    account: { ...templateAccount, display_name: r.display_name, acct: r.acct },
+    created_at: r.created_at,
+    favourites_count: r.favourites_count,
+    replies_count: 0,
+    favourited: false,
+    bookmarked: false,
+  });
+}
+
+writeFileSync(DATA_PATH, JSON.stringify(data, null, 2) + '\n');
+
+const relCount = (entry.replies ?? []).reduce((n, r) => n + (r.relations?.length ?? 0), 0);
+console.log(`ok: ${REPLY_DEFS.length} replies annotated (${relCount} relations), ` +
+  `${DUAL_ROLE_RELATED_IDS.length} dual-role posts, small entry has ${small.replies.length} replies`);

--- a/src/app/(shell)/ChineseEVs/URL_SCHEMA.md
+++ b/src/app/(shell)/ChineseEVs/URL_SCHEMA.md
@@ -17,7 +17,7 @@ All params are managed by [`useUrlSync`](../../../utils/useUrlSync.ts) unless no
 
 | Param | Type / format | Default | Hydration | Write | Purpose |
 |---|---|---|---|---|---|
-| `tab` | `time \| recommended \| stacked \| summary` | `time` (omitted from URL) | yes | yes | Active reply tab |
+| `tab` | `time \| recommended \| stacked \| summary \| top \| liked` | `top` when the reply-sort-tabs experiment flag is on (its default), else `time`; the default is omitted from the URL | yes | yes | Active reply tab. `top`/`liked` belong to the flagged Top / Newest / Most liked set; `recommended`/`stacked`/`summary` to the legacy set — an out-of-set value is coerced on mount |
 | `fc` | CSV of category keys, sorted alpha | empty | yes | yes | Active filter chips (AND semantics) |
 | `fs` | `start-end` (numeric offsets into focus-post plaintext) | none | deferred until post content loads | yes | Focus-span filter from clicking a mark on the focus post |
 | `from` | `{post-id}` | none | one-shot on mount (seeds `previousPath`) | no | Back-link source — sets `sessionStorage['previousPath:/.../posts/{current}']` so BackButton can render |

--- a/src/app/(shell)/ChineseEVs/page.tsx
+++ b/src/app/(shell)/ChineseEVs/page.tsx
@@ -679,6 +679,19 @@ export default function ListyInjectionPage() {
         initialCard={null}
         onNavigate={opts?.isAncestor ? opts.onAncestorClick ? () => opts.onAncestorClick!() : undefined : navigateToPost}
         focusRelations={opts?.isAncestor ? [] : postData.focusRelations}
+        // Span-dwell tooltip count for NON-focused feed posts: their stacks
+        // aren't in context, so count linked responses from this post's own
+        // flat stacks (one stack per related post — distinct-post semantics).
+        relatedCountForSpans={
+          opts?.isAncestor
+            ? undefined
+            : (ranges) =>
+                postData.relatedStacks.filter((s: any) =>
+                  (s.topPost?.relations ?? []).some((r: any) =>
+                    ranges.some((u) => r.focusStart < u.fe && u.fs < r.focusEnd)
+                  )
+                ).length
+        }
       />
     );
   }

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -136,6 +136,18 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     [replyRelationsById]
   );
 
+  // Focus-post mark coverage: related-post relations PLUS reply relations.
+  // A reply can connect to a passage no related post covers (bs-011's was the
+  // canary) — without merging, hovering that reply had no mark to light up in
+  // the focus post or the pinned post. Gated with reply contributions: when
+  // replies render plain, their regions don't mark the focus post either.
+  const focusRelationsAll = useMemo(() => {
+    if (!flags.replyContributions) return focusRelations;
+    const merged = [...focusRelations];
+    replyRelationsById.forEach((rels) => merged.push(...rels));
+    return merged;
+  }, [flags.replyContributions, focusRelations, replyRelationsById]);
+
   // Top-level order for the current sort mode (also the pagination order).
   // Only computed under the reply-sort-tabs flag; legacy tabs keep the
   // component-internal newest-first order.
@@ -460,7 +472,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
       relatedStacks={[]}
       setActivePostId={setActivePostId}
       activePostId={activePostId}
-      focusRelations={isFocusPost ? focusRelations : []}
+      focusRelations={isFocusPost ? focusRelationsAll : []}
       contentRelations={showReplyContributions ? replyRelationsById.get(p.id) : undefined}
       categoryBadges={showReplyContributions ? replyBadgesById.get(p.id) : undefined}
       onContentSpanClick={
@@ -520,7 +532,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
           author={post.account.username}
           avatar={post.account.avatar}
           plainText={plainPostText}
-          focusRelations={focusRelations}
+          focusRelations={focusRelationsAll}
           anchorRef={focusWrapRef}
           containerRef={columnRef}
         />

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -37,9 +37,11 @@ import {
   useHighlightStore,
   setFilterCategories,
   clearResponseFilter,
-  clearTopicFilter,
   toggleReplyAnchor,
+  setReplyAnchor,
   clearReplyAnchor,
+  setReRankAnchor,
+  clearReRankAnchors,
   setReplyTopicCounts,
 } from "../../../../../utils/highlightStore";
 
@@ -64,7 +66,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
   const { id } = params;
   const { setFromPost, relatedStacks: ctxRelatedStacks } = useRelatedStacks();
   const flags = useExperimentFlags();
-  const { filterCategories, responseFilter, topicFilter, replyAnchor } = useHighlightStore();
+  const { filterCategories, responseFilter, replyAnchor, reRankAnchorIds, anchoredRangeByPost } = useHighlightStore();
 
   const [post, setPost] = useState<MockPostType | null>(null);
   const [ancestors, setAncestors] = useState<MockPostType[]>([]);
@@ -144,28 +146,60 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     }),
     [replyRelationsById]
   );
-  // ── Cross-pane filtering + reply reranking (Task 7) ───────────────────────
-  // The reply list applies the shared filters (categories, passage, and a
-  // related-anchor's topic) and wears them visibly in ReplyFilterBar. A reply
-  // anchor reranks THIS list in place while its topic filters the OTHER pane.
+  // ── Cross-pane filtering + symmetric topic grouping (Task 7, revised) ─────
+  // FILTERS (categories + passage) apply to both panes and are worn visibly in
+  // ReplyFilterBar. TOPIC interactions never filter: one topic GROUPS BOTH
+  // panes — each pane reranks in place around its own anchor, and the two
+  // anchors are kept in sync below. One concept, one pill per pane.
   const crossFilterActive = flags.crossPaneFiltering && flags.replySortTabs;
-  const relatedTopicForReplies =
-    crossFilterActive && topicFilter?.source === "related" ? topicFilter.topic : null;
 
   const displayedTopLevel = useMemo(() => {
     if (!crossFilterActive) return filteredReplies;
     return filterReplies(
       filteredReplies,
       (r: MockPostType) => replyRelationsById.get(r.id) ?? [],
-      { filterCategories, responseFilter, topicFilter: relatedTopicForReplies }
+      { filterCategories, responseFilter }
     );
-  }, [crossFilterActive, filteredReplies, replyRelationsById, filterCategories, responseFilter, relatedTopicForReplies]);
+  }, [crossFilterActive, filteredReplies, replyRelationsById, filterCategories, responseFilter]);
 
   const replyAnchorTopic = useMemo(() => {
     if (!replyAnchor) return null;
     const rels = replyRelationsById.get(replyAnchor.replyId) ?? [];
     return rels[replyAnchor.rangeIndex]?.topic ?? null;
   }, [replyAnchor, replyRelationsById]);
+
+  // Topic of the related panel's active anchor (explicit topics only — the
+  // curated dataset always carries them).
+  const relatedAnchorTopic = useMemo(() => {
+    const aid = reRankAnchorIds.length > 0 ? reRankAnchorIds[reRankAnchorIds.length - 1] : null;
+    if (!aid) return null;
+    const stack = (ctxRelatedStacks ?? []).find((s: any) => s?.topPost?.id === aid);
+    const ri = anchoredRangeByPost[aid] ?? 0;
+    return ((stack as any)?.topPost?.relations?.[ri]?.topic as string | undefined) ?? null;
+  }, [reRankAnchorIds, anchoredRangeByPost, ctxRelatedStacks]);
+
+  // Grouping sync, related → replies: when the right pane groups by a topic,
+  // cluster the replies around their first post on that topic; when the right
+  // grouping clears, the reply cluster clears with it. (The reply → related
+  // direction is handled synchronously in handleReplySpanClick.) Converges in
+  // one pass: once the reply anchor's topic matches, this effect no-ops.
+  useEffect(() => {
+    if (!crossFilterActive || !flags.replyReranking) return;
+    if (relatedAnchorTopic === null) {
+      if (replyAnchor) setReplyAnchor(null);
+      return;
+    }
+    if (replyAnchorTopic === relatedAnchorTopic) return;
+    for (const r of displayedTopLevel) {
+      const rels = replyRelationsById.get(r.id) ?? [];
+      const idx = rels.findIndex((x) => x.topic === relatedAnchorTopic);
+      if (idx >= 0) {
+        setReplyAnchor({ replyId: r.id, rangeIndex: idx });
+        return;
+      }
+    }
+    setReplyAnchor(null);
+  }, [crossFilterActive, flags.replyReranking, relatedAnchorTopic, replyAnchorTopic, replyAnchor, displayedTopLevel, replyRelationsById]);
 
   const replyCluster =
     flags.replyReranking && flags.replySortTabs && replyAnchor && replyAnchorTopic
@@ -269,9 +303,30 @@ export default function MockPostView({ params }: { params: { id: string } }) {
       const topic = rels[rangeIndex]?.topic ?? null;
       const el = document.querySelector(`[data-post-id="${replyId}"]`) as HTMLElement | null;
       replyPinRef.current = el ? { id: replyId, top: el.getBoundingClientRect().top } : null;
-      toggleReplyAnchor(replyId, rangeIndex, flags.crossPaneFiltering ? topic : null);
+
+      const isSame = replyAnchor?.replyId === replyId && replyAnchor.rangeIndex === rangeIndex;
+      if (isSame) {
+        // Dismissing the topic group clears BOTH panes' grouping.
+        clearReplyAnchor();
+        if (flags.crossPaneFiltering) clearReRankAnchors();
+        return;
+      }
+      toggleReplyAnchor(replyId, rangeIndex);
+      // Mirror the grouping onto the related panel: anchor its first card that
+      // carries the same topic. No topic match over there → no grouping there.
+      if (flags.crossPaneFiltering && topic) {
+        const stack = (ctxRelatedStacks ?? []).find((s: any) =>
+          ((s?.topPost?.relations ?? []) as Relation[]).some((x) => x.topic === topic)
+        );
+        if (stack) {
+          const ri = ((stack as any).topPost.relations as Relation[]).findIndex((x) => x.topic === topic);
+          setReRankAnchor((stack as any).topPost.id, ri);
+        } else {
+          clearReRankAnchors();
+        }
+      }
     },
-    [flags.replyReranking, flags.crossPaneFiltering, replyRelationsById]
+    [flags.replyReranking, flags.crossPaneFiltering, replyRelationsById, replyAnchor, ctxRelatedStacks]
   );
 
   useLayoutEffect(() => {
@@ -526,7 +581,6 @@ export default function MockPostView({ params }: { params: { id: string } }) {
           <ReplyFilterBar
             filterCategories={filterCategories}
             responseFilter={responseFilter}
-            relatedTopic={relatedTopicForReplies}
             shown={displayedTotal}
             total={totalTopLevelReplies}
             onRemoveCategory={(cat) => {
@@ -535,11 +589,9 @@ export default function MockPostView({ params }: { params: { id: string } }) {
               setFilterCategories(next);
             }}
             onClearResponse={clearResponseFilter}
-            onClearTopic={() => clearTopicFilter("related")}
             onClearAll={() => {
               setFilterCategories(new Set());
               clearResponseFilter();
-              clearTopicFilter("related");
             }}
           />
         )}
@@ -563,8 +615,8 @@ export default function MockPostView({ params }: { params: { id: string } }) {
               width: "100%",
             }}
           >
-            {/* Reply grouping pill — dismissing clears the reply anchor AND the
-                topic filter it pushed onto the related panel. */}
+            {/* Reply grouping pill — dismissing clears the topic group in BOTH
+                panes (the grouping is one concept shared across them). */}
             {replyCluster && replyClusterColor && (
               <div
                 data-testid="reply-cluster-pill"
@@ -579,7 +631,10 @@ export default function MockPostView({ params }: { params: { id: string } }) {
                 </Text>
                 <button
                   type="button"
-                  onClick={() => clearReplyAnchor()}
+                  onClick={() => {
+                    clearReplyAnchor();
+                    if (flags.crossPaneFiltering) clearReRankAnchors();
+                  }}
                   aria-label={`Remove ${replyCluster.topic} reply grouping`}
                   style={{
                     background: "#ffffffaa", borderRadius: 4, padding: "2px 8px",

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
   getMockRelatedStacks,
   getMockRecommended,
   getMockFocusRelations,
+  getMockReplyRelations,
   getMockPlainText,
   mockHasPost,
   type MockPostType,
@@ -88,6 +89,27 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     [mergedReplies, id]
   );
   const totalTopLevelReplies = filteredReplies.length;
+
+  // Reply contributions: relations + deduped category badges per reply id.
+  // Memoized maps keep prop references stable so React.memo on Post holds.
+  const replyRelationsById = useMemo(() => {
+    const m = new Map<string, Relation[]>();
+    for (const r of mergedReplies) {
+      const rels = getMockReplyRelations(r.id, id);
+      if (rels.length > 0) m.set(r.id, rels);
+    }
+    return m;
+  }, [mergedReplies, id]);
+
+  const replyBadgesById = useMemo(() => {
+    const m = new Map<string, string[]>();
+    replyRelationsById.forEach((rels, rid) => {
+      const cats: string[] = [];
+      for (const r of rels) if (!cats.includes(r.category)) cats.push(r.category);
+      m.set(rid, cats);
+    });
+    return m;
+  }, [replyRelationsById]);
 
   // -------------------- Load mock data --------------------
   useEffect(() => {
@@ -170,7 +192,12 @@ export default function MockPostView({ params }: { params: { id: string } }) {
   };
 
   // Stack icons are hidden on the focused view; related stacks live in the aside.
-  const renderPost = (p: MockPostType, isFocusPost: boolean = false) => (
+  const renderPost = (p: MockPostType, isFocusPost: boolean = false) => {
+    // Replies (incl. dual-role related posts) get contribution spans + badges;
+    // the focus post keeps its grey marks; ancestors stay passive by design.
+    const showReplyContributions =
+      !isFocusPost && flags.replyContributions && replyRelationsById.has(p.id);
+    return (
     <Post
       key={p.id}
       id={p.id}
@@ -192,6 +219,8 @@ export default function MockPostView({ params }: { params: { id: string } }) {
       setActivePostId={setActivePostId}
       activePostId={activePostId}
       focusRelations={isFocusPost ? focusRelations : []}
+      contentRelations={showReplyContributions ? replyRelationsById.get(p.id) : undefined}
+      categoryBadges={showReplyContributions ? replyBadgesById.get(p.id) : undefined}
       clampLines={10}
       // Keep every post/reply on the mock-backed detail route. Without this the
       // Post component falls back to the real /posts/[id] route, which requires a
@@ -201,7 +230,8 @@ export default function MockPostView({ params }: { params: { id: string } }) {
         router.push(`/ChineseEVs/posts/${pid}`);
       }}
     />
-  );
+    );
+  };
 
   if (!mockHasPost(id)) {
     return (

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
 import type { Relation } from "../../../../../types/PostType";
 import { getCurrentUser } from "../../../../../utils/getCurrentUser";
 import { useLocalStore, useHydrated, getComments } from "../../../../../utils/localStore";
+import { useExperimentFlags } from "../../../../../utils/experimentFlags";
 
 // Thread connector line style — mirrors /posts/[id]
 const THREAD_LINE_COLOR = "#ccd1dc";
@@ -45,6 +46,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
   const searchParamsObj = useSearchParams();
   const { id } = params;
   const { setFromPost } = useRelatedStacks();
+  const flags = useExperimentFlags();
 
   const [post, setPost] = useState<MockPostType | null>(null);
   const [ancestors, setAncestors] = useState<MockPostType[]>([]);
@@ -95,18 +97,33 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     }
     const p = getMockPost(id);
     setPost(p);
-    setAncestors(getMockAncestors(id));
-    setReplies(getMockReplies(id));
+    const threadAncestors = getMockAncestors(id);
+    const threadReplies = getMockReplies(id);
+    setAncestors(threadAncestors);
+    setReplies(threadReplies);
     setRecommendedPosts(getMockRecommended(id));
     setFocusRelations(getMockFocusRelations(id));
     if (p) {
+      // D1 suppression: posts already visible in the thread (the focus post,
+      // its ancestors, its replies) are dropped from the related panel so the
+      // user never meets the same post in both panes. The context only ever
+      // holds the suppressed list, which keeps chip/topic counts honest.
+      const threadIds = new Set<string>([
+        id,
+        ...threadAncestors.map((a) => a.id),
+        ...threadReplies.map((r) => r.id),
+      ]);
+      const visibleStacks = flags.suppressThreadPosts
+        ? p.relatedStacks.filter((s: any) => !threadIds.has(s?.topPost?.id))
+        : p.relatedStacks;
       // ?related={id}: arrived via a shared "pairing" link — emphasise that
       // related card in the aside. If the id isn't among this post's related
-      // responses (stale/invalid link), still show the post, but flag it.
+      // responses (stale/invalid link, or suppressed into the thread), still
+      // show the post, but flag it.
       const relatedId = searchParamsObj?.get("related") ?? null;
-      setFromPost(p.relatedStacks, id, { force: true, highlightPostId: relatedId });
+      setFromPost(visibleStacks, id, { force: true, highlightPostId: relatedId });
       setActivePostId(id);
-      if (relatedId && !p.relatedStacks.some((s: any) => s?.topPost?.id === relatedId)) {
+      if (relatedId && !visibleStacks.some((s: any) => s?.topPost?.id === relatedId)) {
         notifications.show({
           title: "Pairing unavailable",
           message: "That related response isn't available for this post anymore.",
@@ -117,7 +134,8 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     // Read currentUser from localStorage if present (ReplySection wants it; mock allows null).
     const user = getCurrentUser();
     if (user) setCurrentUser(user);
-  }, [id]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, flags.suppressThreadPosts]);
 
   // Defer the reply thread to the next task so the focus post + ancestors
   // paint immediately instead of blocking on one big synchronous render.

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -687,6 +687,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
               renderPost={renderPost as any}
               visibleTopLevelCount={visibleTopLevelReplies}
               topLevelOrder={topLevelOrder}
+              opAcct={post?.account?.acct || post?.account?.username}
             />
             {displayedTotal === 0 && (
               <Text size="sm" c="dimmed" p="md" data-testid="no-matching-replies">

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -31,6 +31,7 @@ import { filterReplies, clusterTopLevel } from "../../../../../utils/threadFilte
 import { getMockReplyRank } from "../../../../../utils/mockPostResolver";
 import ReplySummaryCard from "../../../../../components/ReplySummaryCard";
 import ReplyFilterBar from "../../../../../components/ReplyFilterBar";
+import FocusPostStickyBar from "../../../../../components/Posts/FocusPostStickyBar";
 import { getCategoryColors } from "../../../../../utils/categoryStyles";
 import {
   useHighlightStore,
@@ -196,17 +197,32 @@ export default function MockPostView({ params }: { params: { id: string } }) {
   const displayedTotal = topLevelOrder ? topLevelOrder.length : totalTopLevelReplies;
 
   // Topic → displayed-reply count, published to the store so the related
-  // panel's "N more <topic>" tooltips count across both panes.
+  // panel's "N more <topic>" tooltips count across both panes. Counts every
+  // reply in the displayed branches — nested replies carry contributions too.
   const replyTopicCountsMap = useMemo(() => {
+    const childIds = new Map<string, string[]>();
+    for (const r of mergedReplies) {
+      const pid = r.in_reply_to_id;
+      if (!pid) continue;
+      const arr = childIds.get(pid) ?? [];
+      arr.push(r.id);
+      childIds.set(pid, arr);
+    }
     const m = new Map<string, number>();
-    for (const r of displayedTopLevel) {
+    const stack = displayedTopLevel.map((r) => r.id);
+    const seen = new Set<string>();
+    while (stack.length) {
+      const rid = stack.pop()!;
+      if (seen.has(rid)) continue;
+      seen.add(rid);
       const topics = new Set(
-        (replyRelationsById.get(r.id) ?? []).map((x) => x.topic).filter(Boolean) as string[]
+        (replyRelationsById.get(rid) ?? []).map((x) => x.topic).filter(Boolean) as string[]
       );
       topics.forEach((t) => m.set(t, (m.get(t) ?? 0) + 1));
+      for (const cid of childIds.get(rid) ?? []) stack.push(cid);
     }
     return m;
-  }, [displayedTopLevel, replyRelationsById]);
+  }, [displayedTopLevel, mergedReplies, replyRelationsById]);
 
   useEffect(() => {
     if (!crossFilterActive) {
@@ -243,6 +259,9 @@ export default function MockPostView({ params }: { params: { id: string } }) {
   // Reply span click: rerank in place. The clicked card is scroll-pinned so the
   // user never loses their place (same contract as the related panel's anchors).
   const replyPinRef = useRef<{ id: string; top: number } | null>(null);
+  // Sticky focus bar anchors: the focus post wrapper + the center column.
+  const focusWrapRef = useRef<HTMLDivElement | null>(null);
+  const columnRef = useRef<HTMLDivElement | null>(null);
   const handleReplySpanClick = useCallback(
     (replyId: string, rangeIndex: number) => {
       if (!flags.replyReranking) return;
@@ -439,8 +458,18 @@ export default function MockPostView({ params }: { params: { id: string } }) {
   if (!post) return <Loader size="lg" />;
 
   return (
-    <div style={{ position: "relative" }}>
+    <div style={{ position: "relative" }} ref={columnRef}>
       <BackButton />
+      {flags.stickyFocusBar && post && plainPostText && (
+        <FocusPostStickyBar
+          author={post.account.username}
+          avatar={post.account.avatar}
+          plainText={plainPostText}
+          focusRelations={focusRelations}
+          anchorRef={focusWrapRef}
+          containerRef={columnRef}
+        />
+      )}
       <div>
         <div style={{ position: "relative" }}>
           {/* Ancestors — thread connector line runs at the avatar column,
@@ -482,7 +511,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
           )}
 
           {/* Focus post */}
-          <div style={{ position: "relative" }}>
+          <div style={{ position: "relative" }} ref={focusWrapRef}>
             {renderPost(post, /* isFocusPost */ true)}
           </div>
         </div>

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button, Divider, Loader, Paper, Tabs, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
@@ -27,8 +27,20 @@ import { getCurrentUser } from "../../../../../utils/getCurrentUser";
 import { useLocalStore, useHydrated, getComments } from "../../../../../utils/localStore";
 import { useExperimentFlags } from "../../../../../utils/experimentFlags";
 import { sortReplies } from "../../../../../utils/replySort.mjs";
+import { filterReplies, clusterTopLevel } from "../../../../../utils/threadFilter.mjs";
 import { getMockReplyRank } from "../../../../../utils/mockPostResolver";
 import ReplySummaryCard from "../../../../../components/ReplySummaryCard";
+import ReplyFilterBar from "../../../../../components/ReplyFilterBar";
+import { getCategoryColors } from "../../../../../utils/categoryStyles";
+import {
+  useHighlightStore,
+  setFilterCategories,
+  clearResponseFilter,
+  clearTopicFilter,
+  toggleReplyAnchor,
+  clearReplyAnchor,
+  setReplyTopicCounts,
+} from "../../../../../utils/highlightStore";
 
 // Thread connector line style — mirrors /posts/[id]
 const THREAD_LINE_COLOR = "#ccd1dc";
@@ -49,8 +61,9 @@ export default function MockPostView({ params }: { params: { id: string } }) {
   const router = useRouter();
   const searchParamsObj = useSearchParams();
   const { id } = params;
-  const { setFromPost } = useRelatedStacks();
+  const { setFromPost, relatedStacks: ctxRelatedStacks } = useRelatedStacks();
   const flags = useExperimentFlags();
+  const { filterCategories, responseFilter, topicFilter, replyAnchor } = useHighlightStore();
 
   const [post, setPost] = useState<MockPostType | null>(null);
   const [ancestors, setAncestors] = useState<MockPostType[]>([]);
@@ -130,11 +143,127 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     }),
     [replyRelationsById]
   );
-  const topLevelOrder = useMemo(() => {
-    if (!flags.replySortTabs) return undefined;
+  // ── Cross-pane filtering + reply reranking (Task 7) ───────────────────────
+  // The reply list applies the shared filters (categories, passage, and a
+  // related-anchor's topic) and wears them visibly in ReplyFilterBar. A reply
+  // anchor reranks THIS list in place while its topic filters the OTHER pane.
+  const crossFilterActive = flags.crossPaneFiltering && flags.replySortTabs;
+  const relatedTopicForReplies =
+    crossFilterActive && topicFilter?.source === "related" ? topicFilter.topic : null;
+
+  const displayedTopLevel = useMemo(() => {
+    if (!crossFilterActive) return filteredReplies;
+    return filterReplies(
+      filteredReplies,
+      (r: MockPostType) => replyRelationsById.get(r.id) ?? [],
+      { filterCategories, responseFilter, topicFilter: relatedTopicForReplies }
+    );
+  }, [crossFilterActive, filteredReplies, replyRelationsById, filterCategories, responseFilter, relatedTopicForReplies]);
+
+  const replyAnchorTopic = useMemo(() => {
+    if (!replyAnchor) return null;
+    const rels = replyRelationsById.get(replyAnchor.replyId) ?? [];
+    return rels[replyAnchor.rangeIndex]?.topic ?? null;
+  }, [replyAnchor, replyRelationsById]);
+
+  const replyCluster =
+    flags.replyReranking && flags.replySortTabs && replyAnchor && replyAnchorTopic
+      ? { anchorId: replyAnchor.replyId, topic: replyAnchorTopic, rangeIndex: replyAnchor.rangeIndex }
+      : null;
+  const replyClusterColor = replyCluster
+    ? getCategoryColors(
+        (replyRelationsById.get(replyCluster.anchorId) ?? [])[replyCluster.rangeIndex]?.category ?? "uncategorized"
+      )
+    : null;
+
+  const { topLevelOrder, clusterMemberIds } = useMemo(() => {
+    if (!flags.replySortTabs) return { topLevelOrder: undefined, clusterMemberIds: null as Set<string> | null };
     const mode = activeTab === "top" || activeTab === "liked" ? activeTab : "time";
-    return sortReplies(filteredReplies, mode, sortOpts).map((r: MockPostType) => r.id);
-  }, [flags.replySortTabs, activeTab, filteredReplies, sortOpts]);
+    let order = sortReplies(displayedTopLevel, mode, sortOpts).map((r: MockPostType) => r.id);
+    let memberIds: Set<string> | null = null;
+    if (replyCluster) {
+      const res = clusterTopLevel(
+        order,
+        (rid: string) => replyRelationsById.get(rid) ?? [],
+        replyCluster.anchorId,
+        replyCluster.topic
+      );
+      order = res.order;
+      memberIds = res.memberIds;
+    }
+    return { topLevelOrder: order, clusterMemberIds: memberIds };
+  }, [flags.replySortTabs, activeTab, displayedTopLevel, sortOpts, replyCluster, replyRelationsById]);
+  const displayedTotal = topLevelOrder ? topLevelOrder.length : totalTopLevelReplies;
+
+  // Topic → displayed-reply count, published to the store so the related
+  // panel's "N more <topic>" tooltips count across both panes.
+  const replyTopicCountsMap = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const r of displayedTopLevel) {
+      const topics = new Set(
+        (replyRelationsById.get(r.id) ?? []).map((x) => x.topic).filter(Boolean) as string[]
+      );
+      topics.forEach((t) => m.set(t, (m.get(t) ?? 0) + 1));
+    }
+    return m;
+  }, [displayedTopLevel, replyRelationsById]);
+
+  useEffect(() => {
+    if (!crossFilterActive) {
+      setReplyTopicCounts({});
+      return;
+    }
+    const obj: Record<string, number> = {};
+    replyTopicCountsMap.forEach((n, t) => {
+      obj[t] = n;
+    });
+    setReplyTopicCounts(obj);
+  }, [crossFilterActive, replyTopicCountsMap]);
+  useEffect(() => () => setReplyTopicCounts({}), []);
+
+  // Cross-pane tooltip count for reply spans: related posts + displayed replies
+  // sharing the topic, minus the hovered reply itself. Related side counts
+  // explicit topics only (the curated entries always carry them).
+  const relatedTopicCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const s of ctxRelatedStacks ?? []) {
+      const topics = new Set(
+        (((s as any)?.topPost?.relations ?? []) as Relation[]).map((r) => r.topic).filter(Boolean) as string[]
+      );
+      topics.forEach((t) => m.set(t, (m.get(t) ?? 0) + 1));
+    }
+    return m;
+  }, [ctxRelatedStacks]);
+  const replyTopicCountFn = useCallback(
+    (topic: string) =>
+      Math.max(0, (relatedTopicCounts.get(topic) ?? 0) + (replyTopicCountsMap.get(topic) ?? 0) - 1),
+    [relatedTopicCounts, replyTopicCountsMap]
+  );
+
+  // Reply span click: rerank in place. The clicked card is scroll-pinned so the
+  // user never loses their place (same contract as the related panel's anchors).
+  const replyPinRef = useRef<{ id: string; top: number } | null>(null);
+  const handleReplySpanClick = useCallback(
+    (replyId: string, rangeIndex: number) => {
+      if (!flags.replyReranking) return;
+      const rels = replyRelationsById.get(replyId) ?? [];
+      const topic = rels[rangeIndex]?.topic ?? null;
+      const el = document.querySelector(`[data-post-id="${replyId}"]`) as HTMLElement | null;
+      replyPinRef.current = el ? { id: replyId, top: el.getBoundingClientRect().top } : null;
+      toggleReplyAnchor(replyId, rangeIndex, flags.crossPaneFiltering ? topic : null);
+    },
+    [flags.replyReranking, flags.crossPaneFiltering, replyRelationsById]
+  );
+
+  useLayoutEffect(() => {
+    const pin = replyPinRef.current;
+    replyPinRef.current = null;
+    if (!pin) return;
+    const el = document.querySelector(`[data-post-id="${pin.id}"]`) as HTMLElement | null;
+    if (!el) return;
+    const delta = el.getBoundingClientRect().top - pin.top;
+    if (Math.abs(delta) > 0.5) window.scrollTo(0, Math.max(0, window.scrollY + delta));
+  }, [replyAnchor]);
 
   // Keep the active tab valid for whichever tab set the flag selects.
   useEffect(() => {
@@ -235,7 +364,8 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     // the focus post keeps its grey marks; ancestors stay passive by design.
     const showReplyContributions =
       !isFocusPost && flags.replyContributions && replyRelationsById.has(p.id);
-    return (
+    const inCluster = !!clusterMemberIds?.has(p.id) && !!replyClusterColor;
+    const postEl = (
     <Post
       key={p.id}
       id={p.id}
@@ -259,6 +389,14 @@ export default function MockPostView({ params }: { params: { id: string } }) {
       focusRelations={isFocusPost ? focusRelations : []}
       contentRelations={showReplyContributions ? replyRelationsById.get(p.id) : undefined}
       categoryBadges={showReplyContributions ? replyBadgesById.get(p.id) : undefined}
+      onContentSpanClick={
+        showReplyContributions && flags.replyReranking && flags.replySortTabs
+          ? (ri: number) => handleReplySpanClick(p.id, ri)
+          : undefined
+      }
+      replyTopicCount={
+        showReplyContributions && flags.crossPaneFiltering ? replyTopicCountFn : undefined
+      }
       clampLines={10}
       // Keep every post/reply on the mock-backed detail route. Without this the
       // Post component falls back to the real /posts/[id] route, which requires a
@@ -268,6 +406,19 @@ export default function MockPostView({ params }: { params: { id: string } }) {
         router.push(`/ChineseEVs/posts/${pid}`);
       }}
     />
+    );
+    // Reply-cluster members carry a rail in the anchor's category color so the
+    // grouped block reads as one thread (mirrors the related panel's rail).
+    return inCluster && replyClusterColor ? (
+      <div
+        key={`cluster-${p.id}`}
+        data-reply-cluster-member
+        style={{ borderLeft: `3px solid ${replyClusterColor.border}`, borderRadius: 0, paddingLeft: 8 }}
+      >
+        {postEl}
+      </div>
+    ) : (
+      postEl
     );
   };
 
@@ -340,11 +491,36 @@ export default function MockPostView({ params }: { params: { id: string } }) {
 
         {showThread && <ReplySection postId={id} currentUser={currentUser} fetchPostAndReplies={() => {}} />}
 
+        {/* Visible filter state for the replies list — cross-pane filters only
+            act when they are worn by the list they hide posts from. */}
+        {showThread && crossFilterActive && (
+          <ReplyFilterBar
+            filterCategories={filterCategories}
+            responseFilter={responseFilter}
+            relatedTopic={relatedTopicForReplies}
+            shown={displayedTotal}
+            total={totalTopLevelReplies}
+            onRemoveCategory={(cat) => {
+              const next = new Set(filterCategories);
+              next.delete(cat);
+              setFilterCategories(next);
+            }}
+            onClearResponse={clearResponseFilter}
+            onClearTopic={() => clearTopicFilter("related")}
+            onClearAll={() => {
+              setFilterCategories(new Set());
+              clearResponseFilter();
+              clearTopicFilter("related");
+            }}
+          />
+        )}
+
         {/* Summary follows the same small-thread suppression as the sort tabs:
-            with a handful of replies, a digest is noise (Jason's <=5 rule). */}
-        {showThread && flags.summaryCard && totalTopLevelReplies > 5 && filteredReplies.length > 0 && (
-          <div style={{ marginTop: "1rem" }}>
-            <ReplySummaryCard replies={filteredReplies as any} relationsOf={relationsOfReply} />
+            with a handful of replies, a digest is noise (Jason's <=5 rule).
+            It digests the CURRENTLY DISPLAYED (post-filter) replies. */}
+        {showThread && flags.summaryCard && totalTopLevelReplies > 5 && displayedTopLevel.length > 0 && (
+          <div style={{ marginTop: crossFilterActive ? 0 : "1rem" }}>
+            <ReplySummaryCard replies={displayedTopLevel as any} relationsOf={relationsOfReply} />
           </div>
         )}
 
@@ -358,6 +534,37 @@ export default function MockPostView({ params }: { params: { id: string } }) {
               width: "100%",
             }}
           >
+            {/* Reply grouping pill — dismissing clears the reply anchor AND the
+                topic filter it pushed onto the related panel. */}
+            {replyCluster && replyClusterColor && (
+              <div
+                data-testid="reply-cluster-pill"
+                style={{
+                  display: "flex", alignItems: "center", gap: 6,
+                  background: replyClusterColor.bg, border: `1px solid ${replyClusterColor.border}55`,
+                  borderRadius: 6, padding: "4px 8px", marginBottom: "0.5rem",
+                }}
+              >
+                <Text size="xs" fw={600} c={replyClusterColor.text} style={{ fontSize: 11 }}>
+                  Replies grouped by:
+                </Text>
+                <button
+                  type="button"
+                  onClick={() => clearReplyAnchor()}
+                  aria-label={`Remove ${replyCluster.topic} reply grouping`}
+                  style={{
+                    background: "#ffffffaa", borderRadius: 4, padding: "2px 8px",
+                    fontSize: 10, fontWeight: 600, color: replyClusterColor.text,
+                    cursor: "pointer", border: "none",
+                    display: "inline-flex", alignItems: "center", gap: 4, minHeight: 22,
+                  }}
+                >
+                  <span>{replyCluster.topic}</span>
+                  <span aria-hidden style={{ fontSize: 13, lineHeight: 1 }}>×</span>
+                </button>
+              </div>
+            )}
+
             {/* Tabs are suppressed for small threads (<=5 top-level replies):
                 with a handful of comments a sort control is noise — show the
                 thread newest-first, as a traditional interface would. */}
@@ -385,17 +592,22 @@ export default function MockPostView({ params }: { params: { id: string } }) {
               visibleTopLevelCount={visibleTopLevelReplies}
               topLevelOrder={topLevelOrder}
             />
-            {visibleTopLevelReplies < totalTopLevelReplies && (
+            {displayedTotal === 0 && (
+              <Text size="sm" c="dimmed" p="md" data-testid="no-matching-replies">
+                No replies match the active filters.
+              </Text>
+            )}
+            {visibleTopLevelReplies < displayedTotal && (
               <Button
                 onClick={() =>
-                  setVisibleTopLevelReplies((v) => Math.min(v + 5, totalTopLevelReplies))
+                  setVisibleTopLevelReplies((v) => Math.min(v + 5, displayedTotal))
                 }
                 variant="outline"
                 fullWidth
                 style={{ marginTop: 10 }}
               >
-                {totalTopLevelReplies - visibleTopLevelReplies} more{" "}
-                {totalTopLevelReplies - visibleTopLevelReplies === 1 ? "reply" : "replies"}
+                {displayedTotal - visibleTopLevelReplies} more{" "}
+                {displayedTotal - visibleTopLevelReplies === 1 ? "reply" : "replies"}
               </Button>
             )}
           </Paper>

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -26,6 +26,9 @@ import type { Relation } from "../../../../../types/PostType";
 import { getCurrentUser } from "../../../../../utils/getCurrentUser";
 import { useLocalStore, useHydrated, getComments } from "../../../../../utils/localStore";
 import { useExperimentFlags } from "../../../../../utils/experimentFlags";
+import { sortReplies } from "../../../../../utils/replySort.mjs";
+import { getMockReplyRank } from "../../../../../utils/mockPostResolver";
+import ReplySummaryCard from "../../../../../components/ReplySummaryCard";
 
 // Thread connector line style — mirrors /posts/[id]
 const THREAD_LINE_COLOR = "#ccd1dc";
@@ -54,7 +57,8 @@ export default function MockPostView({ params }: { params: { id: string } }) {
   const [replies, setReplies] = useState<MockPostType[]>([]);
   const [recommendedPosts, setRecommendedPosts] = useState<MockPostType[]>([]);
   const [focusRelations, setFocusRelations] = useState<Relation[]>([]);
-  const [activeTab, setActiveTab] = useState<string>("time");
+  // Default tab: "top" under the reply-sort-tabs flag (its default), "time" legacy.
+  const [activeTab, setActiveTab] = useState<string>("top");
   const [visibleTopLevelReplies, setVisibleTopLevelReplies] = useState(5);
   const [activePostId, setActivePostId] = useState<string | null>(null);
   const [currentUser, setCurrentUser] = useState<any | null>(null);
@@ -110,6 +114,39 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     });
     return m;
   }, [replyRelationsById]);
+
+  const relationsOfReply = useCallback(
+    (rid: string) => replyRelationsById.get(rid) ?? [],
+    [replyRelationsById]
+  );
+
+  // Top-level order for the current sort mode (also the pagination order).
+  // Only computed under the reply-sort-tabs flag; legacy tabs keep the
+  // component-internal newest-first order.
+  const sortOpts = useMemo(
+    () => ({
+      rankOf: (r: MockPostType) => getMockReplyRank(r.id),
+      relationsOf: (r: MockPostType) => replyRelationsById.get(r.id) ?? [],
+    }),
+    [replyRelationsById]
+  );
+  const topLevelOrder = useMemo(() => {
+    if (!flags.replySortTabs) return undefined;
+    const mode = activeTab === "top" || activeTab === "liked" ? activeTab : "time";
+    return sortReplies(filteredReplies, mode, sortOpts).map((r: MockPostType) => r.id);
+  }, [flags.replySortTabs, activeTab, filteredReplies, sortOpts]);
+
+  // Keep the active tab valid for whichever tab set the flag selects.
+  useEffect(() => {
+    if (flags.replySortTabs) {
+      if (activeTab === "recommended" || activeTab === "stacked" || activeTab === "summary") {
+        setActiveTab("top");
+      }
+    } else if (activeTab === "top" || activeTab === "liked") {
+      setActiveTab("time");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flags.replySortTabs]);
 
   // -------------------- Load mock data --------------------
   useEffect(() => {
@@ -174,6 +211,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     plainPostText,
     // Mock mode: tab switches don't require data fetches (data is already loaded).
     onHydratedTab: () => {},
+    defaultTab: flags.replySortTabs ? "top" : "time",
   });
 
   // H5: seed BackButton sessionStorage from ?from= when opening a shared link
@@ -302,7 +340,68 @@ export default function MockPostView({ params }: { params: { id: string } }) {
 
         {showThread && <ReplySection postId={id} currentUser={currentUser} fetchPostAndReplies={() => {}} />}
 
-        {showThread && mergedReplies.length > 0 && (
+        {/* Summary follows the same small-thread suppression as the sort tabs:
+            with a handful of replies, a digest is noise (Jason's <=5 rule). */}
+        {showThread && flags.summaryCard && totalTopLevelReplies > 5 && filteredReplies.length > 0 && (
+          <div style={{ marginTop: "1rem" }}>
+            <ReplySummaryCard replies={filteredReplies as any} relationsOf={relationsOfReply} />
+          </div>
+        )}
+
+        {showThread && mergedReplies.length > 0 && flags.replySortTabs && (
+          <Paper
+            style={{
+              borderRadius: "0 0 8px 8px",
+              fontFamily: "Roboto, sans-serif",
+              fontSize: 14,
+              marginTop: flags.summaryCard ? 0 : "1rem",
+              width: "100%",
+            }}
+          >
+            {/* Tabs are suppressed for small threads (<=5 top-level replies):
+                with a handful of comments a sort control is noise — show the
+                thread newest-first, as a traditional interface would. */}
+            {totalTopLevelReplies > 5 && (
+              <Tabs color="#002379" value={activeTab} onChange={handleTabChange}>
+                <Tabs.List style={{ marginBottom: "1rem" }} data-testid="reply-sort-tabs">
+                  {([["top", "Top"], ["time", "Newest"], ["liked", "Most liked"]] as const).map(([val, label]) => (
+                    <Tabs.Tab
+                      key={val}
+                      value={val}
+                      style={{ fontWeight: activeTab === val ? "bold" : "normal" }}
+                    >
+                      {label}
+                    </Tabs.Tab>
+                  ))}
+                </Tabs.List>
+              </Tabs>
+            )}
+            {/* One list for every sort: rendering never varies with the tab —
+                only the top-level order does (subtrees stay intact). */}
+            <ThreadedReplyList
+              replies={mergedReplies as any}
+              rootId={id}
+              renderPost={renderPost as any}
+              visibleTopLevelCount={visibleTopLevelReplies}
+              topLevelOrder={topLevelOrder}
+            />
+            {visibleTopLevelReplies < totalTopLevelReplies && (
+              <Button
+                onClick={() =>
+                  setVisibleTopLevelReplies((v) => Math.min(v + 5, totalTopLevelReplies))
+                }
+                variant="outline"
+                fullWidth
+                style={{ marginTop: 10 }}
+              >
+                {totalTopLevelReplies - visibleTopLevelReplies} more{" "}
+                {totalTopLevelReplies - visibleTopLevelReplies === 1 ? "reply" : "replies"}
+              </Button>
+            )}
+          </Paper>
+        )}
+
+        {showThread && mergedReplies.length > 0 && !flags.replySortTabs && (
           <Paper
             style={{
               borderRadius: "0 0 8px 8px",

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -707,6 +707,19 @@ export default function MockPostView({ params }: { params: { id: string } }) {
                 {displayedTotal - visibleTopLevelReplies === 1 ? "reply" : "replies"}
               </Button>
             )}
+            {visibleTopLevelReplies > 5 && (
+              <Button
+                onClick={() => setVisibleTopLevelReplies(5)}
+                variant="subtle"
+                color="gray"
+                fullWidth
+                size="compact-sm"
+                style={{ marginTop: 6 }}
+                data-testid="top-level-show-fewer"
+              >
+                Show fewer replies
+              </Button>
+            )}
           </Paper>
         )}
 

--- a/src/app/(shell)/related-stacks-context.tsx
+++ b/src/app/(shell)/related-stacks-context.tsx
@@ -73,10 +73,15 @@ export function RelatedStacksProvider({ children }: { children: React.ReactNode 
 
       if (options?.force) {
         // Skip no-op updates so the aside doesn't re-render (and replay framer-motion)
-        // on every scroll tick. Read committed state via the ref mirror. A shared-pairing
-        // highlight still needs to apply even when the post is already active, so don't
-        // early-return when there's a highlight to set.
-        if (postId === activePostIdRef.current && !nextHighlight) return;
+        // on every scroll tick. Read committed state via the ref mirror. A scroll tick
+        // resends the SAME memoized stacks array, so reference equality identifies it;
+        // a re-seed with a different array (e.g. suppression toggling) must apply even
+        // for the already-active post. A shared-pairing highlight also always applies.
+        if (
+          postId === activePostIdRef.current &&
+          !nextHighlight &&
+          nextStacks === relatedStacksRef.current
+        ) return;
         apply(postId, nextStacks, nextHighlight);
         return;
       }

--- a/src/app/FakeData/listy-injection.json
+++ b/src/app/FakeData/listy-injection.json
@@ -1074,6 +1074,118 @@
         "replies_count": 0,
         "favourited": false,
         "bookmarked": false
+      },
+      {
+        "id": "bs-002a-r1",
+        "inReplyToId": "bs-002a",
+        "content": "<p>TAA take-up rates hover around a quarter of eligible workers. The program design is the failure mode, not the concept.</p>",
+        "plainText": "TAA take-up rates hover around a quarter of eligible workers. The program design is the failure mode, not the concept.",
+        "account": {
+          "display_name": "Econ PhD",
+          "acct": "econ_phd",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T13:50:00.000Z",
+        "favourites_count": 6,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-002a-r2",
+        "inReplyToId": "bs-002a",
+        "content": "<p>Design AND funding. Every renewal cycle it gets trimmed before it reaches a single shop floor.</p>",
+        "plainText": "Design AND funding. Every renewal cycle it gets trimmed before it reaches a single shop floor.",
+        "account": {
+          "display_name": "Union Rep",
+          "acct": "union_rep",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T13:56:00.000Z",
+        "favourites_count": 4,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-002a-r3",
+        "inReplyToId": "bs-002a",
+        "content": "<p>Retraining a 55-year-old machinist into \"software\" was always a brochure fantasy.</p>",
+        "plainText": "Retraining a 55-year-old machinist into \"software\" was always a brochure fantasy.",
+        "account": {
+          "display_name": "Garage Skeptic",
+          "acct": "garage_skeptic",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T14:02:00.000Z",
+        "favourites_count": 2,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-002a-r4",
+        "inReplyToId": "bs-002a",
+        "content": "<p>Denmark manages it with flexicurity. It is not impossible, it is just not what we fund.</p>",
+        "plainText": "Denmark manages it with flexicurity. It is not impossible, it is just not what we fund.",
+        "account": {
+          "display_name": "Jane Dev",
+          "acct": "jane_dev",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T14:11:00.000Z",
+        "favourites_count": 3,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-002a-r5",
+        "inReplyToId": "bs-002a",
+        "content": "<p>Denmark is five million people with sectoral bargaining. Scale matters.</p>",
+        "plainText": "Denmark is five million people with sectoral bargaining. Scale matters.",
+        "account": {
+          "display_name": "Tony P",
+          "acct": "tony_p",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T14:19:00.000Z",
+        "favourites_count": 1,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-002a-r6",
+        "inReplyToId": "bs-002a",
+        "content": "<p>Following this thread.</p>",
+        "plainText": "Following this thread.",
+        "account": {
+          "display_name": "Quietreader",
+          "acct": "quietreader",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T14:24:00.000Z",
+        "favourites_count": 0,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs-002a-r7",
+        "inReplyToId": "bs-002a",
+        "content": "<p>Wage insurance pilots polled better than retraining in every evaluation I have seen.</p>",
+        "plainText": "Wage insurance pilots polled better than retraining in every evaluation I have seen.",
+        "account": {
+          "display_name": "Analyst B",
+          "acct": "analyst_b",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T14:31:00.000Z",
+        "favourites_count": 2,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
       }
     ]
   },

--- a/src/app/FakeData/listy-injection.json
+++ b/src/app/FakeData/listy-injection.json
@@ -229,7 +229,8 @@
         "favourites_count": 0,
         "replies_count": 0,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "inReplyToId": "112880124583497150"
       },
       {
         "id": "112880110824825811",
@@ -475,7 +476,8 @@
         "favourites_count": 0,
         "replies_count": 2,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "inReplyToId": "112880124583497150"
       },
       {
         "id": "112880114216355334",
@@ -646,7 +648,34 @@
         "favourites_count": 12,
         "replies_count": 2,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 166,
+            "focusEnd": 198,
+            "focusCommentStart": 181,
+            "focusCommentEnd": 197,
+            "contentStart": 18,
+            "contentEnd": 83,
+            "contentCommentStart": 63,
+            "contentCommentEnd": 83,
+            "category": "framing",
+            "topic": "Manufacturing"
+          },
+          {
+            "focusStart": 1072,
+            "focusEnd": 1132,
+            "focusCommentStart": 1072,
+            "focusCommentEnd": 1072,
+            "contentStart": 126,
+            "contentEnd": 158,
+            "contentCommentStart": 126,
+            "contentCommentEnd": 126,
+            "category": "values",
+            "topic": "Affordable EV access"
+          }
+        ],
+        "rank": 4
       },
       {
         "id": "bs-002",
@@ -662,7 +691,22 @@
         "favourites_count": 4,
         "replies_count": 1,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 538,
+            "focusEnd": 616,
+            "focusCommentStart": 538,
+            "focusCommentEnd": 538,
+            "contentStart": 22,
+            "contentEnd": 53,
+            "contentCommentStart": 38,
+            "contentCommentEnd": 52,
+            "category": "questions",
+            "topic": "Industrial policy"
+          }
+        ],
+        "rank": 9
       },
       {
         "id": "bs-002a",
@@ -710,7 +754,22 @@
         "favourites_count": 7,
         "replies_count": 0,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 971,
+            "focusEnd": 1071,
+            "focusCommentStart": 986,
+            "focusCommentEnd": 1024,
+            "contentStart": 33,
+            "contentEnd": 72,
+            "contentCommentStart": 33,
+            "contentCommentEnd": 33,
+            "category": "connections",
+            "topic": "Climate and tradeoffs"
+          }
+        ],
+        "rank": 7
       },
       {
         "id": "bs-004",
@@ -726,7 +785,22 @@
         "favourites_count": 18,
         "replies_count": 0,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 617,
+            "focusEnd": 678,
+            "focusCommentStart": 617,
+            "focusCommentEnd": 617,
+            "contentStart": 48,
+            "contentEnd": 131,
+            "contentCommentStart": 48,
+            "contentCommentEnd": 48,
+            "category": "evidence_personal",
+            "topic": "Manufacturing"
+          }
+        ],
+        "rank": 6
       },
       {
         "id": "bs-005",
@@ -742,7 +816,22 @@
         "favourites_count": 22,
         "replies_count": 1,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 16,
+            "focusEnd": 68,
+            "focusCommentStart": 16,
+            "focusCommentEnd": 16,
+            "contentStart": 26,
+            "contentEnd": 87,
+            "contentCommentStart": 44,
+            "contentCommentEnd": 55,
+            "category": "evidence_public",
+            "topic": "Industrial policy"
+          }
+        ],
+        "rank": 3
       },
       {
         "id": "bs-006",
@@ -774,7 +863,34 @@
         "favourites_count": 31,
         "replies_count": 0,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 227,
+            "focusEnd": 288,
+            "focusCommentStart": 227,
+            "focusCommentEnd": 227,
+            "contentStart": 0,
+            "contentEnd": 32,
+            "contentCommentStart": 0,
+            "contentCommentEnd": 0,
+            "category": "framing",
+            "topic": "Climate and tradeoffs"
+          },
+          {
+            "focusStart": 1107,
+            "focusEnd": 1211,
+            "focusCommentStart": 1107,
+            "focusCommentEnd": 1107,
+            "contentStart": 34,
+            "contentEnd": 117,
+            "contentCommentStart": 83,
+            "contentCommentEnd": 94,
+            "category": "proposals",
+            "topic": "Affordable EV access"
+          }
+        ],
+        "rank": 2
       },
       {
         "id": "bs-008",
@@ -790,7 +906,22 @@
         "favourites_count": 26,
         "replies_count": 2,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 94,
+            "focusEnd": 162,
+            "focusCommentStart": 120,
+            "focusCommentEnd": 143,
+            "contentStart": 27,
+            "contentEnd": 135,
+            "contentCommentStart": 31,
+            "contentCommentEnd": 51,
+            "category": "evidence_personal",
+            "topic": "Manufacturing"
+          }
+        ],
+        "rank": 1
       },
       {
         "id": "bs-009",
@@ -806,7 +937,22 @@
         "favourites_count": 8,
         "replies_count": 0,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 753,
+            "focusEnd": 820,
+            "focusCommentStart": 753,
+            "focusCommentEnd": 753,
+            "contentStart": 28,
+            "contentEnd": 75,
+            "contentCommentStart": 28,
+            "contentCommentEnd": 28,
+            "category": "evidence_personal",
+            "topic": "Build quality"
+          }
+        ],
+        "rank": 11
       },
       {
         "id": "bs-010",
@@ -822,7 +968,22 @@
         "favourites_count": 9,
         "replies_count": 0,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 538,
+            "focusEnd": 616,
+            "focusCommentStart": 538,
+            "focusCommentEnd": 538,
+            "contentStart": 0,
+            "contentEnd": 46,
+            "contentCommentStart": 32,
+            "contentCommentEnd": 46,
+            "category": "framing",
+            "topic": "Build quality"
+          }
+        ],
+        "rank": 10
       },
       {
         "id": "bs-011",
@@ -838,7 +999,22 @@
         "favourites_count": 14,
         "replies_count": 0,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 824,
+            "focusEnd": 877,
+            "focusCommentStart": 824,
+            "focusCommentEnd": 824,
+            "contentStart": 131,
+            "contentEnd": 167,
+            "contentCommentStart": 131,
+            "contentCommentEnd": 131,
+            "category": "connections",
+            "topic": "Industrial policy"
+          }
+        ],
+        "rank": 5
       },
       {
         "id": "bs-012",
@@ -854,7 +1030,34 @@
         "favourites_count": 6,
         "replies_count": 0,
         "favourited": false,
-        "bookmarked": false
+        "bookmarked": false,
+        "relations": [
+          {
+            "focusStart": 1072,
+            "focusEnd": 1132,
+            "focusCommentStart": 1072,
+            "focusCommentEnd": 1072,
+            "contentStart": 0,
+            "contentEnd": 74,
+            "contentCommentStart": 0,
+            "contentCommentEnd": 0,
+            "category": "questions",
+            "topic": "Tariffs"
+          },
+          {
+            "focusStart": 327,
+            "focusEnd": 415,
+            "focusCommentStart": 327,
+            "focusCommentEnd": 327,
+            "contentStart": 75,
+            "contentEnd": 140,
+            "contentCommentStart": 75,
+            "contentCommentEnd": 75,
+            "category": "predictions",
+            "topic": "Industrial policy"
+          }
+        ],
+        "rank": 8
       },
       {
         "id": "bs-013",
@@ -1440,6 +1643,56 @@
         "created_at": "2024-07-31T08:16:29.838Z",
         "favourites_count": 0,
         "replies_count": 108,
+        "favourited": false,
+        "bookmarked": false
+      }
+    ],
+    "replies": [
+      {
+        "id": "bs2-001",
+        "inReplyToId": "112880110824825811",
+        "content": "<p>The Ford numbers get repeated a lot but they fold fixed R&D into per-unit loss. Still bad, just not 50k-per-car bad.</p>",
+        "plainText": "The Ford numbers get repeated a lot but they fold fixed R&D into per-unit loss. Still bad, just not 50k-per-car bad.",
+        "account": {
+          "display_name": "Garage Skeptic",
+          "acct": "garage_skeptic",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T13:05:00.000Z",
+        "favourites_count": 2,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs2-002",
+        "inReplyToId": "112880110824825811",
+        "content": "<p>Point 4 is the sleeper issue. No sales tax parity means the incentives push in opposite directions.</p>",
+        "plainText": "Point 4 is the sleeper issue. No sales tax parity means the incentives push in opposite directions.",
+        "account": {
+          "display_name": "Tony P",
+          "acct": "tony_p",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T13:22:00.000Z",
+        "favourites_count": 1,
+        "replies_count": 0,
+        "favourited": false,
+        "bookmarked": false
+      },
+      {
+        "id": "bs2-003",
+        "inReplyToId": "112880110824825811",
+        "content": "<p>Same.</p>",
+        "plainText": "Same.",
+        "account": {
+          "display_name": "Quietreader",
+          "acct": "quietreader",
+          "avatar": "https://beta.stacky.social/avatars/original/missing.png"
+        },
+        "created_at": "2024-07-31T13:41:00.000Z",
+        "favourites_count": 0,
+        "replies_count": 0,
         "favourited": false,
         "bookmarked": false
       }

--- a/src/app/annotation/layout.tsx
+++ b/src/app/annotation/layout.tsx
@@ -47,9 +47,9 @@ export default function AnnotationPageLayout({ children }: { children: ReactNode
                         * bottom tier: This post is off-topic.
                     </Text>
                     <Text>
-                        Also, does each of the 8 posts AGREE or DISAGREE with the blue post's main views, claims, evidence, or values?
+                        Also, does each of the 8 posts AGREE or DISAGREE with the blue post&apos;s main views, claims, evidence, or values?
                         <br/>
-                        Select "Agrees" or "Disagrees" accordingly. You may select neither or both.
+                        Select &quot;Agrees&quot; or &quot;Disagrees&quot; accordingly. You may select neither or both.
                     </Text>
                 </Stack>
 

--- a/src/components/NavBar/ExperimentPanel.tsx
+++ b/src/components/NavBar/ExperimentPanel.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Popover, ActionIcon, Switch, Text, Button, Tooltip, Divider } from "@mantine/core";
+import { IconFlask } from "@tabler/icons-react";
+import {
+  useExperimentFlags,
+  setExperimentFlag,
+  resetExperimentFlags,
+  FLAG_META,
+} from "../../utils/experimentFlags";
+
+/**
+ * Experiment settings popover (TopNav flask button). Each switch toggles one
+ * thread-display condition; OFF = the control/legacy behavior for that feature.
+ */
+export function ExperimentPanel() {
+  const flags = useExperimentFlags();
+
+  return (
+    <Popover width={340} position="bottom-end" shadow="md" withArrow>
+      <Popover.Target>
+        <Tooltip label="Experiment settings" withArrow>
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            size="lg"
+            aria-label="Experiment settings"
+            data-testid="nav-experiments"
+          >
+            <IconFlask size={20} stroke={1.8} />
+          </ActionIcon>
+        </Tooltip>
+      </Popover.Target>
+      <Popover.Dropdown style={{ maxHeight: 420, overflowY: "auto" }}>
+        <Text size="sm" fw={700} mb={2}>
+          Experiment settings
+        </Text>
+        <Text size="xs" c="dimmed" mb="sm">
+          Thread-display conditions. Off = the traditional interface for that feature.
+        </Text>
+        {FLAG_META.map(({ key, label, description }) => (
+          <div key={key} style={{ marginBottom: 10 }}>
+            <Switch
+              size="sm"
+              checked={flags[key]}
+              onChange={(e) => setExperimentFlag(key, e.currentTarget.checked)}
+              label={label}
+              data-testid={`flag-${key}`}
+              styles={{ label: { fontWeight: 600, fontSize: 13 } }}
+            />
+            <Text size="xs" c="dimmed" style={{ marginLeft: 42, marginTop: 2 }}>
+              {description}
+            </Text>
+          </div>
+        ))}
+        <Divider my="xs" />
+        <Button
+          variant="subtle"
+          size="compact-xs"
+          color="gray"
+          onClick={resetExperimentFlags}
+          data-testid="flags-reset"
+        >
+          Reset to defaults
+        </Button>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/src/components/NavBar/TopNav.tsx
+++ b/src/components/NavBar/TopNav.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tabler/icons-react";
 import { useRouter, usePathname } from "next/navigation";
 import CrossweaveLogo from "./CrossweaveLogo";
+import { ExperimentPanel } from "./ExperimentPanel";
 
 const MastodonInstanceUrl = "https://beta.stacky.social";
 const clientId = process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_ID;
@@ -109,6 +110,8 @@ export function TopNav() {
                         </Tooltip>
                     );
                 })}
+
+                <ExperimentPanel />
 
                 <Tooltip label="Logout" withArrow>
                     <ActionIcon

--- a/src/components/Posts/FocusPostStickyBar.tsx
+++ b/src/components/Posts/FocusPostStickyBar.tsx
@@ -181,9 +181,18 @@ export default function FocusPostStickyBar({
       if (!mark) return;
       const boxRect = box.getBoundingClientRect();
       const markRect = mark.getBoundingClientRect();
-      // Center the mark in the 3-line window.
-      const top = box.scrollTop + (markRect.top - boxRect.top) - boxRect.height / 2 + markRect.height / 2;
-      animateScrollTo(box, Math.max(0, top));
+      // Snap to whole lines — the window must always show exactly 3 full lines,
+      // never a clipped one. Top-align regions of 3+ lines (their start is the
+      // point of the highlight); shorter regions sit centered on line grid, so
+      // anything that fits the window is fully in view.
+      const markTopInContent = markRect.top - boxRect.top + box.scrollTop;
+      const startLine = Math.round(markTopInContent / LINE_HEIGHT_PX);
+      const markLines = Math.max(1, Math.round(markRect.height / LINE_HEIGHT_PX));
+      const lead = markLines >= VISIBLE_LINES ? 0 : Math.floor((VISIBLE_LINES - markLines) / 2);
+      const maxTop =
+        Math.floor(Math.max(0, box.scrollHeight - box.clientHeight) / LINE_HEIGHT_PX) * LINE_HEIGHT_PX;
+      const top = Math.max(0, Math.min(maxTop, (startLine - lead) * LINE_HEIGHT_PX));
+      animateScrollTo(box, top);
     }, 120);
 
     return () => {

--- a/src/components/Posts/FocusPostStickyBar.tsx
+++ b/src/components/Posts/FocusPostStickyBar.tsx
@@ -5,7 +5,13 @@ import { Avatar, Text } from "@mantine/core";
 import { IconArrowUp } from "@tabler/icons-react";
 import type { Relation } from "../../types/PostType";
 import { getCategoryColors } from "../../utils/categoryStyles";
-import { useHighlightStore, setHoveredHighlightRangeIndex } from "../../utils/highlightStore";
+import {
+  useHighlightStore,
+  setHoveredHighlightRangeIndex,
+  setResponseFilter,
+  clearResponseFilter,
+} from "../../utils/highlightStore";
+import { useRelatedStacks } from "../../app/(shell)/related-stacks-context";
 import { TOP_NAV_HEIGHT } from "../NavBar/TopNav";
 
 function hexToRgba(hex: string, alpha: number): string {
@@ -64,12 +70,13 @@ interface FocusPostStickyBarProps {
 }
 
 /**
- * Collapsed focus-post bar (D9): a ~56px fixed bar with the author, one line of
- * text, and the contribution strip — a minimap of the focus post's relation
- * regions in category colors. It exists so cross-highlights from reply/related
- * hovers always have a visible landing zone: the strip segments light up from
- * the same hover store the full post uses, on stable nodes (no re-parsing).
- * Click returns to the post.
+ * Collapsed focus-post bar (D9): a compact fixed bar with the author, two lines
+ * of the post, and the contribution strip — a minimap of the focus post's
+ * relation regions in category colors. It is the landing zone for cross-
+ * highlights while the post is off-screen, AND a controller for the related
+ * panel: hovering a strip segment scrolls the panel to the first linked card,
+ * clicking a segment filters both panes to that passage (same semantics as
+ * clicking the span in the full post). Clicking the bar body returns to the post.
  */
 export default function FocusPostStickyBar({
   author,
@@ -81,7 +88,9 @@ export default function FocusPostStickyBar({
 }: FocusPostStickyBarProps) {
   const [visible, setVisible] = useState(false);
   const [bounds, setBounds] = useState<{ left: number; width: number } | null>(null);
-  const { hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory } = useHighlightStore();
+  const { hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter } = useHighlightStore();
+  const { relatedStacks: ctxRelatedStacks } = useRelatedStacks();
+  const asideScrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Show the bar only while the focus post is fully scrolled above the nav.
   useEffect(() => {
@@ -111,6 +120,12 @@ export default function FocusPostStickyBar({
     return () => window.removeEventListener("resize", measure);
   }, [containerRef, visible]);
 
+  useEffect(() => {
+    return () => {
+      if (asideScrollTimer.current) clearTimeout(asideScrollTimer.current);
+    };
+  }, []);
+
   const strip = useMemo(
     () => buildStrip(focusRelations, plainText.length),
     [focusRelations, plainText.length]
@@ -122,6 +137,7 @@ export default function FocusPostStickyBar({
 
   const segmentState = (seg: StripSegment): "off" | "faint" | "strong" => {
     if (!seg.category) return "off";
+    if (responseFilter && responseFilter.start < seg.end && seg.start < responseFilter.end) return "strong";
     if (hoveredHighlightRangeIndex != null && hoveredRelations) {
       const l2 = hoveredRelations[hoveredHighlightRangeIndex];
       if (l2 && l2.focusStart < seg.end && seg.start < l2.focusEnd) return "strong";
@@ -136,6 +152,50 @@ export default function FocusPostStickyBar({
     }
     if (hoveredRelations?.some((r) => r.focusStart < seg.end && seg.start < r.focusEnd)) return "faint";
     return "off";
+  };
+
+  /** First related card whose relations overlap the segment's focus region. */
+  const firstLinkedCardId = (seg: StripSegment): string | null => {
+    for (const s of ctxRelatedStacks ?? []) {
+      const rels: Relation[] = (((s as any)?.topPost?.relations ?? []) as Relation[]);
+      if (rels.some((r) => r.focusStart < seg.end && seg.start < r.focusEnd)) {
+        return (s as any).topPost.id as string;
+      }
+    }
+    return null;
+  };
+
+  const handleSegmentEnter = (seg: StripSegment) => {
+    if (seg.rangeIndexes.length === 1) setHoveredHighlightRangeIndex(seg.rangeIndexes[0]);
+    // Reveal the related section for this passage: after a short dwell, scroll
+    // the aside to the first card linked to the hovered region.
+    if (asideScrollTimer.current) clearTimeout(asideScrollTimer.current);
+    asideScrollTimer.current = setTimeout(() => {
+      asideScrollTimer.current = null;
+      const cardId = firstLinkedCardId(seg);
+      if (!cardId) return;
+      const aside = document.querySelector('[data-testid="col-aside"]');
+      const cardEl = (aside ?? document).querySelector(`[data-post-id="${cardId}"]`);
+      cardEl?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }, 150);
+  };
+
+  const handleSegmentLeave = () => {
+    setHoveredHighlightRangeIndex(null);
+    if (asideScrollTimer.current) {
+      clearTimeout(asideScrollTimer.current);
+      asideScrollTimer.current = null;
+    }
+  };
+
+  const handleSegmentClick = (e: React.MouseEvent, seg: StripSegment) => {
+    if (!seg.category) return;
+    e.stopPropagation(); // segment click filters; it must not trigger the bar's return-to-post
+    if (responseFilter && responseFilter.start === seg.start && responseFilter.end === seg.end) {
+      clearResponseFilter();
+      return;
+    }
+    setResponseFilter({ start: seg.start, end: seg.end, text: plainText.slice(seg.start, seg.end) });
   };
 
   return (
@@ -162,57 +222,66 @@ export default function FocusPostStickyBar({
         borderTop: "none",
         borderRadius: "0 0 10px 10px",
         boxShadow: "0 6px 16px rgba(0,0,0,0.08)",
-        padding: "7px 12px 8px",
+        padding: "10px 14px 11px",
         cursor: "pointer",
       }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
-        <Avatar src={avatar} alt={author} radius="xl" size={22} style={{ flexShrink: 0 }} />
-        <Text size="xs" fw={700} c="#011445" style={{ flexShrink: 0 }}>
-          {author}
-        </Text>
-        <Text
-          size="xs"
-          c="#475569"
-          style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
-        >
-          {oneLine}
-        </Text>
-        <span style={{ marginLeft: "auto", flexShrink: 0, display: "inline-flex", color: "#94a3b8" }}>
-          <IconArrowUp size={14} />
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 10, minWidth: 0 }}>
+        <Avatar src={avatar} alt={author} radius="xl" size={30} style={{ flexShrink: 0, marginTop: 1 }} />
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <Text size="sm" fw={700} c="#011445" style={{ lineHeight: 1.3 }}>
+            {author}
+          </Text>
+          <Text
+            size="xs"
+            c="#475569"
+            style={{
+              display: "-webkit-box",
+              WebkitBoxOrient: "vertical",
+              WebkitLineClamp: 2,
+              overflow: "hidden",
+              lineHeight: 1.45,
+            }}
+          >
+            {oneLine}
+          </Text>
+        </div>
+        <span style={{ flexShrink: 0, display: "inline-flex", color: "#94a3b8", marginTop: 2 }}>
+          <IconArrowUp size={15} />
         </span>
       </div>
       {strip.length > 0 && (
         <div
           data-testid="contribution-strip"
-          style={{ display: "flex", gap: 2, marginTop: 6, height: 8 }}
-          aria-hidden
+          style={{ display: "flex", gap: 2, marginTop: 8, height: 11 }}
         >
           {strip.map((seg, i) => {
             if (!seg.category) {
-              return <span key={i} style={{ flexGrow: seg.end - seg.start, minWidth: 0 }} />;
+              return <span key={i} aria-hidden style={{ flexGrow: seg.end - seg.start, minWidth: 0 }} />;
             }
             const tc = getCategoryColors(seg.category);
             const state = segmentState(seg);
             return (
               <span
                 key={i}
+                role="button"
+                aria-label="Filter to responses for this passage"
                 data-strip-state={state}
-                onMouseEnter={() => {
-                  if (seg.rangeIndexes.length === 1) setHoveredHighlightRangeIndex(seg.rangeIndexes[0]);
-                }}
-                onMouseLeave={() => setHoveredHighlightRangeIndex(null)}
+                onMouseEnter={() => handleSegmentEnter(seg)}
+                onMouseLeave={handleSegmentLeave}
+                onClick={(e) => handleSegmentClick(e, seg)}
                 style={{
                   flexGrow: seg.end - seg.start,
-                  minWidth: 3,
+                  minWidth: 4,
                   borderRadius: 2,
+                  cursor: "pointer",
                   background:
                     state === "strong"
                       ? tc.border
                       : state === "faint"
                         ? tc.bg
                         : hexToRgba(tc.bg, 0.55),
-                  outline: state === "strong" ? `1px solid ${tc.border}` : "none",
+                  outline: state === "strong" ? `1px solid ${tc.border}` : `1px solid ${hexToRgba(tc.border, 0.25)}`,
                   transition: "background 150ms ease",
                 }}
               />

--- a/src/components/Posts/FocusPostStickyBar.tsx
+++ b/src/components/Posts/FocusPostStickyBar.tsx
@@ -195,6 +195,19 @@ export default function FocusPostStickyBar({
 
   const oneLine = plainText.replace(/\s+/g, " ").trim();
 
+  // Level-2 bold: when a SPECIFIC span is hovered, only the data's optional
+  // focusComment sub-range goes bold — never the whole region. Relations on
+  // the same focus region carry different focusComments, so this is looked up
+  // from the hovered relation at render time (mirrors the full post).
+  const l2Relation =
+    hoveredRelations && hoveredHighlightRangeIndex != null
+      ? hoveredRelations[hoveredHighlightRangeIndex]
+      : null;
+  const boldRange =
+    l2Relation && l2Relation.focusCommentEnd > l2Relation.focusCommentStart
+      ? { start: l2Relation.focusCommentStart, end: l2Relation.focusCommentEnd }
+      : null;
+
   // Visual state per segment — same precedence as the full post's cross-highlight.
   const segmentTint = (seg: TextSegment): string | undefined => {
     if (seg.contributors.length === 0) return undefined;
@@ -313,6 +326,26 @@ export default function FocusPostStickyBar({
                 return <React.Fragment key={i}>{text}</React.Fragment>;
               }
               const tint = segmentTint(seg);
+              // Intersect the hovered relation's focusComment with this segment.
+              // The text-shadow faux-bold matches the full post: real font-weight
+              // would reflow the 3-line window and shift the auto-scroll target.
+              const bs = boldRange ? Math.max(seg.start, boldRange.start) : 0;
+              const be = boldRange ? Math.min(seg.end, boldRange.end) : 0;
+              const content =
+                boldRange && be > bs ? (
+                  <>
+                    {plainText.slice(seg.start, bs)}
+                    <span
+                      data-pinned-bold
+                      style={{ textShadow: "0 0 0.7px currentColor, 0 0 0.7px currentColor" }}
+                    >
+                      {plainText.slice(bs, be)}
+                    </span>
+                    {plainText.slice(be, seg.end)}
+                  </>
+                ) : (
+                  text
+                );
               return (
                 <mark
                   key={i}
@@ -328,7 +361,7 @@ export default function FocusPostStickyBar({
                     cursor: "pointer",
                   }}
                 >
-                  {text}
+                  {content}
                 </mark>
               );
             })}

--- a/src/components/Posts/FocusPostStickyBar.tsx
+++ b/src/components/Posts/FocusPostStickyBar.tsx
@@ -10,6 +10,7 @@ import {
   setHoveredHighlightRangeIndex,
   setResponseFilter,
   clearResponseFilter,
+  setFilterCategories,
 } from "../../utils/highlightStore";
 import { useRelatedStacks } from "../../app/(shell)/related-stacks-context";
 import { TOP_NAV_HEIGHT } from "../NavBar/TopNav";
@@ -88,7 +89,7 @@ export default function FocusPostStickyBar({
 }: FocusPostStickyBarProps) {
   const [visible, setVisible] = useState(false);
   const [bounds, setBounds] = useState<{ left: number; width: number } | null>(null);
-  const { hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter } = useHighlightStore();
+  const { hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter, filterCategories } = useHighlightStore();
   const { relatedStacks: ctxRelatedStacks } = useRelatedStacks();
   const asideScrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -195,6 +196,18 @@ export default function FocusPostStickyBar({
       clearResponseFilter();
       return;
     }
+    // Same dead-end guard as the full post's span click: category chips that
+    // cannot coexist with this passage are dropped instead of composing to zero.
+    if (filterCategories.size > 0) {
+      const compatible = (ctxRelatedStacks ?? []).some((s: any) => {
+        const rels: Relation[] = ((s?.topPost?.relations ?? []) as Relation[]);
+        const responds = rels.some((r) => r.focusStart < seg.end && seg.start < r.focusEnd);
+        if (!responds) return false;
+        const own = new Set<string>(rels.map((r) => r.category));
+        return Array.from(filterCategories).every((c) => own.has(c));
+      });
+      if (!compatible) setFilterCategories(new Set());
+    }
     setResponseFilter({ start: seg.start, end: seg.end, text: plainText.slice(seg.start, seg.end) });
   };
 
@@ -253,6 +266,7 @@ export default function FocusPostStickyBar({
       {strip.length > 0 && (
         <div
           data-testid="contribution-strip"
+          title="Contribution map — hover to preview in the related panel, click to filter to that passage"
           style={{ display: "flex", gap: 2, marginTop: 8, height: 11 }}
         >
           {strip.map((seg, i) => {
@@ -261,6 +275,9 @@ export default function FocusPostStickyBar({
             }
             const tc = getCategoryColors(seg.category);
             const state = segmentState(seg);
+            // Idle segments show their category color solid (the same shade the
+            // contribution spans use in posts) so the strip reads as a minimap
+            // of the post's contributions, not as washed-out decoration.
             return (
               <span
                 key={i}
@@ -279,9 +296,9 @@ export default function FocusPostStickyBar({
                     state === "strong"
                       ? tc.border
                       : state === "faint"
-                        ? tc.bg
-                        : hexToRgba(tc.bg, 0.55),
-                  outline: state === "strong" ? `1px solid ${tc.border}` : `1px solid ${hexToRgba(tc.border, 0.25)}`,
+                        ? hexToRgba(tc.border, 0.45)
+                        : tc.bg,
+                  outline: `1px solid ${hexToRgba(tc.border, state === "strong" ? 1 : 0.35)}`,
                   transition: "background 150ms ease",
                 }}
               />

--- a/src/components/Posts/FocusPostStickyBar.tsx
+++ b/src/components/Posts/FocusPostStickyBar.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Avatar, Text } from "@mantine/core";
+import { IconArrowUp } from "@tabler/icons-react";
+import type { Relation } from "../../types/PostType";
+import { getCategoryColors } from "../../utils/categoryStyles";
+import { useHighlightStore, setHoveredHighlightRangeIndex } from "../../utils/highlightStore";
+import { TOP_NAV_HEIGHT } from "../NavBar/TopNav";
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+interface StripSegment {
+  start: number;
+  end: number;
+  category: string | null; // null = uncovered text (spacer)
+  rangeIndexes: number[];
+}
+
+/** Merge relations into non-overlapping strip segments over [0, textLength).
+ *  Overlaps take the first contributing relation's category (one uniform band —
+ *  the strip is a minimap, not a data-faithful gradient). */
+function buildStrip(relations: Relation[], textLength: number): StripSegment[] {
+  if (textLength <= 0) return [];
+  const points = new Set<number>([0, textLength]);
+  for (const r of relations) {
+    points.add(Math.max(0, Math.min(textLength, r.focusStart)));
+    points.add(Math.max(0, Math.min(textLength, r.focusEnd)));
+  }
+  const sorted = Array.from(points).sort((a, b) => a - b);
+  const segments: StripSegment[] = [];
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const s = sorted[i];
+    const e = sorted[i + 1];
+    if (e <= s) continue;
+    const contributors: number[] = [];
+    relations.forEach((r, ri) => {
+      if (r.focusStart < e && s < r.focusEnd) contributors.push(ri);
+    });
+    segments.push({
+      start: s,
+      end: e,
+      category: contributors.length > 0 ? relations[contributors[0]].category : null,
+      rangeIndexes: contributors,
+    });
+  }
+  return segments;
+}
+
+interface FocusPostStickyBarProps {
+  author: string;
+  avatar: string;
+  plainText: string;
+  focusRelations: Relation[];
+  /** The focus post's wrapper — the bar shows while this is above the viewport. */
+  anchorRef: React.RefObject<HTMLElement>;
+  /** The centered column the bar should span — measured for fixed positioning. */
+  containerRef: React.RefObject<HTMLElement>;
+}
+
+/**
+ * Collapsed focus-post bar (D9): a ~56px fixed bar with the author, one line of
+ * text, and the contribution strip — a minimap of the focus post's relation
+ * regions in category colors. It exists so cross-highlights from reply/related
+ * hovers always have a visible landing zone: the strip segments light up from
+ * the same hover store the full post uses, on stable nodes (no re-parsing).
+ * Click returns to the post.
+ */
+export default function FocusPostStickyBar({
+  author,
+  avatar,
+  plainText,
+  focusRelations,
+  anchorRef,
+  containerRef,
+}: FocusPostStickyBarProps) {
+  const [visible, setVisible] = useState(false);
+  const [bounds, setBounds] = useState<{ left: number; width: number } | null>(null);
+  const { hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory } = useHighlightStore();
+
+  // Show the bar only while the focus post is fully scrolled above the nav.
+  useEffect(() => {
+    const el = anchorRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        const above = !entry.isIntersecting && entry.boundingClientRect.bottom < TOP_NAV_HEIGHT + 4;
+        setVisible(above);
+      },
+      { rootMargin: `-${TOP_NAV_HEIGHT}px 0px 0px 0px`, threshold: 0 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [anchorRef]);
+
+  // Track the center column's box for the fixed bar.
+  useEffect(() => {
+    const measure = () => {
+      const el = containerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      setBounds({ left: rect.left, width: rect.width });
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [containerRef, visible]);
+
+  const strip = useMemo(
+    () => buildStrip(focusRelations, plainText.length),
+    [focusRelations, plainText.length]
+  );
+
+  if (!visible || !bounds) return null;
+
+  const oneLine = plainText.replace(/\s+/g, " ").trim();
+
+  const segmentState = (seg: StripSegment): "off" | "faint" | "strong" => {
+    if (!seg.category) return "off";
+    if (hoveredHighlightRangeIndex != null && hoveredRelations) {
+      const l2 = hoveredRelations[hoveredHighlightRangeIndex];
+      if (l2 && l2.focusStart < seg.end && seg.start < l2.focusEnd) return "strong";
+    }
+    if (hoveredCategory && hoveredRelations) {
+      if (
+        hoveredRelations.some(
+          (r) => r.category === hoveredCategory && r.focusStart < seg.end && seg.start < r.focusEnd
+        )
+      )
+        return "strong";
+    }
+    if (hoveredRelations?.some((r) => r.focusStart < seg.end && seg.start < r.focusEnd)) return "faint";
+    return "off";
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label="Return to focused post"
+      data-testid="focus-sticky-bar"
+      onClick={() => anchorRef.current?.scrollIntoView({ block: "start", behavior: "smooth" })}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          anchorRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+        }
+      }}
+      style={{
+        position: "fixed",
+        top: TOP_NAV_HEIGHT,
+        left: bounds.left,
+        width: bounds.width,
+        zIndex: 150,
+        background: "#ffffff",
+        border: "1px solid #dbe2ea",
+        borderTop: "none",
+        borderRadius: "0 0 10px 10px",
+        boxShadow: "0 6px 16px rgba(0,0,0,0.08)",
+        padding: "7px 12px 8px",
+        cursor: "pointer",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+        <Avatar src={avatar} alt={author} radius="xl" size={22} style={{ flexShrink: 0 }} />
+        <Text size="xs" fw={700} c="#011445" style={{ flexShrink: 0 }}>
+          {author}
+        </Text>
+        <Text
+          size="xs"
+          c="#475569"
+          style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        >
+          {oneLine}
+        </Text>
+        <span style={{ marginLeft: "auto", flexShrink: 0, display: "inline-flex", color: "#94a3b8" }}>
+          <IconArrowUp size={14} />
+        </span>
+      </div>
+      {strip.length > 0 && (
+        <div
+          data-testid="contribution-strip"
+          style={{ display: "flex", gap: 2, marginTop: 6, height: 8 }}
+          aria-hidden
+        >
+          {strip.map((seg, i) => {
+            if (!seg.category) {
+              return <span key={i} style={{ flexGrow: seg.end - seg.start, minWidth: 0 }} />;
+            }
+            const tc = getCategoryColors(seg.category);
+            const state = segmentState(seg);
+            return (
+              <span
+                key={i}
+                data-strip-state={state}
+                onMouseEnter={() => {
+                  if (seg.rangeIndexes.length === 1) setHoveredHighlightRangeIndex(seg.rangeIndexes[0]);
+                }}
+                onMouseLeave={() => setHoveredHighlightRangeIndex(null)}
+                style={{
+                  flexGrow: seg.end - seg.start,
+                  minWidth: 3,
+                  borderRadius: 2,
+                  background:
+                    state === "strong"
+                      ? tc.border
+                      : state === "faint"
+                        ? tc.bg
+                        : hexToRgba(tc.bg, 0.55),
+                  outline: state === "strong" ? `1px solid ${tc.border}` : "none",
+                  transition: "background 150ms ease",
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Posts/FocusPostStickyBar.tsx
+++ b/src/components/Posts/FocusPostStickyBar.tsx
@@ -4,10 +4,9 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Avatar, Text } from "@mantine/core";
 import { IconArrowUp } from "@tabler/icons-react";
 import type { Relation } from "../../types/PostType";
-import { getCategoryColors } from "../../utils/categoryStyles";
+import { getCategoryColors, blendHex } from "../../utils/categoryStyles";
 import {
   useHighlightStore,
-  setHoveredHighlightRangeIndex,
   setResponseFilter,
   clearResponseFilter,
   setFilterCategories,
@@ -15,24 +14,21 @@ import {
 import { useRelatedStacks } from "../../app/(shell)/related-stacks-context";
 import { TOP_NAV_HEIGHT } from "../NavBar/TopNav";
 
-function hexToRgba(hex: string, alpha: number): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  return `rgba(${r},${g},${b},${alpha})`;
-}
+// The 3-line text window: fontSize 12.5 × lineHeight 1.5 ≈ 19px per line.
+const LINE_HEIGHT_PX = 19;
+const VISIBLE_LINES = 3;
 
-interface StripSegment {
+interface TextSegment {
   start: number;
   end: number;
-  category: string | null; // null = uncovered text (spacer)
-  rangeIndexes: number[];
+  /** Indices into focusRelations covering this segment (empty = plain text). */
+  contributors: number[];
 }
 
-/** Merge relations into non-overlapping strip segments over [0, textLength).
- *  Overlaps take the first contributing relation's category (one uniform band —
- *  the strip is a minimap, not a data-faithful gradient). */
-function buildStrip(relations: Relation[], textLength: number): StripSegment[] {
+/** Split the full text into non-overlapping segments at relation boundaries.
+ *  Focus relations overlap freely; flat segments let us render the whole post
+ *  as a single sequence of text and <mark> runs with no nesting. */
+function buildSegments(relations: Relation[], textLength: number): TextSegment[] {
   if (textLength <= 0) return [];
   const points = new Set<number>([0, textLength]);
   for (const r of relations) {
@@ -40,7 +36,7 @@ function buildStrip(relations: Relation[], textLength: number): StripSegment[] {
     points.add(Math.max(0, Math.min(textLength, r.focusEnd)));
   }
   const sorted = Array.from(points).sort((a, b) => a - b);
-  const segments: StripSegment[] = [];
+  const segments: TextSegment[] = [];
   for (let i = 0; i < sorted.length - 1; i++) {
     const s = sorted[i];
     const e = sorted[i + 1];
@@ -49,12 +45,7 @@ function buildStrip(relations: Relation[], textLength: number): StripSegment[] {
     relations.forEach((r, ri) => {
       if (r.focusStart < e && s < r.focusEnd) contributors.push(ri);
     });
-    segments.push({
-      start: s,
-      end: e,
-      category: contributors.length > 0 ? relations[contributors[0]].category : null,
-      rangeIndexes: contributors,
-    });
+    segments.push({ start: s, end: e, contributors });
   }
   return segments;
 }
@@ -71,13 +62,14 @@ interface FocusPostStickyBarProps {
 }
 
 /**
- * Collapsed focus-post bar (D9): a compact fixed bar with the author, two lines
- * of the post, and the contribution strip — a minimap of the focus post's
- * relation regions in category colors. It is the landing zone for cross-
- * highlights while the post is off-screen, AND a controller for the related
- * panel: hovering a strip segment scrolls the panel to the first linked card,
- * clicking a segment filters both panes to that passage (same semantics as
- * clicking the span in the full post). Clicking the bar body returns to the post.
+ * The PINNED POST (D9): while the focused post is scrolled off-screen, a fixed
+ * bar keeps a 3-line window of its REAL text — marks included — under the top
+ * nav. Hovering a contribution span anywhere (a related card on the right, a
+ * reply on the left) cross-highlights the connected region here AND auto-scrolls
+ * the window to bring it into view, so the connection is always visible without
+ * any proxy visualization. Clicking a highlighted region applies the passage
+ * filter (same semantics as clicking it in the full post); clicking anywhere
+ * else on the bar returns to the post.
  */
 export default function FocusPostStickyBar({
   author,
@@ -89,9 +81,37 @@ export default function FocusPostStickyBar({
 }: FocusPostStickyBarProps) {
   const [visible, setVisible] = useState(false);
   const [bounds, setBounds] = useState<{ left: number; width: number } | null>(null);
-  const { hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter, filterCategories } = useHighlightStore();
+  const { hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter, filterCategories } =
+    useHighlightStore();
   const { relatedStacks: ctxRelatedStacks } = useRelatedStacks();
-  const asideScrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const textBoxRef = useRef<HTMLDivElement | null>(null);
+  const scrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tweenRaf = useRef<number>(0);
+
+  // Chromium quirk: scrollTo({behavior:'smooth'}) silently no-ops on an
+  // overflow:hidden box, while direct scrollTop assignment works — so the
+  // window is animated by hand with a short rAF tween.
+  const animateScrollTo = (box: HTMLElement, to: number) => {
+    const from = box.scrollTop;
+    const delta = to - from;
+    if (Math.abs(delta) < 1) return;
+    if (tweenRaf.current) cancelAnimationFrame(tweenRaf.current);
+    const t0 = performance.now();
+    const DURATION_MS = 180;
+    const step = (t: number) => {
+      const p = Math.min(1, (t - t0) / DURATION_MS);
+      const ease = 1 - Math.pow(1 - p, 3);
+      box.scrollTop = from + delta * ease;
+      if (p < 1) tweenRaf.current = requestAnimationFrame(step);
+    };
+    tweenRaf.current = requestAnimationFrame(step);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (tweenRaf.current) cancelAnimationFrame(tweenRaf.current);
+    };
+  }, []);
 
   // Show the bar only while the focus post is fully scrolled above the nav.
   useEffect(() => {
@@ -121,94 +141,114 @@ export default function FocusPostStickyBar({
     return () => window.removeEventListener("resize", measure);
   }, [containerRef, visible]);
 
-  useEffect(() => {
-    return () => {
-      if (asideScrollTimer.current) clearTimeout(asideScrollTimer.current);
-    };
-  }, []);
-
-  const strip = useMemo(
-    () => buildStrip(focusRelations, plainText.length),
+  const segments = useMemo(
+    () => buildSegments(focusRelations, plainText.length),
     [focusRelations, plainText.length]
   );
+
+  // ── Auto-scroll the text window to the active cross-highlight ─────────────
+  // Target precedence mirrors the highlight levels: the specific hovered span
+  // (level 2) wins, then the hovered category's first region, then the hovered
+  // card's first region (level 1). No hover → glide back to the top.
+  useEffect(() => {
+    if (!visible) return;
+    const box = textBoxRef.current;
+    if (!box) return;
+    if (scrollTimer.current) clearTimeout(scrollTimer.current);
+
+    let target: { start: number; end: number } | null = null;
+    if (hoveredRelations && hoveredRelations.length > 0) {
+      const l2 = hoveredHighlightRangeIndex != null ? hoveredRelations[hoveredHighlightRangeIndex] : null;
+      const catRel = !l2 && hoveredCategory ? hoveredRelations.find((r) => r.category === hoveredCategory) : null;
+      const first = l2 ?? catRel ?? hoveredRelations[0];
+      if (first) target = { start: first.focusStart, end: first.focusEnd };
+    } else if (responseFilter) {
+      target = { start: responseFilter.start, end: responseFilter.end };
+    }
+
+    // Coalesce sweeps: one settle per 120ms, not one scroll per card boundary.
+    scrollTimer.current = setTimeout(() => {
+      scrollTimer.current = null;
+      if (target === null) {
+        animateScrollTo(box, 0);
+        return;
+      }
+      const mark = (Array.from(box.querySelectorAll("mark[data-fs]")) as HTMLElement[]).find((m) => {
+        const a = parseInt(m.getAttribute("data-fs") || "NaN", 10);
+        const b = parseInt(m.getAttribute("data-fe") || "NaN", 10);
+        return a < target!.end && target!.start < b;
+      });
+      if (!mark) return;
+      const boxRect = box.getBoundingClientRect();
+      const markRect = mark.getBoundingClientRect();
+      // Center the mark in the 3-line window.
+      const top = box.scrollTop + (markRect.top - boxRect.top) - boxRect.height / 2 + markRect.height / 2;
+      animateScrollTo(box, Math.max(0, top));
+    }, 120);
+
+    return () => {
+      if (scrollTimer.current) clearTimeout(scrollTimer.current);
+    };
+  }, [visible, hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter]);
 
   if (!visible || !bounds) return null;
 
   const oneLine = plainText.replace(/\s+/g, " ").trim();
 
-  const segmentState = (seg: StripSegment): "off" | "faint" | "strong" => {
-    if (!seg.category) return "off";
-    if (responseFilter && responseFilter.start < seg.end && seg.start < responseFilter.end) return "strong";
-    if (hoveredHighlightRangeIndex != null && hoveredRelations) {
-      const l2 = hoveredRelations[hoveredHighlightRangeIndex];
-      if (l2 && l2.focusStart < seg.end && seg.start < l2.focusEnd) return "strong";
+  // Visual state per segment — same precedence as the full post's cross-highlight.
+  const segmentTint = (seg: TextSegment): string | undefined => {
+    if (seg.contributors.length === 0) return undefined;
+    const overlap = (r: { focusStart: number; focusEnd: number }) =>
+      r.focusStart < seg.end && seg.start < r.focusEnd;
+    const catFor = (ri: number) => focusRelations[ri]?.category ?? "uncategorized";
+    if (responseFilter && responseFilter.start < seg.end && seg.start < responseFilter.end) {
+      const c = getCategoryColors(catFor(seg.contributors[0]));
+      return blendHex(c.bg, c.border, 0.15);
     }
-    if (hoveredCategory && hoveredRelations) {
-      if (
-        hoveredRelations.some(
-          (r) => r.category === hoveredCategory && r.focusStart < seg.end && seg.start < r.focusEnd
-        )
-      )
-        return "strong";
-    }
-    if (hoveredRelations?.some((r) => r.focusStart < seg.end && seg.start < r.focusEnd)) return "faint";
-    return "off";
-  };
-
-  /** First related card whose relations overlap the segment's focus region. */
-  const firstLinkedCardId = (seg: StripSegment): string | null => {
-    for (const s of ctxRelatedStacks ?? []) {
-      const rels: Relation[] = (((s as any)?.topPost?.relations ?? []) as Relation[]);
-      if (rels.some((r) => r.focusStart < seg.end && seg.start < r.focusEnd)) {
-        return (s as any).topPost.id as string;
+    if (hoveredRelations) {
+      const l2 = hoveredHighlightRangeIndex != null ? hoveredRelations[hoveredHighlightRangeIndex] : null;
+      if (l2 && overlap(l2)) {
+        const c = getCategoryColors(l2.category);
+        return blendHex(c.bg, c.border, 0.15);
+      }
+      if (hoveredCategory) {
+        const catMatch = hoveredRelations.find((r) => r.category === hoveredCategory && overlap(r));
+        if (catMatch) {
+          const c = getCategoryColors(hoveredCategory);
+          return blendHex(c.bg, c.border, 0.15);
+        }
+      }
+      const l1 = hoveredRelations.find(overlap);
+      if (l1) {
+        const c = getCategoryColors(l1.category);
+        return blendHex(c.bg, "#ffffff", 0.35);
       }
     }
-    return null;
+    return undefined; // idle: marks are invisible, exactly like the full post
   };
 
-  const handleSegmentEnter = (seg: StripSegment) => {
-    if (seg.rangeIndexes.length === 1) setHoveredHighlightRangeIndex(seg.rangeIndexes[0]);
-    // Reveal the related section for this passage: after a short dwell, scroll
-    // the aside to the first card linked to the hovered region.
-    if (asideScrollTimer.current) clearTimeout(asideScrollTimer.current);
-    asideScrollTimer.current = setTimeout(() => {
-      asideScrollTimer.current = null;
-      const cardId = firstLinkedCardId(seg);
-      if (!cardId) return;
-      const aside = document.querySelector('[data-testid="col-aside"]');
-      const cardEl = (aside ?? document).querySelector(`[data-post-id="${cardId}"]`);
-      cardEl?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-    }, 150);
-  };
-
-  const handleSegmentLeave = () => {
-    setHoveredHighlightRangeIndex(null);
-    if (asideScrollTimer.current) {
-      clearTimeout(asideScrollTimer.current);
-      asideScrollTimer.current = null;
-    }
-  };
-
-  const handleSegmentClick = (e: React.MouseEvent, seg: StripSegment) => {
-    if (!seg.category) return;
-    e.stopPropagation(); // segment click filters; it must not trigger the bar's return-to-post
-    if (responseFilter && responseFilter.start === seg.start && responseFilter.end === seg.end) {
+  const handleMarkClick = (e: React.MouseEvent, seg: TextSegment) => {
+    if (seg.contributors.length === 0) return;
+    e.stopPropagation(); // a highlight click filters; it must not trigger return-to-post
+    const rel = focusRelations[seg.contributors[0]];
+    const span = { start: rel.focusStart, end: rel.focusEnd, text: plainText.slice(rel.focusStart, rel.focusEnd) };
+    if (responseFilter && responseFilter.start === span.start && responseFilter.end === span.end) {
       clearResponseFilter();
       return;
     }
-    // Same dead-end guard as the full post's span click: category chips that
+    // Dead-end guard (same as the full post's span click): category chips that
     // cannot coexist with this passage are dropped instead of composing to zero.
     if (filterCategories.size > 0) {
       const compatible = (ctxRelatedStacks ?? []).some((s: any) => {
         const rels: Relation[] = ((s?.topPost?.relations ?? []) as Relation[]);
-        const responds = rels.some((r) => r.focusStart < seg.end && seg.start < r.focusEnd);
+        const responds = rels.some((r) => r.focusStart < span.end && span.start < r.focusEnd);
         if (!responds) return false;
         const own = new Set<string>(rels.map((r) => r.category));
         return Array.from(filterCategories).every((c) => own.has(c));
       });
       if (!compatible) setFilterCategories(new Set());
     }
-    setResponseFilter({ start: seg.start, end: seg.end, text: plainText.slice(seg.start, seg.end) });
+    setResponseFilter(span);
   };
 
   return (
@@ -217,6 +257,7 @@ export default function FocusPostStickyBar({
       tabIndex={0}
       aria-label="Return to focused post"
       data-testid="focus-sticky-bar"
+      title="Pinned post — click to return to it"
       onClick={() => anchorRef.current?.scrollIntoView({ block: "start", behavior: "smooth" })}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
@@ -235,77 +276,63 @@ export default function FocusPostStickyBar({
         borderTop: "none",
         borderRadius: "0 0 10px 10px",
         boxShadow: "0 6px 16px rgba(0,0,0,0.08)",
-        padding: "10px 14px 11px",
+        padding: "9px 14px 10px",
         cursor: "pointer",
       }}
     >
-      <div style={{ display: "flex", alignItems: "flex-start", gap: 10, minWidth: 0 }}>
-        <Avatar src={avatar} alt={author} radius="xl" size={30} style={{ flexShrink: 0, marginTop: 1 }} />
-        <div style={{ minWidth: 0, flex: 1 }}>
-          <Text size="sm" fw={700} c="#011445" style={{ lineHeight: 1.3 }}>
-            {author}
-          </Text>
-          <Text
-            size="xs"
-            c="#475569"
-            style={{
-              display: "-webkit-box",
-              WebkitBoxOrient: "vertical",
-              WebkitLineClamp: 2,
-              overflow: "hidden",
-              lineHeight: 1.45,
-            }}
-          >
-            {oneLine}
-          </Text>
-        </div>
-        <span style={{ flexShrink: 0, display: "inline-flex", color: "#94a3b8", marginTop: 2 }}>
-          <IconArrowUp size={15} />
+      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+        <Avatar src={avatar} alt={author} radius="xl" size={24} style={{ flexShrink: 0 }} />
+        <Text size="xs" fw={700} c="#011445" style={{ flexShrink: 0 }}>
+          {author}
+        </Text>
+        <span style={{ marginLeft: "auto", flexShrink: 0, display: "inline-flex", color: "#94a3b8" }}>
+          <IconArrowUp size={14} />
         </span>
       </div>
-      {strip.length > 0 && (
-        <div
-          data-testid="contribution-strip"
-          title="Contribution map — hover to preview in the related panel, click to filter to that passage"
-          style={{ display: "flex", gap: 2, marginTop: 8, height: 11 }}
-        >
-          {strip.map((seg, i) => {
-            if (!seg.category) {
-              return <span key={i} aria-hidden style={{ flexGrow: seg.end - seg.start, minWidth: 0 }} />;
-            }
-            const tc = getCategoryColors(seg.category);
-            const state = segmentState(seg);
-            // Idle segments show their category color solid (the same shade the
-            // contribution spans use in posts) so the strip reads as a minimap
-            // of the post's contributions, not as washed-out decoration.
-            return (
-              <span
-                key={i}
-                role="button"
-                aria-label="Filter to responses for this passage"
-                data-strip-state={state}
-                onMouseEnter={() => handleSegmentEnter(seg)}
-                onMouseLeave={handleSegmentLeave}
-                onClick={(e) => handleSegmentClick(e, seg)}
-                style={{
-                  flexGrow: seg.end - seg.start,
-                  minWidth: 4,
-                  borderRadius: 2,
-                  cursor: "pointer",
-                  background:
-                    state === "strong"
-                      ? tc.border
-                      : state === "faint"
-                        ? hexToRgba(tc.border, 0.45)
-                        : tc.bg,
-                  outline: `1px solid ${hexToRgba(tc.border, state === "strong" ? 1 : 0.35)}`,
-                  transition: "background 150ms ease",
-                }}
-              />
-            );
-          })}
-        </div>
-      )}
+      {/* 3-line window over the FULL post text. overflow:hidden still scrolls
+          programmatically — the auto-scroll effect drives it to whichever
+          region is cross-highlighted, so hovering a span in either pane always
+          reveals what it connects to. */}
+      <div
+        ref={textBoxRef}
+        data-testid="pinned-post-text"
+        style={{
+          marginTop: 6,
+          height: LINE_HEIGHT_PX * VISIBLE_LINES,
+          overflow: "hidden",
+          fontSize: "12.5px",
+          lineHeight: `${LINE_HEIGHT_PX}px`,
+          color: "#334155",
+        }}
+      >
+        {segments.length === 0
+          ? oneLine
+          : segments.map((seg, i) => {
+              const text = plainText.slice(seg.start, seg.end);
+              if (seg.contributors.length === 0) {
+                return <React.Fragment key={i}>{text}</React.Fragment>;
+              }
+              const tint = segmentTint(seg);
+              return (
+                <mark
+                  key={i}
+                  data-fs={seg.start}
+                  data-fe={seg.end}
+                  onClick={(e) => handleMarkClick(e, seg)}
+                  style={{
+                    background: tint ?? "transparent",
+                    color: "inherit",
+                    borderRadius: 2,
+                    padding: "1px 0",
+                    transition: "background 150ms ease",
+                    cursor: "pointer",
+                  }}
+                >
+                  {text}
+                </mark>
+              );
+            })}
+      </div>
     </div>
   );
 }

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -15,7 +15,8 @@ import InteractionControl from '../InteractionControl';
 import { toggleFavourite, toggleBookmark } from '../../utils/mastoActions';
 import { getPost, isLiked as storeIsLiked, isBookmarked as storeIsBookmarked } from '../../utils/localStore';
 import { useHighlightStore, setResponseFilter, clearResponseFilter, setPendingResponseFilter } from '../../utils/highlightStore';
-import { CATEGORY_COLORS } from '../../utils/categoryStyles';
+import { CATEGORY_COLORS, CATEGORY_LABELS, categoryIcon, getCategoryColors } from '../../utils/categoryStyles';
+import ReplyHighlightedContent from './ReplyHighlightedContent';
 import { useRelatedStacks } from '../../app/(shell)/related-stacks-context';
 import type { Relation } from '../../types/PostType';
 import { showTooltip, hideTooltip } from '../HoverTooltip';
@@ -639,6 +640,15 @@ interface PostProps {
   focusRelations?: Relation[];
   /** Collapsed line-clamp before "Read more" (feed uses 5; the full-post view passes more, e.g. 10). */
   clampLines?: number;
+  /** Related-card-style relations whose content offsets index THIS post's own
+   *  text (replies in the thread view). Renders colored category spans. */
+  contentRelations?: Relation[];
+  /** Deduped contribution categories shown as a badge row under the header. */
+  categoryBadges?: string[];
+  /** A contribution span in this post was clicked (rangeIndex into contentRelations). */
+  onContentSpanClick?: (rangeIndex: number) => void;
+  /** Optional cross-pane count for the reply span tooltip ("N more <topic>"). */
+  replyTopicCount?: (topic: string) => number;
 }
 
 function Post({
@@ -662,6 +672,10 @@ function Post({
   onNavigate,
   focusRelations = [],
   clampLines = 5,
+  contentRelations,
+  categoryBadges,
+  onContentSpanClick,
+  replyTopicCount,
 }: PostProps) {
   const router = useRouter();
   const [cardHeight, setCardHeight] = useState(0);
@@ -1087,12 +1101,62 @@ function Post({
           </Group>
         </div>
 
+        {categoryBadges && categoryBadges.length > 0 && (
+          <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap', margin: '6px 0 2px 3rem' }}>
+            {categoryBadges.map((cat) => {
+              const tc = getCategoryColors(cat);
+              return (
+                <span
+                  key={cat}
+                  data-reply-badge={cat}
+                  style={{
+                    background: tc.bg, color: tc.text, border: `1px solid ${tc.border}`,
+                    borderRadius: '5px', padding: '2px 7px',
+                    display: 'inline-flex', alignItems: 'center', gap: '4px',
+                    fontSize: '10px', fontWeight: 700,
+                  }}
+                >
+                  {categoryIcon(cat, 12, tc.text)}
+                  {CATEGORY_LABELS[cat] ?? cat}
+                </span>
+              );
+            })}
+          </div>
+        )}
+
         <div
           style={{ paddingLeft: '3rem', paddingRight:'3rem', cursor: 'pointer'}}
           onMouseUp={(e) => handleMouseUp(e)}
         >
           <div>
-      {focusRelations.length > 0 ? (
+      {contentRelations && contentRelations.length > 0 ? (
+        // Reply with contributions: colored category spans over its own text
+        // (the left-pane counterpart of a related card). Clamp/Read-more reuse
+        // the same wrapper the plain branch uses.
+        <div
+          ref={textRef}
+          className={isTextExpanded ? undefined : 'postClampedText'}
+          style={{
+            display: isTextExpanded ? 'block' : '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: isTextExpanded ? undefined : clampLines,
+            overflow: isTextExpanded ? 'visible' : 'hidden',
+            textOverflow: isTextExpanded ? 'unset' : 'ellipsis',
+            maxHeight: isTextExpanded ? undefined : `calc(1.5em * ${clampLines})`,
+            marginTop: '0px',
+            lineHeight: '1.5',
+            color: '#011445',
+          }}
+        >
+          <ReplyHighlightedContent
+            plainText={stripHtml(text)}
+            relations={contentRelations}
+            replyId={id}
+            onSpanClick={onContentSpanClick}
+            otherCountByTopic={replyTopicCount}
+          />
+        </div>
+      ) : focusRelations.length > 0 ? (
         // Render the interactive spans for EVERY post that has them — not just the
         // focused one — so feed posts get span hover + click-to-focus. active gates
         // the focused-only behaviour (cross-highlight, filter visual, auto-reveal).

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -241,7 +241,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   /** Non-focused post only: a span was clicked — focus this post then filter. */
   onSpanFocusRequest?: (span: { start: number; end: number; text: string }) => void;
 }>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded, focusRelations = [], onAutoReveal, active = true, onSpanFocusRequest }, ref) {
-  const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, responseFilter } = useHighlightStore();
+  const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter } = useHighlightStore();
   // Related stacks of the active (focus) post — used to count "N related posts"
   // for the click-to-filter affordance. Mirrored to a ref so the DOM hover
   // handlers read the latest without re-subscribing.
@@ -502,6 +502,12 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     clearFocusCommentBold(el);
     const level2 = (hoveredRelations && hoveredHighlightRangeIndex != null)
       ? hoveredRelations[hoveredHighlightRangeIndex] : null;
+    // Category-badge hover: every hovered-card relation OF THAT CATEGORY gets
+    // the level-2 shade (a badge is "the same relation at category grain"), the
+    // rest stay level-1. A specific span hover still wins over the badge.
+    const level2Cats = (!level2 && hoveredCategory && hoveredRelations)
+      ? hoveredRelations.filter((r) => r.category === hoveredCategory)
+      : null;
     const marks = Array.from(el.querySelectorAll('mark[data-fs]')) as HTMLElement[];
     marks.forEach((m) => {
       const a = parseInt(m.getAttribute('data-fs') || 'NaN', 10);
@@ -511,6 +517,11 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
         // L2 = a stronger shade of the SAME category colour, but only lightly toward
         // the saturated border (0.15, was 0.30 which read as too dark). Still clearly
         // stronger than the L1 faint (blend toward white), still pastel — not dark.
+        m.style.backgroundColor = c ? blendHex(c.bg, c.border, 0.15) : '#cbd5e1';
+        return;
+      }
+      if (level2Cats && level2Cats.some((r) => a < r.focusEnd && r.focusStart < b)) {
+        const c = crossColors(hoveredCategory!);
         m.style.backgroundColor = c ? blendHex(c.bg, c.border, 0.15) : '#cbd5e1';
         return;
       }

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -14,7 +14,7 @@ import { PreviewCardType } from '../../types/PostType';
 import InteractionControl from '../InteractionControl';
 import { toggleFavourite, toggleBookmark } from '../../utils/mastoActions';
 import { getPost, isLiked as storeIsLiked, isBookmarked as storeIsBookmarked } from '../../utils/localStore';
-import { useHighlightStore, setResponseFilter, clearResponseFilter, setPendingResponseFilter } from '../../utils/highlightStore';
+import { useHighlightStore, setResponseFilter, clearResponseFilter, setPendingResponseFilter, setFilterCategories } from '../../utils/highlightStore';
 import { CATEGORY_COLORS, CATEGORY_LABELS, categoryIcon, getCategoryColors } from '../../utils/categoryStyles';
 import ReplyHighlightedContent from './ReplyHighlightedContent';
 import { useRelatedStacks } from '../../app/(shell)/related-stacks-context';
@@ -241,7 +241,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   /** Non-focused post only: a span was clicked — focus this post then filter. */
   onSpanFocusRequest?: (span: { start: number; end: number; text: string }) => void;
 }>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded, focusRelations = [], onAutoReveal, active = true, onSpanFocusRequest }, ref) {
-  const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter } = useHighlightStore();
+  const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter, filterCategories } = useHighlightStore();
   // Related stacks of the active (focus) post — used to count "N related posts"
   // for the click-to-filter affordance. Mirrored to a ref so the DOM hover
   // handlers read the latest without re-subscribing.
@@ -273,6 +273,8 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   responseFilterRef.current = responseFilter;
   const focusRelationsRef = useRef(focusRelations);
   focusRelationsRef.current = focusRelations;
+  const filterCategoriesRef = useRef(filterCategories);
+  filterCategoriesRef.current = filterCategories;
 
   // Cleanup dwell timer on unmount
   useEffect(() => {
@@ -465,6 +467,21 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       if (!activeRef.current) { onSpanFocusRequestRef.current?.(span); return; }
       const ff = responseFilterRef.current;
       if (ff && ff.start === fs && ff.end === fe) { clearResponseFilter(); return; }
+      // A passage click with category chips active can compose into an empty
+      // result (the chips have their own stack/switch logic, but this path had
+      // none). Mirror it: keep chips that can coexist with the passage, drop
+      // them when no responding post satisfies them — never a dead-end panel.
+      const cats = filterCategoriesRef.current;
+      if (cats && cats.size > 0) {
+        const compatible = (relatedStacksRef.current || []).some((s: any) => {
+          const rels = s?.topPost?.relations ?? [];
+          const responds = rels.some((r: any) => r.focusStart < fe && fs < r.focusEnd);
+          if (!responds) return false;
+          const own = new Set(rels.map((r: any) => r.category));
+          return Array.from(cats).every((c) => own.has(c));
+        });
+        if (!compatible) setFilterCategories(new Set());
+      }
       setResponseFilter(span);
     };
 

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -240,7 +240,10 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   active?: boolean;
   /** Non-focused post only: a span was clicked — focus this post then filter. */
   onSpanFocusRequest?: (span: { start: number; end: number; text: string }) => void;
-}>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded, focusRelations = [], onAutoReveal, active = true, onSpanFocusRequest }, ref) {
+  /** Count of THIS post's related posts linked to the hovered span union — for
+   *  the dwell tooltip on non-focused posts (whose stacks aren't in context). */
+  relatedCountForSpans?: (ranges: Array<{ fs: number; fe: number }>) => number;
+}>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded, focusRelations = [], onAutoReveal, active = true, onSpanFocusRequest, relatedCountForSpans }, ref) {
   const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter, filterCategories } = useHighlightStore();
   // Related stacks of the active (focus) post — used to count "N related posts"
   // for the click-to-filter affordance. Mirrored to a ref so the DOM hover
@@ -266,6 +269,8 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   activeRef.current = active;
   const onSpanFocusRequestRef = useRef(onSpanFocusRequest);
   onSpanFocusRequestRef.current = onSpanFocusRequest;
+  const relatedCountForSpansRef = useRef(relatedCountForSpans);
+  relatedCountForSpansRef.current = relatedCountForSpans;
 
   // Refs mirror reactive state so the deferred dwell-timer callback always reads
   // the latest values (otherwise its closure would freeze at timer setup time).
@@ -372,7 +377,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   // Spec hover model (CSS-driven via classes — never re-parses the article):
   //  · enter the post       → faint ALL its spans (.fp-hovering on the container)
   //  · over a span          → DARKEN the union of spans covering the cursor
-  //  · dwell 1.5s on a span → tooltip "Click to focus on N related posts"
+  //  · dwell 1.5s on a span → tooltip "Click to show/focus on N related posts"
   //  · click a span         → filter to those posts (post is already focused)
   //  · click a non-span     → falls through to the card-level navigate handler
   useEffect(() => {
@@ -439,12 +444,19 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       cancelDwell();
       dwellTimerRef.current = setTimeout(() => {
         dwellTimerRef.current = null;
-        // On the focused post the count is its related stacks; on a non-focused
-        // feed post we don't have its stacks loaded, so the tooltip just invites
-        // focusing it (the click will focus + filter).
+        // Verb encodes the click's effect: the FOCUSED post's span click SHOWS
+        // (filters to) its linked responses; a non-focused post's click FOCUSES
+        // that post first. Both carry the count — the focused post counts from
+        // the context's stacks, a non-focused post through the counter its page
+        // supplies (its stacks aren't in context).
         const content = activeRef.current
-          ? (() => { const n = countRelated(ranges); return <>Click to focus on <strong>{n} related {n === 1 ? 'post' : 'posts'}</strong></>; })()
-          : <>Click to <strong>focus this post</strong></>;
+          ? (() => { const n = countRelated(ranges); return <>Click to show <strong>{n} related {n === 1 ? 'post' : 'posts'}</strong></>; })()
+          : (() => {
+              const counter = relatedCountForSpansRef.current;
+              if (!counter) return <>Click to <strong>focus this post</strong></>;
+              const n = counter(ranges);
+              return <>Click to focus on <strong>{n} related {n === 1 ? 'post' : 'posts'}</strong></>;
+            })();
         showTooltip({
           content,
           colors: { text: '#334155', border: '#cbd5e1' },
@@ -677,6 +689,9 @@ interface PostProps {
   onContentSpanClick?: (rangeIndex: number) => void;
   /** Optional cross-pane count for the reply span tooltip ("N more <topic>"). */
   replyTopicCount?: (topic: string) => number;
+  /** Count of THIS post's related posts linked to a span union — feeds the
+   *  dwell tooltip on non-focused posts, whose stacks aren't in context. */
+  relatedCountForSpans?: (ranges: Array<{ fs: number; fe: number }>) => number;
 }
 
 function Post({
@@ -704,6 +719,7 @@ function Post({
   categoryBadges,
   onContentSpanClick,
   replyTopicCount,
+  relatedCountForSpans,
 }: PostProps) {
   const router = useRouter();
   const [cardHeight, setCardHeight] = useState(0);
@@ -1197,6 +1213,7 @@ function Post({
           focusRelations={focusRelations}
           active={isActive}
           onSpanFocusRequest={handleSpanFocusRequest}
+          relatedCountForSpans={relatedCountForSpans}
           onAutoReveal={handleAutoReveal}
           className={isTextExpanded ? undefined : 'postClampedText'}
           style={{

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -15,6 +15,7 @@ import InteractionControl from '../InteractionControl';
 import { toggleFavourite, toggleBookmark } from '../../utils/mastoActions';
 import { getPost, isLiked as storeIsLiked, isBookmarked as storeIsBookmarked } from '../../utils/localStore';
 import { useHighlightStore, setResponseFilter, clearResponseFilter, setPendingResponseFilter } from '../../utils/highlightStore';
+import { CATEGORY_COLORS } from '../../utils/categoryStyles';
 import { useRelatedStacks } from '../../app/(shell)/related-stacks-context';
 import type { Relation } from '../../types/PostType';
 import { showTooltip, hideTooltip } from '../HoverTooltip';
@@ -26,20 +27,13 @@ function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, '').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, ' ');
 }
 
-const CROSS_HIGHLIGHT_CATEGORY_COLORS: Record<string, { bg: string; border: string }> = {
-  agree:              { bg: "#d4f9d3", border: "#4caf50" },
-  disagree:           { bg: "#ffe0e0", border: "#f44336" },
-  predictions:        { bg: "#fff3cd", border: "#ff9800" },
-  evidence_public:    { bg: "#e3f2fd", border: "#2196f3" },
-  evidence_personal:  { bg: "#f3e5f5", border: "#9c27b0" },
-  connections:        { bg: "#e0f2f1", border: "#009688" },
-  questions:          { bg: "#fce4ec", border: "#e91e63" },
-  humor:              { bg: "#fff8e1", border: "#ffc107" },
-  values:             { bg: "#ede7f6", border: "#673ab7" },
-  framing:            { bg: "#e0f7fa", border: "#00bcd4" },
-  proposals:          { bg: "#e8eaf6", border: "#3f51b5" },
-  pointers:           { bg: "#e8eaf6", border: "#3f51b5" },
-};
+/** Category colors for the aside→focus cross-highlight — the shared table, minus
+ *  `uncategorized`: relations with an unknown/uncategorized category are dropped
+ *  from the focus post's marks (the guard below relies on undefined). */
+function crossColors(category: string): { bg: string; border: string } | undefined {
+  if (category === 'uncategorized') return undefined;
+  return CATEGORY_COLORS[category];
+}
 
 /** Convert hex color to rgba string */
 function hexToRgba(hex: string, alpha: number): string {
@@ -126,7 +120,7 @@ function renderMultiHighlightHtml(
   if (relations.length === 0) return displayHtml;
 
   const entries = relations.map((r, i) => {
-    const catColors = CROSS_HIGHLIGHT_CATEGORY_COLORS[r.category];
+    const catColors = crossColors(r.category);
     if (!catColors) return null;
 
     const snippet = focusPlainText.slice(r.focusStart, r.focusEnd);
@@ -512,7 +506,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
       const a = parseInt(m.getAttribute('data-fs') || 'NaN', 10);
       const b = parseInt(m.getAttribute('data-fe') || 'NaN', 10);
       if (level2 && a < level2.focusEnd && level2.focusStart < b) {
-        const c = CROSS_HIGHLIGHT_CATEGORY_COLORS[level2.category];
+        const c = crossColors(level2.category);
         // L2 = a stronger shade of the SAME category colour, but only lightly toward
         // the saturated border (0.15, was 0.30 which read as too dark). Still clearly
         // stronger than the L1 faint (blend toward white), still pastel — not dark.
@@ -520,10 +514,9 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
         return;
       }
       const matched = hoveredRelations?.find((r) => a < r.focusEnd && r.focusStart < b);
+      const matchedColors = matched ? crossColors(matched.category) : undefined;
       m.style.backgroundColor = matched
-        ? (CROSS_HIGHLIGHT_CATEGORY_COLORS[matched.category]
-            ? blendHex(CROSS_HIGHLIGHT_CATEGORY_COLORS[matched.category].bg, '#ffffff', 0.35)
-            : '#eef0f3')
+        ? (matchedColors ? blendHex(matchedColors.bg, '#ffffff', 0.35) : '#eef0f3')
         : '';
     });
     // Level 2: bold ONLY the data's optional bold sub-span, not the whole region.

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -1041,6 +1041,7 @@ function Post({
       <Paper
         ref={paperRef}
         data-testid="post"
+        data-post-id={id}
         data-active={isActive ? 'true' : 'false'}
         style={{
           position: 'relative',

--- a/src/components/Posts/ReplyHighlightedContent.tsx
+++ b/src/components/Posts/ReplyHighlightedContent.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import React, { useRef, useEffect, useState } from "react";
+import type { Relation } from "../../types/PostType";
+import { getCategoryColors } from "../../utils/categoryStyles";
+import {
+  setHoveredSidebarPost,
+  setHoveredHighlightRangeIndex,
+} from "../../utils/highlightStore";
+import { showTooltip, hideTooltip } from "../HoverTooltip";
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+interface ReplyHighlightedContentProps {
+  /** The reply's plain text — relation content offsets index into this string. */
+  plainText: string;
+  /** Non-overlapping content-side relations (the dataset generator guarantees it). */
+  relations: Relation[];
+  replyId: string;
+  /** Clicking a span (rangeIndex into `relations`). Reranking wires in here. */
+  onSpanClick?: (rangeIndex: number) => void;
+  /** Optional "N more <topic>" tooltip count — wired by the thread page. */
+  otherCountByTopic?: (topic: string) => number;
+}
+
+/**
+ * Reply body with colored contribution spans — the left-pane counterpart of the
+ * related cards' highlight rendering, deliberately simpler: replies are short,
+ * plain-text, and their spans never overlap. Hovering the reply publishes its
+ * relations to the highlight store, which is all the focus post needs to
+ * cross-highlight the connected regions (same path a related-card hover uses).
+ */
+export default function ReplyHighlightedContent({
+  plainText,
+  relations,
+  replyId,
+  onSpanClick,
+  otherCountByTopic,
+}: ReplyHighlightedContentProps) {
+  const [hovered, setHovered] = useState(false);
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  const enterTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const publishedRef = useRef(false);
+
+  // Clear any pending publish + our store entry on unmount so a hovered reply
+  // that gets filtered/reordered away doesn't leave a stale cross-highlight.
+  useEffect(() => {
+    return () => {
+      if (enterTimer.current) clearTimeout(enterTimer.current);
+      if (publishedRef.current) {
+        setHoveredSidebarPost(null);
+        publishedRef.current = false;
+      }
+      hideTooltip();
+    };
+  }, []);
+
+  const publishHover = () => {
+    setHovered(true);
+    if (enterTimer.current) clearTimeout(enterTimer.current);
+    // Same 90ms coalescing as the related cards: sweeping the cursor across the
+    // reply list must not fire a cross-highlight per card boundary.
+    enterTimer.current = setTimeout(() => {
+      setHoveredSidebarPost(replyId, relations);
+      publishedRef.current = true;
+    }, 90);
+  };
+
+  const clearHover = () => {
+    setHovered(false);
+    setHoveredIdx(null);
+    if (enterTimer.current) clearTimeout(enterTimer.current);
+    enterTimer.current = setTimeout(() => {
+      if (publishedRef.current) {
+        setHoveredSidebarPost(null);
+        publishedRef.current = false;
+      }
+      setHoveredHighlightRangeIndex(null);
+    }, 60);
+    hideTooltip();
+  };
+
+  // Sorted, validated segments. Overlap would mean corrupt data — render plain
+  // rather than mis-highlighting.
+  const sorted = relations
+    .map((r, i) => [i, r] as [number, Relation])
+    .sort((a, b) => a[1].contentStart - b[1].contentStart);
+  let valid = true;
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i][1].contentStart < sorted[i - 1][1].contentEnd) valid = false;
+  }
+  for (const [, r] of sorted) {
+    if (r.contentStart < 0 || r.contentEnd > plainText.length || r.contentEnd <= r.contentStart) valid = false;
+  }
+  if (!valid || sorted.length === 0) {
+    return <span>{plainText}</span>;
+  }
+
+  const nodes: React.ReactNode[] = [];
+  let cursor = 0;
+  for (const [origIdx, r] of sorted) {
+    if (r.contentStart > cursor) nodes.push(plainText.slice(cursor, r.contentStart));
+    const colors = getCategoryColors(r.category);
+    const segText = plainText.slice(r.contentStart, r.contentEnd);
+    const isSpanHovered = hoveredIdx === origIdx;
+    const alpha = isSpanHovered || hovered ? 1 : 0.7;
+    // Bold sub-phrase (contentComment) shown while the span is hovered — matches
+    // the related cards' non-reflowing text-shadow emphasis.
+    const cs = r.contentCommentStart - r.contentStart;
+    const ce = r.contentCommentEnd - r.contentStart;
+    const hasComment = r.contentCommentEnd > r.contentCommentStart && cs >= 0 && ce <= segText.length;
+    const content = isSpanHovered && hasComment ? (
+      <>
+        {segText.slice(0, cs)}
+        <span style={{ textShadow: "0 0 0.7px currentColor, 0 0 0.7px currentColor" }}>
+          {segText.slice(cs, ce)}
+        </span>
+        {segText.slice(ce)}
+      </>
+    ) : segText;
+    nodes.push(
+      <mark
+        key={origIdx}
+        data-reply-range-id={origIdx}
+        style={{
+          background: alpha < 1 ? hexToRgba(colors.bg, alpha) : colors.bg,
+          color: "inherit",
+          borderRadius: "3px",
+          padding: "1px 0",
+          transition: "background 200ms ease",
+          cursor: onSpanClick ? "pointer" : "inherit",
+          WebkitTapHighlightColor: "transparent",
+        }}
+        onMouseEnter={(e) => {
+          setHoveredIdx(origIdx);
+          setHoveredHighlightRangeIndex(origIdx);
+          if (r.topic && otherCountByTopic) {
+            showTooltip({
+              content: (
+                <>
+                  {otherCountByTopic(r.topic)} more <strong style={{ color: colors.text }}>{r.topic}</strong>
+                </>
+              ),
+              colors: { text: colors.text, border: colors.border },
+              x: e.clientX,
+              y: e.clientY,
+            });
+          }
+        }}
+        onMouseLeave={() => {
+          setHoveredIdx(null);
+          setHoveredHighlightRangeIndex(null);
+          hideTooltip();
+        }}
+        onClick={(e) => {
+          if (!onSpanClick) return;
+          e.preventDefault();
+          e.stopPropagation();
+          hideTooltip();
+          onSpanClick(origIdx);
+        }}
+      >
+        {content}
+      </mark>
+    );
+    cursor = r.contentEnd;
+  }
+  if (cursor < plainText.length) nodes.push(plainText.slice(cursor));
+
+  return (
+    <span onMouseEnter={publishHover} onMouseLeave={clearHover}>
+      {nodes}
+    </span>
+  );
+}

--- a/src/components/Posts/ReplyHighlightedContent.tsx
+++ b/src/components/Posts/ReplyHighlightedContent.tsx
@@ -44,6 +44,10 @@ export default function ReplyHighlightedContent({
 }: ReplyHighlightedContentProps) {
   const [hovered, setHovered] = useState(false);
   const [hoveredIdx, setHoveredIdx] = useState<number | null>(null);
+  // Mirror of hoveredIdx for the debounced publish below: setHoveredSidebarPost
+  // resets the store's range index, so the publish must re-assert the span the
+  // cursor is already on (the span's own enter fires BEFORE the 90ms publish).
+  const hoveredIdxRef = useRef<number | null>(null);
   const enterTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const publishedRef = useRef(false);
 
@@ -68,6 +72,7 @@ export default function ReplyHighlightedContent({
     enterTimer.current = setTimeout(() => {
       setHoveredSidebarPost(replyId, relations);
       publishedRef.current = true;
+      if (hoveredIdxRef.current != null) setHoveredHighlightRangeIndex(hoveredIdxRef.current);
     }, 90);
   };
 
@@ -138,6 +143,7 @@ export default function ReplyHighlightedContent({
         }}
         onMouseEnter={(e) => {
           setHoveredIdx(origIdx);
+          hoveredIdxRef.current = origIdx;
           setHoveredHighlightRangeIndex(origIdx);
           if (r.topic && otherCountByTopic) {
             showTooltip({
@@ -154,6 +160,7 @@ export default function ReplyHighlightedContent({
         }}
         onMouseLeave={() => {
           setHoveredIdx(null);
+          hoveredIdxRef.current = null;
           setHoveredHighlightRangeIndex(null);
           hideTooltip();
         }}

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -11,7 +11,7 @@ import { toggleFavourite, toggleBookmark } from '../utils/mastoActions';
 import { notifications } from '@mantine/notifications';
 import { copyLink } from '../utils/share';
 import { useRelatedStacks } from '../app/(shell)/related-stacks-context';
-import { setHoveredSidebarPost, setHoveredHighlightRangeIndex, setHoveredCategory, setTapped, clearTapped, toggleReRankAnchor, clearReRankAnchors, setFilterCategories, clearResponseFilter, clearTopicFilter, setPanelFocus, savePanelScroll, getPanelScroll, useHighlightStore } from '../utils/highlightStore';
+import { setHoveredSidebarPost, setHoveredHighlightRangeIndex, setHoveredCategory, setTapped, clearTapped, toggleReRankAnchor, clearReRankAnchors, setFilterCategories, clearResponseFilter, setPanelFocus, savePanelScroll, getPanelScroll, useHighlightStore } from '../utils/highlightStore';
 import { useExperimentFlags } from '../utils/experimentFlags';
 import { reorderForAnchor } from '../utils/reorderForAnchor';
 import type { Relation } from '../types/PostType';
@@ -757,11 +757,8 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
   const [favouritedOverride, setFavouritedOverride] = useState<Record<string, boolean>>({});
   const [bookmarkedOverride, setBookmarkedOverride] = useState<Record<string, boolean>>({});
   const [favouritesCountOverride, setFavouritesCountOverride] = useState<Record<string, number>>({});
-  const { filterCategories, responseFilter, hoveredHighlightRangeIndex, hoveredCategory, tappedCardPostId, tappedRangeIndex, reRankAnchorIds, anchoredRangeByPost, topicFilter, replyTopicCounts } = useHighlightStore();
+  const { filterCategories, responseFilter, hoveredHighlightRangeIndex, hoveredCategory, tappedCardPostId, tappedRangeIndex, reRankAnchorIds, anchoredRangeByPost, replyTopicCounts } = useHighlightStore();
   const flags = useExperimentFlags();
-  // Reply-sourced cross-pane topic filter: a reply anchor in the thread filters
-  // THIS panel by its topic (the anchoring pane reranks, the other pane filters).
-  const replyTopicFilter = flags.crossPaneFiltering && topicFilter?.source === 'reply' ? topicFilter.topic : null;
   // C2: hover preview state for filter chips
   const [chipHovered, setChipHovered] = useState<string | null>(null);
   // Interaction mode: hover (mouse/pen) vs tap (touch). Adaptive — the most
@@ -1061,11 +1058,6 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
           (s.topPost.relations ?? []).some(r =>
             r.focusStart < responseFilter!.end && responseFilter!.start < r.focusEnd));
       }
-      // Cross-pane: a reply anchor in the thread filters this panel by topic.
-      if (replyTopicFilter !== null) {
-        result = result.filter(s =>
-          (s.topPost.relations ?? []).some((r, ri) => topicOf(r, s.stackId, ri) === replyTopicFilter));
-      }
       return { displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown, activeAnchorTopic, groupMemberIds };
     }
 
@@ -1196,21 +1188,30 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
       );
     }
 
-    // Cross-pane: a reply anchor in the thread filters this panel by topic
-    // (the anchor card stays visible — it defines the right-pane grouping).
-    if (replyTopicFilter !== null) {
-      result = result.filter(s =>
-        s.topPost.id === anchorId ||
-        (s.topPost.relations ?? []).some((r, ri) => topicOf(r, s.stackId, ri) === replyTopicFilter));
-    }
-
     return { displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown, activeAnchorTopic, groupMemberIds };
-  }, [relatedStacks, filterCategories, responseFilter, replyTopicFilter, reRankAnchorIds, shownByAnchor, anchoredRangeByPost]);
+  }, [relatedStacks, filterCategories, responseFilter, reRankAnchorIds, shownByAnchor, anchoredRangeByPost]);
 
   // E: keep prevDisplayStacksRef up-to-date so the next anchor activation can
   // capture the order the user currently sees as the new baseOrder.
   useEffect(() => {
     prevDisplayStacksRef.current = displayStacks;
+  }, [displayStacks]);
+
+  // Robustness: sweep away residual FLIP transforms whenever the visible list
+  // changes for a reason the FLIP effect does not run for (filters, cross-pane
+  // updates, data refresh). An interrupted FLIP could otherwise leave a card
+  // frozen at translateY(...) — rendering it ON TOP of its neighbours.
+  useLayoutEffect(() => {
+    if (flipFirstTopsRef.current) return; // a FLIP is in flight — its effect owns cleanup
+    const aside = document.querySelector('[data-testid="col-aside"]') as HTMLElement | null;
+    if (!aside) return;
+    aside.querySelectorAll('[data-related-card]').forEach((el) => {
+      const h = el as HTMLElement;
+      if (h.style.transform) {
+        h.style.transition = 'none';
+        h.style.transform = '';
+      }
+    });
   }, [displayStacks]);
 
   const handleShowMore = (anchorId: string) => {
@@ -1357,15 +1358,10 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     });
     flipFirstTopsRef.current = firstTops;
 
-    // Cross-pane filtering: publish the anchor's topic so the reply list can
-    // filter by it (this pane reranks, the other pane filters — Jason's rule).
-    const anchorStackForTopic = relatedStacks.find(s => s.topPost.id === postId);
-    const relForTopic = anchorStackForTopic?.topPost.relations?.[rangeIndex ?? 0];
-    const topicForFilter =
-      flags.crossPaneFiltering && anchorStackForTopic && relForTopic
-        ? topicOf(relForTopic, anchorStackForTopic.stackId, rangeIndex ?? 0)
-        : null;
-    toggleReRankAnchor(postId, rangeIndex, topicForFilter);
+    // Topic grouping is symmetric across panes: the thread page watches this
+    // anchor's topic and mirrors the grouping onto the replies (see the sync
+    // effect in ChineseEVs/posts/[id]/page.tsx). No filtering happens here.
+    toggleReRankAnchor(postId, rangeIndex);
   };
 
   // Compensate scroll BEFORE paint so the clicked card never visually moves on a
@@ -1710,42 +1706,6 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
               onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = '#475569'; (e.currentTarget as HTMLElement).style.background = '#e2e8f0'; }}
               onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = '#94a3b8'; (e.currentTarget as HTMLElement).style.background = 'none'; }}
               aria-label="Clear responses-to filter"
-            >×</button>
-          </div>
-        )}
-
-        {/* Cross-pane indicator: a reply anchor in the thread is filtering this
-            panel by topic. Dismissing lifts only THIS pane's filter — the reply
-            cluster itself is dismissed at its own pill above the replies. */}
-        {replyTopicFilter !== null && (
-          <div data-testid="reply-topic-pill" style={{
-            display: 'flex', alignItems: 'center', gap: '6px', padding: '3px 8px',
-            background: '#eef7f2', borderRadius: '6px', marginBottom: '0.5rem',
-            border: '1px solid #bfdccb', flexWrap: 'wrap',
-          }}>
-            <Text size="xs" c="#2f6b4f" fw={600} style={{ fontSize: '11px', flexShrink: 0 }}>
-              Reply topic:
-            </Text>
-            <Text size="xs" c="#3e7a5e" style={{
-              fontSize: '10px', fontWeight: 600,
-              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '150px',
-            }}>
-              {replyTopicFilter}
-            </Text>
-            <button
-              type="button"
-              onClick={(e) => { e.stopPropagation(); clearTopicFilter('reply'); }}
-              style={{
-                background: 'none', border: 'none', cursor: 'pointer',
-                color: '#94a3b8', fontSize: '16px', lineHeight: 1,
-                padding: '6px 8px', marginLeft: 'auto',
-                minWidth: 24, minHeight: 24,
-                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-                borderRadius: 4,
-              }}
-              onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = '#475569'; (e.currentTarget as HTMLElement).style.background = '#dceee3'; }}
-              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = '#94a3b8'; (e.currentTarget as HTMLElement).style.background = 'none'; }}
-              aria-label="Clear reply topic filter"
             >×</button>
           </div>
         )}
@@ -2342,7 +2302,11 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                   // Always show the category color so the chip is recognizable
                   // as the topic-anchor for that highlight color.
                   const indicatorColor = indicatorColors.text;
-                  const clusterCount = topicTotal.get(indicatorTopic) ?? 0;
+                  // PANE-LOCAL count: how many cards in THIS panel share the topic.
+                  // (topicTotal folds in reply counts for tooltips; using it here
+                  // showed "(8)" over a visible 5-card cluster — confusing.)
+                  let clusterCount = 0;
+                  postTopics.forEach((topics) => { if (topics.has(indicatorTopic)) clusterCount++; });
                   const baseOpacity = isCurrentAnchor ? 1 : 0.75;
                   return (
                     <button

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -11,7 +11,8 @@ import { toggleFavourite, toggleBookmark } from '../utils/mastoActions';
 import { notifications } from '@mantine/notifications';
 import { copyLink } from '../utils/share';
 import { useRelatedStacks } from '../app/(shell)/related-stacks-context';
-import { setHoveredSidebarPost, setHoveredHighlightRangeIndex, setHoveredCategory, setTapped, clearTapped, toggleReRankAnchor, clearReRankAnchors, setFilterCategories, clearResponseFilter, setPanelFocus, savePanelScroll, getPanelScroll, useHighlightStore } from '../utils/highlightStore';
+import { setHoveredSidebarPost, setHoveredHighlightRangeIndex, setHoveredCategory, setTapped, clearTapped, toggleReRankAnchor, clearReRankAnchors, setFilterCategories, clearResponseFilter, clearTopicFilter, setPanelFocus, savePanelScroll, getPanelScroll, useHighlightStore } from '../utils/highlightStore';
+import { useExperimentFlags } from '../utils/experimentFlags';
 import { reorderForAnchor } from '../utils/reorderForAnchor';
 import type { Relation } from '../types/PostType';
 import { showTooltip, hideTooltip, type TooltipColors } from './HoverTooltip';
@@ -756,7 +757,11 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
   const [favouritedOverride, setFavouritedOverride] = useState<Record<string, boolean>>({});
   const [bookmarkedOverride, setBookmarkedOverride] = useState<Record<string, boolean>>({});
   const [favouritesCountOverride, setFavouritesCountOverride] = useState<Record<string, number>>({});
-  const { filterCategories, responseFilter, hoveredHighlightRangeIndex, hoveredCategory, tappedCardPostId, tappedRangeIndex, reRankAnchorIds, anchoredRangeByPost } = useHighlightStore();
+  const { filterCategories, responseFilter, hoveredHighlightRangeIndex, hoveredCategory, tappedCardPostId, tappedRangeIndex, reRankAnchorIds, anchoredRangeByPost, topicFilter, replyTopicCounts } = useHighlightStore();
+  const flags = useExperimentFlags();
+  // Reply-sourced cross-pane topic filter: a reply anchor in the thread filters
+  // THIS panel by its topic (the anchoring pane reranks, the other pane filters).
+  const replyTopicFilter = flags.crossPaneFiltering && topicFilter?.source === 'reply' ? topicFilter.topic : null;
   // C2: hover preview state for filter chips
   const [chipHovered, setChipHovered] = useState<string | null>(null);
   // Interaction mode: hover (mouse/pen) vs tap (touch). Adaptive — the most
@@ -948,8 +953,15 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     realTopicTotal.forEach((count, topic) => {
       topicTotal.set(topic, getSyntheticTopicCount(topic, count));
     });
+    // Cross-pane counts: fold in the thread page's displayed-reply topic counts
+    // so "N more <topic>" reflects both panes (suppression keeps ids disjoint).
+    if (flags.crossPaneFiltering) {
+      for (const [topic, n] of Object.entries(replyTopicCounts)) {
+        topicTotal.set(topic, (topicTotal.get(topic) ?? 0) + n);
+      }
+    }
     return { postTopics, topicTotal };
-  }, [relatedStacks]);
+  }, [relatedStacks, replyTopicCounts, flags.crossPaneFiltering]);
 
   const SIMILARITY_THRESHOLD = 0.15;
   const SHOWN_INCREMENT = 3;
@@ -1048,6 +1060,11 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
         result = result.filter(s =>
           (s.topPost.relations ?? []).some(r =>
             r.focusStart < responseFilter!.end && responseFilter!.start < r.focusEnd));
+      }
+      // Cross-pane: a reply anchor in the thread filters this panel by topic.
+      if (replyTopicFilter !== null) {
+        result = result.filter(s =>
+          (s.topPost.relations ?? []).some((r, ri) => topicOf(r, s.stackId, ri) === replyTopicFilter));
       }
       return { displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown, activeAnchorTopic, groupMemberIds };
     }
@@ -1179,8 +1196,16 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
       );
     }
 
+    // Cross-pane: a reply anchor in the thread filters this panel by topic
+    // (the anchor card stays visible — it defines the right-pane grouping).
+    if (replyTopicFilter !== null) {
+      result = result.filter(s =>
+        s.topPost.id === anchorId ||
+        (s.topPost.relations ?? []).some((r, ri) => topicOf(r, s.stackId, ri) === replyTopicFilter));
+    }
+
     return { displayStacks: result, claimedBy, anchorSet, anchorParent, groupTotal, groupShown, activeAnchorTopic, groupMemberIds };
-  }, [relatedStacks, filterCategories, responseFilter, reRankAnchorIds, shownByAnchor, anchoredRangeByPost]);
+  }, [relatedStacks, filterCategories, responseFilter, replyTopicFilter, reRankAnchorIds, shownByAnchor, anchoredRangeByPost]);
 
   // E: keep prevDisplayStacksRef up-to-date so the next anchor activation can
   // capture the order the user currently sees as the new baseOrder.
@@ -1332,7 +1357,15 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     });
     flipFirstTopsRef.current = firstTops;
 
-    toggleReRankAnchor(postId, rangeIndex);
+    // Cross-pane filtering: publish the anchor's topic so the reply list can
+    // filter by it (this pane reranks, the other pane filters — Jason's rule).
+    const anchorStackForTopic = relatedStacks.find(s => s.topPost.id === postId);
+    const relForTopic = anchorStackForTopic?.topPost.relations?.[rangeIndex ?? 0];
+    const topicForFilter =
+      flags.crossPaneFiltering && anchorStackForTopic && relForTopic
+        ? topicOf(relForTopic, anchorStackForTopic.stackId, rangeIndex ?? 0)
+        : null;
+    toggleReRankAnchor(postId, rangeIndex, topicForFilter);
   };
 
   // Compensate scroll BEFORE paint so the clicked card never visually moves on a
@@ -1654,6 +1687,42 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
               onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = '#475569'; (e.currentTarget as HTMLElement).style.background = '#e2e8f0'; }}
               onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = '#94a3b8'; (e.currentTarget as HTMLElement).style.background = 'none'; }}
               aria-label="Clear responses-to filter"
+            >×</button>
+          </div>
+        )}
+
+        {/* Cross-pane indicator: a reply anchor in the thread is filtering this
+            panel by topic. Dismissing lifts only THIS pane's filter — the reply
+            cluster itself is dismissed at its own pill above the replies. */}
+        {replyTopicFilter !== null && (
+          <div data-testid="reply-topic-pill" style={{
+            display: 'flex', alignItems: 'center', gap: '6px', padding: '3px 8px',
+            background: '#eef7f2', borderRadius: '6px', marginBottom: '0.5rem',
+            border: '1px solid #bfdccb', flexWrap: 'wrap',
+          }}>
+            <Text size="xs" c="#2f6b4f" fw={600} style={{ fontSize: '11px', flexShrink: 0 }}>
+              Reply topic:
+            </Text>
+            <Text size="xs" c="#3e7a5e" style={{
+              fontSize: '10px', fontWeight: 600,
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: '150px',
+            }}>
+              {replyTopicFilter}
+            </Text>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); clearTopicFilter('reply'); }}
+              style={{
+                background: 'none', border: 'none', cursor: 'pointer',
+                color: '#94a3b8', fontSize: '16px', lineHeight: 1,
+                padding: '6px 8px', marginLeft: 'auto',
+                minWidth: 24, minHeight: 24,
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                borderRadius: 4,
+              }}
+              onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = '#475569'; (e.currentTarget as HTMLElement).style.background = '#dceee3'; }}
+              onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = '#94a3b8'; (e.currentTarget as HTMLElement).style.background = 'none'; }}
+              aria-label="Clear reply topic filter"
             >×</button>
           </div>
         )}

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useLayoutEffect, useState, useMemo } from 'react';
 import { Paper, UnstyledButton, Group, Avatar, Text, Divider, Anchor } from '@mantine/core';
-import { IconMessageCircle, IconHeart, IconHeartFilled, IconBookmark, IconBookmarkFilled, IconShare, IconQuestionMark, IconBulb, IconQuote, IconLink, IconPointer, IconBook, IconMoodSmile, IconFrame, IconUser, IconThumbUp, IconThumbDown } from '@tabler/icons-react';
-import { Layers } from 'lucide-react';
+import { IconMessageCircle, IconHeart, IconHeartFilled, IconBookmark, IconBookmarkFilled, IconShare } from '@tabler/icons-react';
+import { CATEGORY_COLORS, CATEGORY_LABELS, iconMapping, getCategoryColors, type CategoryStyle } from '../utils/categoryStyles';
 import { formatPostDate } from '../utils/formatPostDate';
 import RelatedStackCount from './RelatedStackCount';
 import { useRouter } from 'next/navigation';
@@ -60,46 +60,8 @@ interface RelatedStacksProps {
 }
 
 // ─── Category colors ─────────────────────────────────────────────────────────
-
-interface CategoryStyle { bg: string; border: string; text: string }
-
-const CATEGORY_COLORS: Record<string, CategoryStyle> = {
-  agree:              { bg: "#d4f9d3", border: "#4caf50", text: "#1b5e20" },
-  disagree:           { bg: "#ffe0e0", border: "#f44336", text: "#b71c1c" },
-  predictions:        { bg: "#fff3cd", border: "#ff9800", text: "#e65100" },
-  evidence_public:    { bg: "#e3f2fd", border: "#2196f3", text: "#0d47a1" },
-  evidence_personal:  { bg: "#f3e5f5", border: "#9c27b0", text: "#4a148c" },
-  connections:        { bg: "#e0f2f1", border: "#009688", text: "#004d40" },
-  questions:          { bg: "#fce4ec", border: "#e91e63", text: "#880e4f" },
-  humor:              { bg: "#fff8e1", border: "#ffc107", text: "#ff6f00" },
-  values:             { bg: "#ede7f6", border: "#673ab7", text: "#311b92" },
-  framing:            { bg: "#e0f7fa", border: "#00bcd4", text: "#006064" },
-  proposals:          { bg: "#e8eaf6", border: "#3f51b5", text: "#1a237e" },
-  pointers:           { bg: "#e8eaf6", border: "#3f51b5", text: "#1a237e" },
-  uncategorized:      { bg: "#f5f5f5", border: "#9e9e9e", text: "#424242" },
-};
-
-const CATEGORY_LABELS: Record<string, string> = {
-  agree: "Agree", disagree: "Disagree", predictions: "Predictions",
-  evidence_public: "Evidence (Public)", evidence_personal: "Evidence (Personal)",
-  connections: "Connections", questions: "Questions", humor: "Humor",
-  values: "Values", framing: "Framing", proposals: "Proposals",
-  pointers: "Pointers", uncategorized: "Uncategorized",
-};
-
-const iconMapping: Record<string, JSX.Element> = {
-  uncategorized: <Layers size={14} />, predictions: <IconBulb size={14} />,
-  evidence_public: <IconQuote size={14} />, evidence_personal: <IconUser size={14} />,
-  connections: <IconLink size={14} />, pointers: <IconPointer size={14} />,
-  proposals: <IconBook size={14} />, humor: <IconMoodSmile size={14} />,
-  values: <IconHeart size={14} />, framing: <IconFrame size={14} />,
-  questions: <IconQuestionMark size={14} />, default: <Layers size={14} />,
-  agree: <IconThumbUp size={14} />, disagree: <IconThumbDown size={14} />,
-};
-
-function getCategoryColors(rel: string): CategoryStyle {
-  return CATEGORY_COLORS[rel] ?? CATEGORY_COLORS.uncategorized;
-}
+// Shared with Post (focus cross-highlight), reply badges, and the experiment
+// panel via src/utils/categoryStyles — keep presentation in one place.
 
 // ─── Eye cursor — indicates "click to see more like this" ───────────────────
 // Small 20x20 SVG eye, encoded inline as the cursor image. Fallback: pointer.
@@ -1674,7 +1636,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
               overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
               maxWidth: '140px', fontStyle: 'italic',
             }}>
-              "{responseFilter.text.length > 35 ? responseFilter.text.slice(0, 35) + '…' : responseFilter.text}"
+              &ldquo;{responseFilter.text.length > 35 ? responseFilter.text.slice(0, 35) + '…' : responseFilter.text}&rdquo;
             </Text>
             <button
               type="button"
@@ -2367,7 +2329,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                         overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
                         fontStyle: 'italic',
                       }}>
-                        "{shortestCommonText}"
+                        &ldquo;{shortestCommonText}&rdquo;
                       </Text>
                     </div>
                   )}

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -2048,9 +2048,9 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
               key={`header-${anchorForThisCard}`}
               style={{
                 position: 'relative',
-                display: 'flex', alignItems: 'center', gap: '6px',
+                display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'nowrap',
                 marginLeft: `${indentPx}px`,
-                padding: '2px 0 4px 2px',
+                padding: '6px 0 4px 2px',
               }}
             >
               <div aria-hidden style={{
@@ -2218,7 +2218,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                 }}
                 style={{
                   position: 'relative', width: '100%', backgroundColor: '#ffffff', zIndex: isHighlighted ? 6 : 5,
-                  borderRadius: '10px', margin: '0 auto', paddingTop: '40px',
+                  borderRadius: '10px', margin: '0 auto', paddingTop: '10px',
                   border: isHighlighted ? `2px solid #1c2b4a` : `2px solid #e2e8f0`,
                   boxShadow: isHighlighted
                     ? '0 0 0 3px rgba(28,43,74,0.18), 0 4px 16px rgba(0,0,0,0.10)'
@@ -2227,8 +2227,12 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                   cursor: 'pointer',
                 }}
               >
-                {/* Category tags — one per unique relation category, dims/brightens with highlight hover */}
-                <div style={{ position: 'absolute', top: '10px', left: '10px', display: 'flex', gap: '4px', alignItems: 'center', zIndex: 10, flexWrap: 'wrap' }}>
+                {/* Card header row — category tags (left, wrapping) and the F relation
+                    indicator (right), in NORMAL FLOW. The old absolute positioning over
+                    a fixed 40px reserve overlapped the author header and the indicator
+                    as soon as tags wrapped or labels ran long; a flow row just grows. */}
+                <div style={{ display: 'flex', alignItems: 'flex-start', gap: '4px', padding: '0 10px 6px' }}>
+                <div style={{ display: 'flex', gap: '4px', alignItems: 'center', flexWrap: 'wrap', flex: '1 1 auto', minWidth: 0 }}>
                   {(() => {
                     // Dedupe categories from relations, preserving order
                     const rels = stack.topPost.relations ?? [];
@@ -2350,10 +2354,9 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                       aria-label={`Show more posts about ${indicatorTopic}`}
                       aria-pressed={isCurrentAnchor}
                       style={{
-                        position: 'absolute',
-                        top: '10px',
-                        right: '10px',
-                        zIndex: 10,
+                        marginLeft: 'auto',
+                        alignSelf: 'flex-start',
+                        flexShrink: 0,
                         background: isCurrentAnchor ? indicatorColors.bg : 'transparent',
                         border: isCurrentAnchor ? `1px solid ${indicatorColors.border}55` : 'none',
                         borderRadius: '4px',
@@ -2387,6 +2390,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                     </button>
                   );
                 })()}
+                </div>
 
                 <UnstyledButton onClick={(e) => { e.stopPropagation(); handleNavigate(stack.topPost.id, stack.stackId); }} style={{ width: '100%' }}>
                   <Group style={{ paddingLeft: '1rem' }}>

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -1491,6 +1491,29 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     setHoveredHighlightRangeIndex(null);
   };
 
+  // Badge-hover reveal: after a short dwell, scroll the card so the hovered
+  // category's contribution span is visible (block:'nearest' no-ops when it
+  // already is). The dwell keeps a cursor sweep across badges from scrolljacking.
+  const tagScrollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleTagScroll = (cardIndex: number, rangeIndex: number) => {
+    if (tagScrollTimer.current) clearTimeout(tagScrollTimer.current);
+    tagScrollTimer.current = setTimeout(() => {
+      tagScrollTimer.current = null;
+      const paperEl = paperRefs.current[cardIndex];
+      if (!paperEl) return;
+      let markEl = paperEl.querySelector(`mark[data-range-id="${rangeIndex}"]`) as HTMLElement | null;
+      if (!markEl) {
+        // Overlap segments carry the range id in a CSV attribute.
+        markEl = (Array.from(paperEl.querySelectorAll('mark[data-overlap-range-ids]')) as HTMLElement[])
+          .find((m) => (m.getAttribute('data-overlap-range-ids') ?? '').split(',').includes(String(rangeIndex))) ?? null;
+      }
+      (markEl ?? paperEl).scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }, 150);
+  };
+  const cancelTagScroll = () => {
+    if (tagScrollTimer.current) { clearTimeout(tagScrollTimer.current); tagScrollTimer.current = null; }
+  };
+
   // hoveredIndex: for the stacked-card bottom-edge layer effect only
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   // hoveredCardId: tracks which card the mouse is actually over, BY POST ID (not
@@ -2239,8 +2262,8 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                       return (
                         <div
                           key={cat}
-                          onMouseEnter={(e) => { if (!isTouch) setHoveredCategory(cat); tagHover(e.clientX, e.clientY); }}
-                          onMouseLeave={() => { if (!isTouch) setHoveredCategory(null); hideTooltip(); }}
+                          onMouseEnter={(e) => { if (!isTouch) { setHoveredCategory(cat); scheduleTagScroll(index, indices[0]); } tagHover(e.clientX, e.clientY); }}
+                          onMouseLeave={() => { if (!isTouch) { setHoveredCategory(null); cancelTagScroll(); } hideTooltip(); }}
                           onPointerEnter={(e) => { if (e.pointerType !== 'mouse') return; tagHover(e.clientX, e.clientY); }}
                           onPointerLeave={(e) => { if (e.pointerType === 'mouse') hideTooltip(); }}
                           onClick={(e) => {

--- a/src/components/ReplyFilterBar.tsx
+++ b/src/components/ReplyFilterBar.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import React from "react";
+import { Text } from "@mantine/core";
+import { CATEGORY_LABELS, getCategoryColors, categoryIcon } from "../utils/categoryStyles";
+
+interface ReplyFilterBarProps {
+  filterCategories: Set<string>;
+  responseFilter: { start: number; end: number; text: string } | null;
+  /** Topic pushed onto the replies by a related-panel anchor (source 'related'). */
+  relatedTopic: string | null;
+  shown: number;
+  total: number;
+  onRemoveCategory: (category: string) => void;
+  onClearResponse: () => void;
+  onClearTopic: () => void;
+  onClearAll: () => void;
+}
+
+const chipX: React.CSSProperties = {
+  background: "none", border: "none", cursor: "pointer", lineHeight: 1,
+  fontSize: 13, padding: "0 0 0 2px", color: "inherit",
+};
+
+/**
+ * Visible filter state for the replies list. Cross-pane filtering only works
+ * when the filtered list wears its filters: every active lens renders as a
+ * removable chip HERE, next to the replies it hides — never as invisible
+ * action-at-a-distance from the other pane.
+ */
+export default function ReplyFilterBar({
+  filterCategories,
+  responseFilter,
+  relatedTopic,
+  shown,
+  total,
+  onRemoveCategory,
+  onClearResponse,
+  onClearTopic,
+  onClearAll,
+}: ReplyFilterBarProps) {
+  const cats = Array.from(filterCategories);
+  const anyActive = cats.length > 0 || responseFilter !== null || relatedTopic !== null;
+  if (!anyActive) return null;
+
+  return (
+    <div
+      data-testid="reply-filter-bar"
+      style={{
+        display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap",
+        background: "#f8fafc", border: "1px solid #e2e8f0", borderRadius: 8,
+        padding: "6px 10px", margin: "0.75rem 0 0.5rem",
+      }}
+    >
+      <Text size="xs" fw={600} c="#64748b" style={{ fontSize: 11, flexShrink: 0 }}>
+        Replies filtered:
+      </Text>
+
+      {cats.map((cat) => {
+        const tc = getCategoryColors(cat);
+        return (
+          <button
+            key={cat}
+            type="button"
+            onClick={() => onRemoveCategory(cat)}
+            aria-label={`Remove ${CATEGORY_LABELS[cat] ?? cat} filter from replies`}
+            style={{
+              display: "inline-flex", alignItems: "center", gap: 4,
+              background: tc.bg, color: tc.text, border: `1px solid ${tc.border}`,
+              borderRadius: 12, padding: "2px 8px", cursor: "pointer",
+              fontSize: 11, fontWeight: 600,
+            }}
+          >
+            {categoryIcon(cat, 12, tc.text)}
+            {CATEGORY_LABELS[cat] ?? cat}
+            <span aria-hidden style={chipX}>×</span>
+          </button>
+        );
+      })}
+
+      {responseFilter !== null && (
+        <button
+          type="button"
+          onClick={onClearResponse}
+          aria-label="Remove passage filter from replies"
+          style={{
+            display: "inline-flex", alignItems: "center", gap: 4,
+            background: "#f1f5f9", color: "#475569", border: "1px solid #cbd5e1",
+            borderRadius: 12, padding: "2px 8px", cursor: "pointer",
+            fontSize: 11, fontWeight: 600, maxWidth: 220,
+          }}
+        >
+          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontStyle: "italic" }}>
+            &ldquo;{responseFilter.text.length > 28 ? responseFilter.text.slice(0, 28) + "…" : responseFilter.text}&rdquo;
+          </span>
+          <span aria-hidden style={chipX}>×</span>
+        </button>
+      )}
+
+      {relatedTopic !== null && (
+        <button
+          type="button"
+          onClick={onClearTopic}
+          aria-label={`Remove ${relatedTopic} topic filter from replies`}
+          style={{
+            display: "inline-flex", alignItems: "center", gap: 4,
+            background: "#eef7f2", color: "#2f6b4f", border: "1px solid #bfdccb",
+            borderRadius: 12, padding: "2px 8px", cursor: "pointer",
+            fontSize: 11, fontWeight: 600, maxWidth: 200,
+          }}
+        >
+          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{relatedTopic}</span>
+          <span aria-hidden style={chipX}>×</span>
+        </button>
+      )}
+
+      <Text size="xs" c="#64748b" style={{ fontSize: 11, marginLeft: "auto", flexShrink: 0 }}>
+        showing {shown} of {total} {total === 1 ? "reply" : "replies"}
+      </Text>
+      <button
+        type="button"
+        onClick={onClearAll}
+        aria-label="Clear all reply filters"
+        style={{
+          background: "none", border: "none", cursor: "pointer",
+          color: "#5a71a8", fontSize: 11, fontWeight: 600, padding: "2px 4px",
+        }}
+      >
+        clear
+      </button>
+    </div>
+  );
+}

--- a/src/components/ReplyFilterBar.tsx
+++ b/src/components/ReplyFilterBar.tsx
@@ -7,13 +7,10 @@ import { CATEGORY_LABELS, getCategoryColors, categoryIcon } from "../utils/categ
 interface ReplyFilterBarProps {
   filterCategories: Set<string>;
   responseFilter: { start: number; end: number; text: string } | null;
-  /** Topic pushed onto the replies by a related-panel anchor (source 'related'). */
-  relatedTopic: string | null;
   shown: number;
   total: number;
   onRemoveCategory: (category: string) => void;
   onClearResponse: () => void;
-  onClearTopic: () => void;
   onClearAll: () => void;
 }
 
@@ -31,16 +28,14 @@ const chipX: React.CSSProperties = {
 export default function ReplyFilterBar({
   filterCategories,
   responseFilter,
-  relatedTopic,
   shown,
   total,
   onRemoveCategory,
   onClearResponse,
-  onClearTopic,
   onClearAll,
 }: ReplyFilterBarProps) {
   const cats = Array.from(filterCategories);
-  const anyActive = cats.length > 0 || responseFilter !== null || relatedTopic !== null;
+  const anyActive = cats.length > 0 || responseFilter !== null;
   if (!anyActive) return null;
 
   return (
@@ -93,23 +88,6 @@ export default function ReplyFilterBar({
           <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontStyle: "italic" }}>
             &ldquo;{responseFilter.text.length > 28 ? responseFilter.text.slice(0, 28) + "…" : responseFilter.text}&rdquo;
           </span>
-          <span aria-hidden style={chipX}>×</span>
-        </button>
-      )}
-
-      {relatedTopic !== null && (
-        <button
-          type="button"
-          onClick={onClearTopic}
-          aria-label={`Remove ${relatedTopic} topic filter from replies`}
-          style={{
-            display: "inline-flex", alignItems: "center", gap: 4,
-            background: "#eef7f2", color: "#2f6b4f", border: "1px solid #bfdccb",
-            borderRadius: 12, padding: "2px 8px", cursor: "pointer",
-            fontSize: 11, fontWeight: 600, maxWidth: 200,
-          }}
-        >
-          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{relatedTopic}</span>
           <span aria-hidden style={chipX}>×</span>
         </button>
       )}

--- a/src/components/ReplySection.tsx
+++ b/src/components/ReplySection.tsx
@@ -60,9 +60,30 @@ const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchP
         };
     }, []);
 
+    /** Drop any visible/in-flight feedback — the draft no longer exists. */
+    const clearFeedback = () => {
+        reqIdRef.current++; // invalidate any in-flight request
+        if (debounceTimeoutRef.current) {
+            clearTimeout(debounceTimeoutRef.current);
+            debounceTimeoutRef.current = null;
+        }
+        setAdvice(null);
+        setPraise(null);
+        setSimulatedReplies([]);
+        setLoading(false);
+        setCountdown(0);
+    };
+
     const handleReplyContentChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const newContent = e.target.value;
         setReplyContent(newContent);
+
+        // Stopped writing: an (effectively) cleared draft takes its feedback with
+        // it immediately — stale robots reacting to deleted text read as a bug.
+        if (newContent.trim().length < 3) {
+            clearFeedback();
+            return;
+        }
 
         if (debounceTimeoutRef.current) {
             clearTimeout(debounceTimeoutRef.current);
@@ -70,6 +91,11 @@ const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchP
         debounceTimeoutRef.current = setTimeout(() => {
             void fetchRealTimeFeedback(newContent);
         }, 500);
+    };
+
+    /** Unfocusing an empty composer also dismisses leftover feedback. */
+    const handleBlur = () => {
+        if (replyContent.trim().length === 0) clearFeedback();
     };
 
     const fetchRealTimeFeedback = async (inputContent: string) => {
@@ -148,6 +174,7 @@ const ReplySection: React.FC<ReplySectionProps> = ({ postId, currentUser, fetchP
                     size="xl"
                     value={replyContent}
                     onChange={handleReplyContentChange}
+                    onBlur={handleBlur}
                     style={{ flex: 1, fontFamily: 'Roboto, sans-serif', fontSize: '16px' }}
                 />
                 <Button

--- a/src/components/ReplySummaryCard.tsx
+++ b/src/components/ReplySummaryCard.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { Paper, Text } from "@mantine/core";
+import { IconSparkles, IconChevronDown, IconChevronUp } from "@tabler/icons-react";
+import { buildReplySummary } from "../utils/replySort.mjs";
+import { CATEGORY_LABELS, getCategoryColors } from "../utils/categoryStyles";
+import type { Relation } from "../types/PostType";
+
+interface ReplySummaryCardProps {
+  /** The CURRENTLY DISPLAYED replies (post-filter) — the summary always
+   *  describes what the list below it shows, never hidden posts. */
+  replies: Array<{ id: string; content: string; created_at: string; favourites_count: number; account: { username?: string; display_name?: string } }>;
+  relationsOf: (replyId: string) => Relation[];
+}
+
+/**
+ * Collapsible summary of the visible replies. Deliberately a card above the
+ * list, NOT a sort tab: a summary is not an ordering, and parking it in the
+ * sort control would teach users that tabs change content rather than
+ * arrangement. Collapsed by default so it never competes with real posts
+ * unless asked for.
+ */
+export default function ReplySummaryCard({ replies, relationsOf }: ReplySummaryCardProps) {
+  const [open, setOpen] = useState(false);
+
+  const digest = useMemo(
+    () => buildReplySummary(replies, { relationsOf: (r: any) => relationsOf(r.id) }),
+    [replies, relationsOf]
+  );
+
+  if (replies.length === 0) return null;
+
+  return (
+    <Paper
+      withBorder
+      data-testid="reply-summary-card"
+      style={{ borderRadius: 8, borderStyle: "dashed", background: "#fcfcf9", marginBottom: "0.75rem" }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        data-testid="reply-summary-toggle"
+        style={{
+          display: "flex", alignItems: "center", gap: 8, width: "100%",
+          background: "none", border: "none", cursor: "pointer",
+          padding: "10px 14px", textAlign: "left",
+        }}
+      >
+        <IconSparkles size={16} color="#5a71a8" />
+        <Text size="sm" fw={600} c="#374151">
+          {open ? `Summary of ${digest.total} ${digest.total === 1 ? "reply" : "replies"}` : `Summarize these ${digest.total} ${digest.total === 1 ? "reply" : "replies"}`}
+        </Text>
+        <span style={{ marginLeft: "auto", display: "inline-flex", color: "#94a3b8" }}>
+          {open ? <IconChevronUp size={16} /> : <IconChevronDown size={16} />}
+        </span>
+      </button>
+
+      {open && (
+        <div style={{ padding: "0 14px 12px" }}>
+          <Text size="xs" c="#475569" mb={6}>
+            {digest.withContributions} of {digest.total} replies carry contributions
+            {digest.topTopics.length > 0 ? <> — most discussed: {digest.topTopics.join(", ")}</> : null}.
+          </Text>
+          {digest.byCategory.length > 0 && (
+            <div style={{ display: "flex", gap: 4, flexWrap: "wrap", marginBottom: 8 }}>
+              {digest.byCategory.map(([cat, count]) => {
+                const tc = getCategoryColors(cat);
+                return (
+                  <span key={cat} style={{
+                    background: tc.bg, color: tc.text, border: `1px solid ${tc.border}55`,
+                    borderRadius: 5, padding: "1px 7px", fontSize: 10, fontWeight: 700,
+                  }}>
+                    {CATEGORY_LABELS[cat] ?? cat} ({count})
+                  </span>
+                );
+              })}
+            </div>
+          )}
+          {digest.sample.map((s, i) => (
+            <Text key={i} size="xs" c="#64748b" style={{ fontStyle: "italic", marginBottom: 2 }}>
+              {s.author}: &ldquo;{s.firstSentence}&rdquo;
+            </Text>
+          ))}
+          <Text size="xs" c="dimmed" mt={6} style={{ fontSize: 10 }}>
+            Demo summary — generated locally from the visible replies.
+          </Text>
+        </div>
+      )}
+    </Paper>
+  );
+}

--- a/src/components/ThreadedReplyList.tsx
+++ b/src/components/ThreadedReplyList.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styles from "./ThreadedReplyList.module.css";
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -80,14 +80,23 @@ function buildChildMap(replies: PostType[]): Map<string, PostType[]> {
 
 // ── Sub-renderer ─────────────────────────────────────────────────────────────
 
+/** Nested children shown per parent before the "see more" pagination kicks in,
+ *  and the increment each click reveals (mirrors the top-level 5-at-a-time). */
+const NESTED_PAGE = 5;
+
 function renderTree(
   post: PostType,
   depth: number,
   childMap: Map<string, PostType[]>,
-  renderPost: (p: PostType) => React.ReactNode
+  renderPost: (p: PostType) => React.ReactNode,
+  shownByParent: Record<string, number>,
+  onShowMore: (parentId: string) => void
 ): React.ReactNode {
   const effectiveDepth = Math.min(depth, MAX_DEPTH);
   const children = childMap.get(post.id) ?? [];
+  const shown = shownByParent[post.id] ?? NESTED_PAGE;
+  const visibleChildren = children.slice(0, shown);
+  const remaining = children.length - visibleChildren.length;
 
   return (
     <div
@@ -101,9 +110,35 @@ function renderTree(
       {/* The post card itself */}
       {renderPost(post)}
 
-      {/* Recursively render children */}
-      {children.map((child) =>
-        renderTree(child, depth + 1, childMap, renderPost)
+      {/* Recursively render children — paginated per parent so a branch with
+          many nested descendants doesn't dump its whole subtree at once. */}
+      {visibleChildren.map((child) =>
+        renderTree(child, depth + 1, childMap, renderPost, shownByParent, onShowMore)
+      )}
+      {remaining > 0 && (
+        <button
+          type="button"
+          data-testid={`nested-see-more-${post.id}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onShowMore(post.id);
+          }}
+          aria-label={`Show more replies to this comment (${remaining} hidden)`}
+          style={{
+            display: "block",
+            marginLeft: Math.min(depth + 1, MAX_DEPTH) * INDENT_PX,
+            marginBottom: "0.75rem",
+            background: "none",
+            border: "none",
+            padding: "2px 0",
+            cursor: "pointer",
+            color: "#5a71a8",
+            fontWeight: 600,
+            fontSize: 13,
+          }}
+        >
+          See {remaining} more {remaining === 1 ? "reply" : "replies"}
+        </button>
       )}
     </div>
   );
@@ -118,6 +153,15 @@ export default function ThreadedReplyList({
   visibleTopLevelCount,
   topLevelOrder,
 }: ThreadedReplyListProps) {
+  // Per-parent nested pagination: parentId → children currently shown.
+  // Reset when the thread root changes (navigating to a different post).
+  const [shownByParent, setShownByParent] = useState<Record<string, number>>({});
+  useEffect(() => {
+    setShownByParent({});
+  }, [rootId]);
+  const handleShowMore = (parentId: string) =>
+    setShownByParent((prev) => ({ ...prev, [parentId]: (prev[parentId] ?? NESTED_PAGE) + NESTED_PAGE }));
+
   const childMap = buildChildMap(replies);
   let topLevelReplies = childMap.get(rootId) ?? [];
   if (topLevelOrder) {
@@ -140,7 +184,7 @@ export default function ThreadedReplyList({
   return (
     <div>
       {visibleReplies.map((post) =>
-        renderTree(post, 0, childMap, renderPost)
+        renderTree(post, 0, childMap, renderPost, shownByParent, handleShowMore)
       )}
     </div>
   );

--- a/src/components/ThreadedReplyList.tsx
+++ b/src/components/ThreadedReplyList.tsx
@@ -51,6 +51,12 @@ interface ThreadedReplyListProps {
    * the default newest-first top level.
    */
   topLevelOrder?: string[];
+  /**
+   * The focus post's author handle. A nested reply by the ORIGINAL POSTER is
+   * always the branch's inline preview (X's rule: author replies surface
+   * first), before falling back to the most-liked child.
+   */
+  opAcct?: string;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -80,9 +86,27 @@ function buildChildMap(replies: PostType[]): Map<string, PostType[]> {
 
 // ── Sub-renderer ─────────────────────────────────────────────────────────────
 
-/** Nested children shown per parent before the "see more" pagination kicks in,
- *  and the increment each click reveals (mirrors the top-level 5-at-a-time). */
+/** X-style branch preview: each parent shows ONE nested reply inline by
+ *  default (the OP's reply if there is one, else the most-liked child) — the
+ *  rest collapse behind "Show N more replies", which expands in place. */
+const NESTED_PREVIEW = 1;
+/** Children revealed per "show more" click (mirrors the top-level 5-at-a-time). */
 const NESTED_PAGE = 5;
+
+/** OP reply first, then most-liked, then newest — X's relevance, approximated. */
+function pickPreviewFirst(children: PostType[], opAcct?: string): PostType[] {
+  if (children.length <= 1) return children;
+  const score = (p: PostType) => {
+    const isOp = opAcct && (p.account.acct === opAcct || p.account.username === opAcct) ? 1 : 0;
+    return isOp * 1e9 + (p.favourites_count ?? 0);
+  };
+  let best = children[0];
+  for (const c of children) {
+    if (score(c) > score(best)) best = c;
+  }
+  if (best === children[0]) return children;
+  return [best, ...children.filter((c) => c !== best)];
+}
 
 function renderTree(
   post: PostType,
@@ -90,11 +114,12 @@ function renderTree(
   childMap: Map<string, PostType[]>,
   renderPost: (p: PostType) => React.ReactNode,
   shownByParent: Record<string, number>,
-  onShowMore: (parentId: string) => void
+  onShowMore: (parentId: string) => void,
+  opAcct?: string
 ): React.ReactNode {
   const effectiveDepth = Math.min(depth, MAX_DEPTH);
-  const children = childMap.get(post.id) ?? [];
-  const shown = shownByParent[post.id] ?? NESTED_PAGE;
+  const children = pickPreviewFirst(childMap.get(post.id) ?? [], opAcct);
+  const shown = shownByParent[post.id] ?? NESTED_PREVIEW;
   const visibleChildren = children.slice(0, shown);
   const remaining = children.length - visibleChildren.length;
 
@@ -110,10 +135,12 @@ function renderTree(
       {/* The post card itself */}
       {renderPost(post)}
 
-      {/* Recursively render children — paginated per parent so a branch with
-          many nested descendants doesn't dump its whole subtree at once. */}
+      {/* Recursively render children — one preview inline, the rest behind the
+          in-place expander, so a branch never dumps its whole subtree at once.
+          Preview children apply the same rule to THEIR children, so the default
+          view reads as X-style linear chains. */}
       {visibleChildren.map((child) =>
-        renderTree(child, depth + 1, childMap, renderPost, shownByParent, onShowMore)
+        renderTree(child, depth + 1, childMap, renderPost, shownByParent, onShowMore, opAcct)
       )}
       {remaining > 0 && (
         <button
@@ -123,7 +150,7 @@ function renderTree(
             e.stopPropagation();
             onShowMore(post.id);
           }}
-          aria-label={`Show more replies to this comment (${remaining} hidden)`}
+          aria-label={`Show more replies to this comment (${remaining} hidden, expands in place)`}
           style={{
             display: "block",
             marginLeft: Math.min(depth + 1, MAX_DEPTH) * INDENT_PX,
@@ -137,7 +164,7 @@ function renderTree(
             fontSize: 13,
           }}
         >
-          See {remaining} more {remaining === 1 ? "reply" : "replies"}
+          Show {remaining} more {remaining === 1 ? "reply" : "replies"}
         </button>
       )}
     </div>
@@ -160,7 +187,7 @@ export default function ThreadedReplyList({
     setShownByParent({});
   }, [rootId]);
   const handleShowMore = (parentId: string) =>
-    setShownByParent((prev) => ({ ...prev, [parentId]: (prev[parentId] ?? NESTED_PAGE) + NESTED_PAGE }));
+    setShownByParent((prev) => ({ ...prev, [parentId]: (prev[parentId] ?? NESTED_PREVIEW) + NESTED_PAGE }));
 
   const childMap = buildChildMap(replies);
   let topLevelReplies = childMap.get(rootId) ?? [];

--- a/src/components/ThreadedReplyList.tsx
+++ b/src/components/ThreadedReplyList.tsx
@@ -108,6 +108,16 @@ function pickPreviewFirst(children: PostType[], opAcct?: string): PostType[] {
   return [best, ...children.filter((c) => c !== best)];
 }
 
+const expanderStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  padding: "2px 0",
+  cursor: "pointer",
+  color: "#5a71a8",
+  fontWeight: 600,
+  fontSize: 13,
+};
+
 function renderTree(
   post: PostType,
   depth: number,
@@ -115,6 +125,7 @@ function renderTree(
   renderPost: (p: PostType) => React.ReactNode,
   shownByParent: Record<string, number>,
   onShowMore: (parentId: string) => void,
+  onShowLess: (parentId: string) => void,
   opAcct?: string
 ): React.ReactNode {
   const effectiveDepth = Math.min(depth, MAX_DEPTH);
@@ -122,6 +133,7 @@ function renderTree(
   const shown = shownByParent[post.id] ?? NESTED_PREVIEW;
   const visibleChildren = children.slice(0, shown);
   const remaining = children.length - visibleChildren.length;
+  const isExpanded = visibleChildren.length > NESTED_PREVIEW;
 
   return (
     <div
@@ -140,32 +152,46 @@ function renderTree(
           Preview children apply the same rule to THEIR children, so the default
           view reads as X-style linear chains. */}
       {visibleChildren.map((child) =>
-        renderTree(child, depth + 1, childMap, renderPost, shownByParent, onShowMore, opAcct)
+        renderTree(child, depth + 1, childMap, renderPost, shownByParent, onShowMore, onShowLess, opAcct)
       )}
-      {remaining > 0 && (
-        <button
-          type="button"
-          data-testid={`nested-see-more-${post.id}`}
-          onClick={(e) => {
-            e.stopPropagation();
-            onShowMore(post.id);
-          }}
-          aria-label={`Show more replies to this comment (${remaining} hidden, expands in place)`}
+      {(remaining > 0 || isExpanded) && (
+        <div
           style={{
-            display: "block",
+            display: "flex",
+            gap: 16,
             marginLeft: Math.min(depth + 1, MAX_DEPTH) * INDENT_PX,
             marginBottom: "0.75rem",
-            background: "none",
-            border: "none",
-            padding: "2px 0",
-            cursor: "pointer",
-            color: "#5a71a8",
-            fontWeight: 600,
-            fontSize: 13,
           }}
         >
-          Show {remaining} more {remaining === 1 ? "reply" : "replies"}
-        </button>
+          {remaining > 0 && (
+            <button
+              type="button"
+              data-testid={`nested-see-more-${post.id}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onShowMore(post.id);
+              }}
+              aria-label={`Show more replies to this comment (${remaining} hidden, expands in place)`}
+              style={expanderStyle}
+            >
+              Show {remaining} more {remaining === 1 ? "reply" : "replies"}
+            </button>
+          )}
+          {isExpanded && (
+            <button
+              type="button"
+              data-testid={`nested-show-less-${post.id}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                onShowLess(post.id);
+              }}
+              aria-label="Collapse this branch back to its preview reply"
+              style={{ ...expanderStyle, color: "#94a3b8" }}
+            >
+              Show fewer
+            </button>
+          )}
+        </div>
       )}
     </div>
   );
@@ -179,6 +205,7 @@ export default function ThreadedReplyList({
   renderPost,
   visibleTopLevelCount,
   topLevelOrder,
+  opAcct,
 }: ThreadedReplyListProps) {
   // Per-parent nested pagination: parentId → children currently shown.
   // Reset when the thread root changes (navigating to a different post).
@@ -188,6 +215,13 @@ export default function ThreadedReplyList({
   }, [rootId]);
   const handleShowMore = (parentId: string) =>
     setShownByParent((prev) => ({ ...prev, [parentId]: (prev[parentId] ?? NESTED_PREVIEW) + NESTED_PAGE }));
+  // Collapse folds the branch back to its one-reply preview. Descendants'
+  // own expansion counts are kept, so re-expanding restores where you were.
+  const handleShowLess = (parentId: string) =>
+    setShownByParent((prev) => {
+      const { [parentId]: _gone, ...rest } = prev;
+      return rest;
+    });
 
   const childMap = buildChildMap(replies);
   let topLevelReplies = childMap.get(rootId) ?? [];
@@ -211,7 +245,7 @@ export default function ThreadedReplyList({
   return (
     <div>
       {visibleReplies.map((post) =>
-        renderTree(post, 0, childMap, renderPost, shownByParent, handleShowMore)
+        renderTree(post, 0, childMap, renderPost, shownByParent, handleShowMore, handleShowLess, opAcct)
       )}
     </div>
   );

--- a/src/components/ThreadedReplyList.tsx
+++ b/src/components/ThreadedReplyList.tsx
@@ -44,6 +44,13 @@ interface ThreadedReplyListProps {
   /** How many top-level reply branches to show. Each branch includes its full
    *  descendant subtree — no branch is split. Omit to show all. */
   visibleTopLevelCount?: number;
+  /**
+   * Explicit top-level ordering AND filter: when provided, only these ids
+   * render as top-level branches, in this order (ids missing from the thread
+   * are ignored). Nested children keep their own newest-first order. Omit for
+   * the default newest-first top level.
+   */
+  topLevelOrder?: string[];
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -109,9 +116,16 @@ export default function ThreadedReplyList({
   rootId,
   renderPost,
   visibleTopLevelCount,
+  topLevelOrder,
 }: ThreadedReplyListProps) {
   const childMap = buildChildMap(replies);
-  const topLevelReplies = childMap.get(rootId) ?? [];
+  let topLevelReplies = childMap.get(rootId) ?? [];
+  if (topLevelOrder) {
+    const byId = new Map(topLevelReplies.map((p) => [p.id, p]));
+    topLevelReplies = topLevelOrder
+      .map((id) => byId.get(id))
+      .filter((p): p is PostType => p !== undefined);
+  }
 
   if (topLevelReplies.length === 0) {
     return null;

--- a/src/types/PostType.tsx
+++ b/src/types/PostType.tsx
@@ -119,6 +119,19 @@ export interface RelatedPostMock {
   };
 }
 
+/** A reply in the thread. Extends the base post shape with optional NLP output. */
+export interface ReplyMock extends FocusPostMock {
+  /**
+   * Offset-based relations mirroring RelatedPostMock: `content*` offsets index
+   * THIS reply's plainText, `focus*` offsets index the parent entry's
+   * focusPost.plainText. Absent/empty = a reply with no contributions
+   * (e.g. "me too"), which renders plain.
+   */
+  relations?: Relation[];
+  /** Quality/diversity rank for the Top reply tab (1 = best). Optional. */
+  rank?: number;
+}
+
 export interface ListyInjectionEntry {
   focusPost: FocusPostMock;
   relatedPosts: RelatedPostMock[];
@@ -127,7 +140,7 @@ export interface ListyInjectionEntry {
    * is the immediate parent of `focusPost`. See LISTY-INJECTION-SCHEMA.md.
    */
   ancestors?: FocusPostMock[];
-  replies?: FocusPostMock[];
+  replies?: ReplyMock[];
 }
 
 export type ListyInjectionData = ListyInjectionEntry[];

--- a/src/utils/categoryStyles.tsx
+++ b/src/utils/categoryStyles.tsx
@@ -55,3 +55,21 @@ export const iconMapping: Record<string, JSX.Element> = {
 export function categoryIcon(cat: string, size = 14, color?: string): JSX.Element {
   return React.cloneElement(iconMapping[cat] ?? iconMapping.default, { size, color });
 }
+
+/** Hex → rgba() string. */
+export function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+/** Blend two hex colours by t (0..1) → OPAQUE rgb, so stacked/adjacent marks
+ *  can never compound into darker bands. Level-1 faint = blend toward white;
+ *  level-2 strong = blend the category bg toward its saturated border. */
+export function blendHex(from: string, to: string, t: number): string {
+  const a = [1, 3, 5].map((i) => parseInt(from.slice(i, i + 2), 16));
+  const b = [1, 3, 5].map((i) => parseInt(to.slice(i, i + 2), 16));
+  const m = (x: number, y: number) => Math.round(x + (y - x) * t);
+  return `rgb(${m(a[0], b[0])},${m(a[1], b[1])},${m(a[2], b[2])})`;
+}

--- a/src/utils/categoryStyles.tsx
+++ b/src/utils/categoryStyles.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+  IconQuestionMark, IconBulb, IconQuote, IconLink, IconPointer, IconBook,
+  IconMoodSmile, IconFrame, IconUser, IconHeart, IconThumbUp, IconThumbDown,
+} from '@tabler/icons-react';
+import { Layers } from 'lucide-react';
+
+// Single source of truth for contribution-category presentation. RelatedStacks,
+// Post (focus cross-highlight), reply badges, and the experiment panel all read
+// from here — do not re-declare these tables locally. (RepliesStack/StackCount
+// carry legacy copies pre-dating this module; migrate them when next touched.)
+
+export interface CategoryStyle { bg: string; border: string; text: string }
+
+export const CATEGORY_COLORS: Record<string, CategoryStyle> = {
+  agree:              { bg: "#d4f9d3", border: "#4caf50", text: "#1b5e20" },
+  disagree:           { bg: "#ffe0e0", border: "#f44336", text: "#b71c1c" },
+  predictions:        { bg: "#fff3cd", border: "#ff9800", text: "#e65100" },
+  evidence_public:    { bg: "#e3f2fd", border: "#2196f3", text: "#0d47a1" },
+  evidence_personal:  { bg: "#f3e5f5", border: "#9c27b0", text: "#4a148c" },
+  connections:        { bg: "#e0f2f1", border: "#009688", text: "#004d40" },
+  questions:          { bg: "#fce4ec", border: "#e91e63", text: "#880e4f" },
+  humor:              { bg: "#fff8e1", border: "#ffc107", text: "#ff6f00" },
+  values:             { bg: "#ede7f6", border: "#673ab7", text: "#311b92" },
+  framing:            { bg: "#e0f7fa", border: "#00bcd4", text: "#006064" },
+  proposals:          { bg: "#e8eaf6", border: "#3f51b5", text: "#1a237e" },
+  pointers:           { bg: "#e8eaf6", border: "#3f51b5", text: "#1a237e" },
+  uncategorized:      { bg: "#f5f5f5", border: "#9e9e9e", text: "#424242" },
+};
+
+export const CATEGORY_LABELS: Record<string, string> = {
+  agree: "Agree", disagree: "Disagree", predictions: "Predictions",
+  evidence_public: "Evidence (Public)", evidence_personal: "Evidence (Personal)",
+  connections: "Connections", questions: "Questions", humor: "Humor",
+  values: "Values", framing: "Framing", proposals: "Proposals",
+  pointers: "Pointers", uncategorized: "Uncategorized",
+};
+
+export function getCategoryColors(rel: string): CategoryStyle {
+  return CATEGORY_COLORS[rel] ?? CATEGORY_COLORS.uncategorized;
+}
+
+/** Element map kept for the existing React.cloneElement call sites in
+ *  RelatedStacks. New code should prefer categoryIcon(). */
+export const iconMapping: Record<string, JSX.Element> = {
+  uncategorized: <Layers size={14} />, predictions: <IconBulb size={14} />,
+  evidence_public: <IconQuote size={14} />, evidence_personal: <IconUser size={14} />,
+  connections: <IconLink size={14} />, pointers: <IconPointer size={14} />,
+  proposals: <IconBook size={14} />, humor: <IconMoodSmile size={14} />,
+  values: <IconHeart size={14} />, framing: <IconFrame size={14} />,
+  questions: <IconQuestionMark size={14} />, default: <Layers size={14} />,
+  agree: <IconThumbUp size={14} />, disagree: <IconThumbDown size={14} />,
+};
+
+export function categoryIcon(cat: string, size = 14, color?: string): JSX.Element {
+  return React.cloneElement(iconMapping[cat] ?? iconMapping.default, { size, color });
+}

--- a/src/utils/experimentFlags.ts
+++ b/src/utils/experimentFlags.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { DEFAULT_FLAGS, FLAGS_STORAGE_KEY, mergeFlags } from "./experimentFlagsCore.mjs";
+
+// Experiment-flags store: same module-level useSyncExternalStore pattern as
+// highlightStore. Persisted to localStorage so a chosen condition survives
+// reloads; defaults render on the server and on the first client paint, then
+// the persisted values (if any) apply right after hydration.
+
+export interface ExperimentFlags {
+  suppressThreadPosts: boolean;
+  replyContributions: boolean;
+  crossPaneFiltering: boolean;
+  replyReranking: boolean;
+  replySortTabs: boolean;
+  summaryCard: boolean;
+  stickyFocusBar: boolean;
+}
+
+/** UI metadata for the TopNav experiment panel. */
+export const FLAG_META: Array<{ key: keyof ExperimentFlags; label: string; description: string }> = [
+  { key: "suppressThreadPosts", label: "Hide thread posts in related panel", description: "Posts already shown as ancestors or replies are suppressed from the right pane." },
+  { key: "replyContributions", label: "Reply contributions", description: "Replies show colored contribution spans and category badges." },
+  { key: "crossPaneFiltering", label: "Cross-pane filtering", description: "Chips, passage, and topic filters apply to the replies list too — with a visible filter bar." },
+  { key: "replyReranking", label: "Reply reranking", description: "Clicking a contribution in a reply groups matching replies around it, in place." },
+  { key: "replySortTabs", label: "Reply sort tabs", description: "Top / Newest / Most liked tabs (off restores the legacy tab set)." },
+  { key: "summaryCard", label: "Summary card", description: "Collapsible summary of the currently displayed replies, above the list." },
+  { key: "stickyFocusBar", label: "Sticky focus post", description: "Collapsed focus-post bar with the contribution strip once you scroll into the replies." },
+];
+
+const SERVER_SNAPSHOT: ExperimentFlags = mergeFlags(null) as ExperimentFlags;
+
+let state: ExperimentFlags = mergeFlags(null) as ExperimentFlags;
+let loadedFromStorage = false;
+const listeners = new Set<() => void>();
+
+function notify() {
+  listeners.forEach((l) => l());
+}
+
+function loadPersistedOnce() {
+  if (loadedFromStorage || typeof window === "undefined") return;
+  loadedFromStorage = true;
+  try {
+    const raw = window.localStorage.getItem(FLAGS_STORAGE_KEY);
+    if (!raw) return;
+    const next = mergeFlags(JSON.parse(raw)) as ExperimentFlags;
+    if (JSON.stringify(next) !== JSON.stringify(state)) {
+      state = next;
+      notify();
+    }
+  } catch {
+    // Corrupt storage — keep defaults.
+  }
+}
+
+function persist() {
+  try {
+    window.localStorage.setItem(FLAGS_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Storage unavailable (private mode/quota) — flags stay session-only.
+  }
+}
+
+export function setExperimentFlag(key: keyof ExperimentFlags, value: boolean): void {
+  if (state[key] === value) return;
+  state = { ...state, [key]: value };
+  persist();
+  notify();
+}
+
+export function resetExperimentFlags(): void {
+  state = mergeFlags(null) as ExperimentFlags;
+  try {
+    window.localStorage.removeItem(FLAGS_STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+  notify();
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  // First client subscriber pulls the persisted condition in (post-hydration,
+  // so the server HTML and first client paint agree on defaults).
+  loadPersistedOnce();
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): ExperimentFlags {
+  return state;
+}
+
+function getServerSnapshot(): ExperimentFlags {
+  return SERVER_SNAPSHOT;
+}
+
+export function useExperimentFlags(): ExperimentFlags {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+export { DEFAULT_FLAGS, FLAGS_STORAGE_KEY };

--- a/src/utils/experimentFlagsCore.mjs
+++ b/src/utils/experimentFlagsCore.mjs
@@ -1,0 +1,37 @@
+// Pure helpers for the experiment-flags store. Plain JS (not TS) so the
+// node:test suite in tests/unit can import it without a build step; the
+// React store in experimentFlags.ts re-exports everything from here.
+
+/** Every thread-display experiment condition, ON by default (demo posture).
+ *  Toggling one OFF yields the ablation/control behavior for that feature. */
+export const DEFAULT_FLAGS = {
+  /** D1 — hide posts that already appear in the thread from the related panel */
+  suppressThreadPosts: true,
+  /** Replies render colored contribution spans + category badges */
+  replyContributions: true,
+  /** Category chips / passage / topic filters also filter the replies list,
+   *  and reply-span clicks filter the related panel */
+  crossPaneFiltering: true,
+  /** Clicking a contribution span in a reply reranks the replies in place */
+  replyReranking: true,
+  /** Top / Newest / Most liked reply tabs (off = legacy time/recommended/stacked/summary) */
+  replySortTabs: true,
+  /** Collapsible summary card above the replies list */
+  summaryCard: true,
+  /** Collapsed sticky focus bar with the contribution strip while scrolling */
+  stickyFocusBar: true,
+};
+
+export const FLAGS_STORAGE_KEY = 'stacky:experimentFlags:v1';
+
+/** Merge a persisted (possibly stale/corrupt) blob over the defaults.
+ *  Only known keys with boolean values are honored. Always returns a fresh object. */
+export function mergeFlags(persisted, defaults = DEFAULT_FLAGS) {
+  const out = { ...defaults };
+  if (persisted && typeof persisted === 'object') {
+    for (const key of Object.keys(defaults)) {
+      if (typeof persisted[key] === 'boolean') out[key] = persisted[key];
+    }
+  }
+  return out;
+}

--- a/src/utils/highlightStore.ts
+++ b/src/utils/highlightStore.ts
@@ -37,15 +37,11 @@ interface HighlightState {
   /**
    * Left-pane anchor: the thread reply whose contribution span was clicked.
    * Reranks the reply list in place (mirrors reRankAnchorIds for the aside).
+   * Topic grouping is SYMMETRIC: one topic groups BOTH panes (each reranks in
+   * place around its own anchor) — the panes' anchors are kept in sync by the
+   * thread page, and neither pane is ever filtered by a topic.
    */
   replyAnchor: { replyId: string; rangeIndex: number } | null;
-  /**
-   * Cross-pane topic filter, set by an anchor in the OTHER pane. source
-   * 'related' → the reply list filters by it; source 'reply' → the related
-   * panel filters by it. The anchoring pane reranks, the other pane filters —
-   * never both in the same pane.
-   */
-  topicFilter: { topic: string; source: 'related' | 'reply' } | null;
   /**
    * Topic → count of currently displayed thread replies carrying that topic.
    * Published by the thread page so the related panel's "N more <topic>"
@@ -66,7 +62,6 @@ const INITIAL: HighlightState = {
   anchoredRangeByPost: {},
   responseFilter: null,
   replyAnchor: null,
-  topicFilter: null,
   replyTopicCounts: {},
 };
 
@@ -127,78 +122,64 @@ export function clearTapped(): void {
  * - Selecting a different anchor while one is active replaces the old one entirely;
  *   the old anchor and its anchoredRangeByPost entry are removed before the new one
  *   is added. reRankAnchorIds.length is therefore always 0 or 1.
- *
- * `topic` (cross-pane filtering): the anchor's topic. Non-null activates the
- * related-sourced topic filter (the reply list filters by it); clearing the
- * anchor clears that filter. Pass null/undefined to leave replies untouched.
  */
-export function toggleReRankAnchor(postId: string, rangeIndex?: number, topic?: string | null): void {
+export function toggleReRankAnchor(postId: string, rangeIndex?: number): void {
   const idx = state.reRankAnchorIds.indexOf(postId);
-  const relatedTopicCleared =
-    state.topicFilter?.source === 'related' ? null : state.topicFilter;
   if (idx >= 0) {
-    // Same anchor toggled again — clear it (and its cross-pane topic filter).
+    // Same anchor toggled again — clear it.
     const { [postId]: _, ...rest } = state.anchoredRangeByPost;
-    state = { ...state, reRankAnchorIds: [], anchoredRangeByPost: rest, topicFilter: relatedTopicCleared };
+    state = { ...state, reRankAnchorIds: [], anchoredRangeByPost: rest };
   } else {
     // New anchor selected — replace any existing anchor entirely.
     const newAnchored = rangeIndex !== undefined ? { [postId]: rangeIndex } : {};
-    state = {
-      ...state,
-      reRankAnchorIds: [postId],
-      anchoredRangeByPost: newAnchored,
-      topicFilter: topic ? { topic, source: 'related' } : relatedTopicCleared,
-    };
+    state = { ...state, reRankAnchorIds: [postId], anchoredRangeByPost: newAnchored };
   }
+  notify();
+}
+
+/** Non-toggle setter: make `postId` THE anchor (used by the thread page to sync
+ *  the related panel's grouping to a reply-initiated topic group). */
+export function setReRankAnchor(postId: string, rangeIndex: number): void {
+  if (
+    state.reRankAnchorIds.length === 1 &&
+    state.reRankAnchorIds[0] === postId &&
+    state.anchoredRangeByPost[postId] === rangeIndex
+  ) return;
+  state = { ...state, reRankAnchorIds: [postId], anchoredRangeByPost: { [postId]: rangeIndex } };
   notify();
 }
 
 export function clearReRankAnchors(): void {
   if (state.reRankAnchorIds.length === 0) return;
-  state = {
-    ...state,
-    reRankAnchorIds: [],
-    anchoredRangeByPost: {},
-    topicFilter: state.topicFilter?.source === 'related' ? null : state.topicFilter,
-  };
+  state = { ...state, reRankAnchorIds: [], anchoredRangeByPost: {} };
   notify();
 }
 
-/**
- * Toggle a thread reply as the left-pane anchor (reranks replies in place).
- * `topic` non-null activates the reply-sourced topic filter — the related
- * panel filters by it while the reply list reranks.
- */
-export function toggleReplyAnchor(replyId: string, rangeIndex: number, topic?: string | null): void {
-  const replyTopicCleared =
-    state.topicFilter?.source === 'reply' ? null : state.topicFilter;
+/** Toggle a thread reply as the left-pane anchor (reranks replies in place). */
+export function toggleReplyAnchor(replyId: string, rangeIndex: number): void {
   if (state.replyAnchor?.replyId === replyId && state.replyAnchor.rangeIndex === rangeIndex) {
-    state = { ...state, replyAnchor: null, topicFilter: replyTopicCleared };
+    state = { ...state, replyAnchor: null };
   } else {
-    state = {
-      ...state,
-      replyAnchor: { replyId, rangeIndex },
-      topicFilter: topic ? { topic, source: 'reply' } : replyTopicCleared,
-    };
+    state = { ...state, replyAnchor: { replyId, rangeIndex } };
   }
   notify();
 }
 
-export function clearReplyAnchor(): void {
-  if (state.replyAnchor === null && state.topicFilter?.source !== 'reply') return;
-  state = {
-    ...state,
-    replyAnchor: null,
-    topicFilter: state.topicFilter?.source === 'reply' ? null : state.topicFilter,
-  };
+/** Non-toggle setter for the reply anchor (thread-page grouping sync). */
+export function setReplyAnchor(anchor: { replyId: string; rangeIndex: number } | null): void {
+  const same =
+    (anchor === null && state.replyAnchor === null) ||
+    (anchor !== null &&
+      state.replyAnchor?.replyId === anchor.replyId &&
+      state.replyAnchor.rangeIndex === anchor.rangeIndex);
+  if (same) return;
+  state = { ...state, replyAnchor: anchor };
   notify();
 }
 
-/** Clear the cross-pane topic filter — optionally only when set by `source`. */
-export function clearTopicFilter(source?: 'related' | 'reply'): void {
-  if (state.topicFilter === null) return;
-  if (source && state.topicFilter.source !== source) return;
-  state = { ...state, topicFilter: null };
+export function clearReplyAnchor(): void {
+  if (state.replyAnchor === null) return;
+  state = { ...state, replyAnchor: null };
   notify();
 }
 
@@ -256,7 +237,6 @@ interface PanelSnapshot {
   anchoredRangeByPost: Record<string, number>;
   responseFilter: { start: number; end: number; text: string } | null;
   replyAnchor: { replyId: string; rangeIndex: number } | null;
-  topicFilter: { topic: string; source: 'related' | 'reply' } | null;
 }
 
 const panelStateByFocus = new Map<string, PanelSnapshot>();
@@ -285,7 +265,6 @@ function snapshotPanel(): PanelSnapshot {
     anchoredRangeByPost: { ...state.anchoredRangeByPost },
     responseFilter: state.responseFilter,
     replyAnchor: state.replyAnchor,
-    topicFilter: state.topicFilter,
   };
 }
 
@@ -318,7 +297,6 @@ export function setPanelFocus(focusId: string | null): void {
     anchoredRangeByPost: saved ? { ...saved.anchoredRangeByPost } : {},
     responseFilter: incomingResponseFilter,
     replyAnchor: saved ? saved.replyAnchor : null,
-    topicFilter: saved ? saved.topicFilter : null,
     // reply-topic counts are re-published by the incoming thread page
     replyTopicCounts: {},
     // transient view state never persists across a focus switch

--- a/src/utils/highlightStore.ts
+++ b/src/utils/highlightStore.ts
@@ -34,6 +34,24 @@ interface HighlightState {
    * compute the shortest-common phrase without the full focus post text.
    */
   responseFilter: { start: number; end: number; text: string } | null;
+  /**
+   * Left-pane anchor: the thread reply whose contribution span was clicked.
+   * Reranks the reply list in place (mirrors reRankAnchorIds for the aside).
+   */
+  replyAnchor: { replyId: string; rangeIndex: number } | null;
+  /**
+   * Cross-pane topic filter, set by an anchor in the OTHER pane. source
+   * 'related' → the reply list filters by it; source 'reply' → the related
+   * panel filters by it. The anchoring pane reranks, the other pane filters —
+   * never both in the same pane.
+   */
+  topicFilter: { topic: string; source: 'related' | 'reply' } | null;
+  /**
+   * Topic → count of currently displayed thread replies carrying that topic.
+   * Published by the thread page so the related panel's "N more <topic>"
+   * tooltips can count across both panes.
+   */
+  replyTopicCounts: Record<string, number>;
 }
 
 const INITIAL: HighlightState = {
@@ -47,6 +65,9 @@ const INITIAL: HighlightState = {
   reRankAnchorIds: [],
   anchoredRangeByPost: {},
   responseFilter: null,
+  replyAnchor: null,
+  topicFilter: null,
+  replyTopicCounts: {},
 };
 
 // ─── Module-level store ─────────────────────────────────────────────────────
@@ -106,24 +127,88 @@ export function clearTapped(): void {
  * - Selecting a different anchor while one is active replaces the old one entirely;
  *   the old anchor and its anchoredRangeByPost entry are removed before the new one
  *   is added. reRankAnchorIds.length is therefore always 0 or 1.
+ *
+ * `topic` (cross-pane filtering): the anchor's topic. Non-null activates the
+ * related-sourced topic filter (the reply list filters by it); clearing the
+ * anchor clears that filter. Pass null/undefined to leave replies untouched.
  */
-export function toggleReRankAnchor(postId: string, rangeIndex?: number): void {
+export function toggleReRankAnchor(postId: string, rangeIndex?: number, topic?: string | null): void {
   const idx = state.reRankAnchorIds.indexOf(postId);
+  const relatedTopicCleared =
+    state.topicFilter?.source === 'related' ? null : state.topicFilter;
   if (idx >= 0) {
-    // Same anchor toggled again — clear it.
+    // Same anchor toggled again — clear it (and its cross-pane topic filter).
     const { [postId]: _, ...rest } = state.anchoredRangeByPost;
-    state = { ...state, reRankAnchorIds: [], anchoredRangeByPost: rest };
+    state = { ...state, reRankAnchorIds: [], anchoredRangeByPost: rest, topicFilter: relatedTopicCleared };
   } else {
     // New anchor selected — replace any existing anchor entirely.
     const newAnchored = rangeIndex !== undefined ? { [postId]: rangeIndex } : {};
-    state = { ...state, reRankAnchorIds: [postId], anchoredRangeByPost: newAnchored };
+    state = {
+      ...state,
+      reRankAnchorIds: [postId],
+      anchoredRangeByPost: newAnchored,
+      topicFilter: topic ? { topic, source: 'related' } : relatedTopicCleared,
+    };
   }
   notify();
 }
 
 export function clearReRankAnchors(): void {
   if (state.reRankAnchorIds.length === 0) return;
-  state = { ...state, reRankAnchorIds: [], anchoredRangeByPost: {} };
+  state = {
+    ...state,
+    reRankAnchorIds: [],
+    anchoredRangeByPost: {},
+    topicFilter: state.topicFilter?.source === 'related' ? null : state.topicFilter,
+  };
+  notify();
+}
+
+/**
+ * Toggle a thread reply as the left-pane anchor (reranks replies in place).
+ * `topic` non-null activates the reply-sourced topic filter — the related
+ * panel filters by it while the reply list reranks.
+ */
+export function toggleReplyAnchor(replyId: string, rangeIndex: number, topic?: string | null): void {
+  const replyTopicCleared =
+    state.topicFilter?.source === 'reply' ? null : state.topicFilter;
+  if (state.replyAnchor?.replyId === replyId && state.replyAnchor.rangeIndex === rangeIndex) {
+    state = { ...state, replyAnchor: null, topicFilter: replyTopicCleared };
+  } else {
+    state = {
+      ...state,
+      replyAnchor: { replyId, rangeIndex },
+      topicFilter: topic ? { topic, source: 'reply' } : replyTopicCleared,
+    };
+  }
+  notify();
+}
+
+export function clearReplyAnchor(): void {
+  if (state.replyAnchor === null && state.topicFilter?.source !== 'reply') return;
+  state = {
+    ...state,
+    replyAnchor: null,
+    topicFilter: state.topicFilter?.source === 'reply' ? null : state.topicFilter,
+  };
+  notify();
+}
+
+/** Clear the cross-pane topic filter — optionally only when set by `source`. */
+export function clearTopicFilter(source?: 'related' | 'reply'): void {
+  if (state.topicFilter === null) return;
+  if (source && state.topicFilter.source !== source) return;
+  state = { ...state, topicFilter: null };
+  notify();
+}
+
+/** Publish reply-topic counts (thread page → related panel tooltips). */
+export function setReplyTopicCounts(counts: Record<string, number>): void {
+  const prev = state.replyTopicCounts;
+  const prevKeys = Object.keys(prev);
+  const nextKeys = Object.keys(counts);
+  if (prevKeys.length === nextKeys.length && nextKeys.every((k) => prev[k] === counts[k])) return;
+  state = { ...state, replyTopicCounts: counts };
   notify();
 }
 
@@ -170,6 +255,8 @@ interface PanelSnapshot {
   reRankAnchorIds: string[];
   anchoredRangeByPost: Record<string, number>;
   responseFilter: { start: number; end: number; text: string } | null;
+  replyAnchor: { replyId: string; rangeIndex: number } | null;
+  topicFilter: { topic: string; source: 'related' | 'reply' } | null;
 }
 
 const panelStateByFocus = new Map<string, PanelSnapshot>();
@@ -197,6 +284,8 @@ function snapshotPanel(): PanelSnapshot {
     reRankAnchorIds: [...state.reRankAnchorIds],
     anchoredRangeByPost: { ...state.anchoredRangeByPost },
     responseFilter: state.responseFilter,
+    replyAnchor: state.replyAnchor,
+    topicFilter: state.topicFilter,
   };
 }
 
@@ -228,6 +317,10 @@ export function setPanelFocus(focusId: string | null): void {
     reRankAnchorIds: saved ? [...saved.reRankAnchorIds] : [],
     anchoredRangeByPost: saved ? { ...saved.anchoredRangeByPost } : {},
     responseFilter: incomingResponseFilter,
+    replyAnchor: saved ? saved.replyAnchor : null,
+    topicFilter: saved ? saved.topicFilter : null,
+    // reply-topic counts are re-published by the incoming thread page
+    replyTopicCounts: {},
     // transient view state never persists across a focus switch
     hoveredPostId: null,
     hoveredRelations: null,

--- a/src/utils/mockPostResolver.ts
+++ b/src/utils/mockPostResolver.ts
@@ -6,6 +6,7 @@ import type {
   ListyInjectionEntry,
   FocusPostMock,
   RelatedPostMock,
+  ReplyMock,
   CategoryKey,
   Relation,
 } from "../types/PostType";
@@ -57,7 +58,7 @@ function toMockPostType(p: FocusPostMock | RelatedPostMock, relatedStacks: any[]
 
 const entryByFocusId = new Map<string, ListyInjectionEntry>();
 const relatedById = new Map<string, { rp: RelatedPostMock; parent: ListyInjectionEntry }>();
-const replyById = new Map<string, { reply: FocusPostMock; parent: ListyInjectionEntry }>();
+const replyById = new Map<string, { reply: ReplyMock; parent: ListyInjectionEntry }>();
 const allPostsById = new Map<string, FocusPostMock | RelatedPostMock>();
 /** child id → parent id (inherent thread hierarchy) */
 const parentMap = new Map<string, string>();
@@ -239,6 +240,31 @@ export function getMockRecommended(id: string): MockPostType[] {
   const entry = entryByFocusId.get(id);
   if (!entry) return [];
   return entry.relatedPosts.map((rp) => toMockPostType(rp));
+}
+
+/** Relations for a reply rendered inside the thread of `focusId`. Covers both
+ *  seeded replies and dual-role related posts (posts that are simultaneously a
+ *  related response and a thread reply). Scoped by focus: a reply's relations
+ *  connect to its OWN entry's focus post, so they only apply when that post is
+ *  the one on screen — rendering them under a different focus would put marks
+ *  at offsets belonging to someone else's text. */
+export function getMockReplyRelations(id: string, focusId?: string): Relation[] {
+  const fromReply = replyById.get(id);
+  if (fromReply && (!focusId || fromReply.parent.focusPost.id === focusId)) {
+    return fromReply.reply.relations ?? [];
+  }
+  const fromRelated = relatedById.get(id);
+  if (fromRelated && (!focusId || fromRelated.parent.focusPost.id === focusId)) {
+    return fromRelated.rp.relations ?? [];
+  }
+  return [];
+}
+
+/** Quality/diversity rank for the Top reply tab. Only seeded replies carry a
+ *  reply rank; dual-role related posts' `rank` field is a within-category rank
+ *  with different semantics, so it is deliberately NOT consulted here. */
+export function getMockReplyRank(id: string): number | undefined {
+  return replyById.get(id)?.reply.rank;
 }
 
 /** True if the id exists anywhere in the mock data. */

--- a/src/utils/replySort.d.mts
+++ b/src/utils/replySort.d.mts
@@ -1,0 +1,27 @@
+// Type surface for replySort.mjs (plain JS so node:test can import it).
+
+export interface ReplySortOptions<R> {
+  /** Quality rank (1 = best); undefined = unranked. */
+  rankOf?: (reply: R) => number | undefined;
+  /** Relations carried by the reply (category/topic are all that's read). */
+  relationsOf?: (reply: R) => Array<{ category: string; topic?: string }>;
+}
+
+export function sortReplies<R extends { created_at: string; favourites_count?: number }>(
+  replies: R[],
+  mode: string,
+  options?: ReplySortOptions<R>,
+): R[];
+
+export interface ReplySummaryDigest {
+  total: number;
+  withContributions: number;
+  byCategory: Array<[string, number]>;
+  topTopics: string[];
+  sample: Array<{ author: string; firstSentence: string }>;
+}
+
+export function buildReplySummary<R>(
+  replies: R[],
+  options?: ReplySortOptions<R>,
+): ReplySummaryDigest;

--- a/src/utils/replySort.mjs
+++ b/src/utils/replySort.mjs
@@ -1,0 +1,78 @@
+// Pure reply ordering + summary logic for the thread view. Plain JS so the
+// node:test suite imports it directly; the page passes accessors for rank and
+// relations so this module stays data-shape agnostic.
+
+/** 'top' | 'time' | 'liked'. Unknown modes fall back to 'time' (newest first). */
+export function sortReplies(replies, mode, { rankOf = () => undefined, relationsOf = () => [] } = {}) {
+  const arr = [...replies];
+  const byNewest = (a, b) => String(b.created_at).localeCompare(String(a.created_at));
+
+  if (mode === 'liked') {
+    return arr.sort((a, b) => (b.favourites_count ?? 0) - (a.favourites_count ?? 0) || byNewest(a, b));
+  }
+
+  if (mode === 'top') {
+    // Ranked replies come first, ordered by rank (1 = best). Unranked replies
+    // follow, scored by contribution breadth (distinct categories), having any
+    // contribution at all, and a dampened like count — a stand-in for the
+    // backend's quality/diversity ranking until it exists for replies.
+    const score = (r) => {
+      const rels = relationsOf(r) ?? [];
+      const cats = new Set(rels.map((x) => x.category));
+      return 2 * cats.size + (rels.length > 0 ? 1 : 0) + Math.log10(1 + (r.favourites_count ?? 0));
+    };
+    return arr.sort((a, b) => {
+      const ra = rankOf(a);
+      const rb = rankOf(b);
+      if (ra !== undefined && rb !== undefined) return ra - rb;
+      if (ra !== undefined) return -1;
+      if (rb !== undefined) return 1;
+      return score(b) - score(a) || byNewest(a, b);
+    });
+  }
+
+  return arr.sort(byNewest);
+}
+
+function firstSentenceOf(text) {
+  const clean = String(text ?? '').replace(/<[^>]*>/g, '').trim();
+  const m = clean.match(/[^.!?]*[.!?]/);
+  return (m ? m[0] : clean).trim();
+}
+
+/**
+ * Deterministic local digest of the currently displayed replies — the demo
+ * stand-in for an LLM summary. Returns:
+ * { total, withContributions, byCategory: [[category, count]...] desc,
+ *   topTopics: [topic...] desc, sample: [{ author, firstSentence }] }
+ */
+export function buildReplySummary(replies, { relationsOf = () => [] } = {}) {
+  const byCategory = new Map();
+  const byTopic = new Map();
+  let withContributions = 0;
+
+  for (const r of replies) {
+    const rels = relationsOf(r) ?? [];
+    if (rels.length > 0) withContributions++;
+    const cats = new Set(rels.map((x) => x.category));
+    cats.forEach((c) => byCategory.set(c, (byCategory.get(c) ?? 0) + 1));
+    const topics = new Set(rels.map((x) => x.topic).filter(Boolean));
+    topics.forEach((t) => byTopic.set(t, (byTopic.get(t) ?? 0) + 1));
+  }
+
+  const sample = [...replies]
+    .sort((a, b) => (b.favourites_count ?? 0) - (a.favourites_count ?? 0))
+    .slice(0, 2)
+    .map((r) => ({
+      author: r.account?.username ?? r.account?.display_name ?? 'unknown',
+      firstSentence: firstSentenceOf(r.plainText ?? r.content),
+    }));
+
+  return {
+    total: replies.length,
+    withContributions,
+    byCategory: Array.from(byCategory.entries()).sort((a, b) => b[1] - a[1]),
+    topTopics: Array.from(byTopic.entries()).sort((a, b) => b[1] - a[1]).slice(0, 4).map(([t]) => t),
+    sample,
+  };
+}

--- a/src/utils/threadFilter.d.mts
+++ b/src/utils/threadFilter.d.mts
@@ -1,0 +1,21 @@
+// Type surface for threadFilter.mjs.
+import type { Relation } from "../types/PostType";
+
+export interface ReplyFilterState {
+  filterCategories?: Set<string> | string[];
+  responseFilter?: { start: number; end: number } | null;
+  topicFilter?: string | null;
+}
+
+export function filterReplies<R>(
+  replies: R[],
+  relationsOf: (reply: R) => Relation[],
+  filters?: ReplyFilterState,
+): R[];
+
+export function clusterTopLevel(
+  orderedIds: string[],
+  relationsOfId: (id: string) => Relation[],
+  anchorId: string,
+  anchorTopic: string,
+): { order: string[]; memberIds: Set<string> };

--- a/src/utils/threadFilter.mjs
+++ b/src/utils/threadFilter.mjs
@@ -1,0 +1,68 @@
+// Pure reply-list filter + cluster logic for cross-pane filtering (Task 7).
+// Plain JS so the node:test suite imports it directly. Semantics mirror the
+// related panel: categories AND together; the passage filter keeps replies
+// whose relations overlap the focus span; the topic filter matches relation
+// topics exactly (reply relations always carry explicit topics in the mock).
+
+/**
+ * @param replies    top-level reply objects
+ * @param relationsOf (reply) => Relation[]
+ * @param filters    { filterCategories?: Set|Array, responseFilter?: {start,end}|null, topicFilter?: string|null }
+ */
+export function filterReplies(replies, relationsOf, { filterCategories, responseFilter, topicFilter } = {}) {
+  const cats = filterCategories ? Array.from(filterCategories) : [];
+  return replies.filter((reply) => {
+    const rels = relationsOf(reply) ?? [];
+    if (cats.length > 0) {
+      const own = new Set(rels.map((r) => r.category));
+      if (!cats.every((c) => own.has(c))) return false;
+    }
+    if (responseFilter) {
+      const overlaps = rels.some((r) => r.focusStart < responseFilter.end && responseFilter.start < r.focusEnd);
+      if (!overlaps) return false;
+    }
+    if (topicFilter) {
+      if (!rels.some((r) => r.topic === topicFilter)) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Rerank-in-place for the reply list (mirrors reorderForAnchor's contract):
+ * topic-matching replies ABOVE the anchor move down to immediately above it,
+ * matches BELOW move up to immediately below it — everything else keeps its
+ * relative order and the anchor itself never moves. Reply lists are short, so
+ * unlike the related panel there is no pagination of below-matches.
+ *
+ * @param orderedIds    current top-level order (post-filter, post-sort)
+ * @param relationsOfId (id) => Relation[]
+ * @param anchorId      the clicked reply
+ * @param anchorTopic   topic driving the cluster
+ * @returns { order: string[], memberIds: Set<string> } — memberIds includes the anchor
+ */
+export function clusterTopLevel(orderedIds, relationsOfId, anchorId, anchorTopic) {
+  const memberIds = new Set([anchorId]);
+  const anchorIdx = orderedIds.indexOf(anchorId);
+  if (anchorIdx < 0) return { order: [...orderedIds], memberIds };
+
+  const matches = (id) =>
+    id !== anchorId && (relationsOfId(id) ?? []).some((r) => r.topic === anchorTopic);
+
+  const aboveMatched = [];
+  const aboveRest = [];
+  for (const id of orderedIds.slice(0, anchorIdx)) {
+    (matches(id) ? aboveMatched : aboveRest).push(id);
+  }
+  const belowMatched = [];
+  const belowRest = [];
+  for (const id of orderedIds.slice(anchorIdx + 1)) {
+    (matches(id) ? belowMatched : belowRest).push(id);
+  }
+
+  [...aboveMatched, ...belowMatched].forEach((id) => memberIds.add(id));
+  return {
+    order: [...aboveRest, ...aboveMatched, anchorId, ...belowMatched, ...belowRest],
+    memberIds,
+  };
+}

--- a/src/utils/useUrlSync.ts
+++ b/src/utils/useUrlSync.ts
@@ -193,7 +193,10 @@ export function useUrlSync({
 
     debounceRef.current = setTimeout(() => {
       const newUrl = pathname + (newSearch ? "?" + newSearch : "");
-      router.replace(newUrl);
+      // scroll:false — this replace fires 300ms after every tab/filter change;
+      // the App Router's default scroll-to-top would yank the user away from
+      // the replies they are sorting/filtering.
+      router.replace(newUrl, { scroll: false });
     }, 300);
 
     return () => {

--- a/src/utils/useUrlSync.ts
+++ b/src/utils/useUrlSync.ts
@@ -23,9 +23,14 @@ export interface UrlSyncOptions {
    * Use this to trigger the tab's data fetch (e.g., fetchRecommended).
    */
   onHydratedTab?: (tab: string) => void;
+  /**
+   * The tab treated as default (omitted from the URL). "time" for the legacy
+   * tab set; the thread page passes "top" when the reply-sort-tabs flag is on.
+   */
+  defaultTab?: string;
 }
 
-const VALID_TABS = ["time", "recommended", "stacked", "summary"] as const;
+const VALID_TABS = ["time", "recommended", "stacked", "summary", "top", "liked"] as const;
 type ValidTab = (typeof VALID_TABS)[number];
 
 function isValidTab(v: string): v is ValidTab {
@@ -50,6 +55,7 @@ export function useUrlSync({
   setActiveTab,
   plainPostText,
   onHydratedTab,
+  defaultTab = "time",
 }: UrlSyncOptions): void {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -162,8 +168,8 @@ export function useUrlSync({
 
     const params = new URLSearchParams();
 
-    // Only encode non-default tab (default is "time")
-    if (activeTab && activeTab !== "time") {
+    // Only encode a non-default tab
+    if (activeTab && activeTab !== defaultTab) {
       params.set("tab", activeTab);
     }
 
@@ -196,5 +202,5 @@ export function useUrlSync({
         debounceRef.current = null;
       }
     };
-  }, [activeTab, filterCategories, responseFilter, pathname, searchParams, router]);
+  }, [activeTab, defaultTab, filterCategories, responseFilter, pathname, searchParams, router]);
 }

--- a/tests/unit/experimentFlags.test.mjs
+++ b/tests/unit/experimentFlags.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DEFAULT_FLAGS, FLAGS_STORAGE_KEY, mergeFlags } from '../../src/utils/experimentFlagsCore.mjs';
+
+test('all flags default to true', () => {
+  const keys = Object.keys(DEFAULT_FLAGS);
+  assert.ok(keys.length >= 7, 'expected at least 7 flags');
+  for (const [k, v] of Object.entries(DEFAULT_FLAGS)) {
+    assert.equal(v, true, `flag ${k} should default to true`);
+  }
+});
+
+test('mergeFlags applies persisted booleans, ignores junk keys and non-boolean values', () => {
+  const merged = mergeFlags({ stickyFocusBar: false, unknownFlag: false, replySortTabs: 'nope' });
+  assert.equal(merged.stickyFocusBar, false);
+  assert.equal(merged.replySortTabs, true);
+  assert.ok(!('unknownFlag' in merged));
+});
+
+test('mergeFlags tolerates null and garbage input', () => {
+  assert.deepEqual(mergeFlags(null), DEFAULT_FLAGS);
+  assert.deepEqual(mergeFlags(undefined), DEFAULT_FLAGS);
+  assert.deepEqual(mergeFlags('garbage'), DEFAULT_FLAGS);
+  assert.deepEqual(mergeFlags(42), DEFAULT_FLAGS);
+});
+
+test('mergeFlags returns a fresh object (no aliasing of defaults)', () => {
+  const merged = mergeFlags(null);
+  merged.suppressThreadPosts = false;
+  assert.equal(DEFAULT_FLAGS.suppressThreadPosts, true);
+});
+
+test('storage key is stable', () => {
+  assert.equal(FLAGS_STORAGE_KEY, 'stacky:experimentFlags:v1');
+});

--- a/tests/unit/replyRelations.test.mjs
+++ b/tests/unit/replyRelations.test.mjs
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const data = JSON.parse(readFileSync(join(here, '../../src/app/FakeData/listy-injection.json'), 'utf8'));
+
+const CATEGORIES = new Set([
+  'agree', 'disagree', 'predictions', 'evidence_public', 'evidence_personal',
+  'connections', 'questions', 'humor', 'values', 'framing', 'proposals', 'pointers', 'uncategorized',
+]);
+
+const BIG_ENTRY_ID = '112880124583497150';
+const bigEntry = data.find((e) => e.focusPost.id === BIG_ENTRY_ID);
+
+test('target entry exists and has replies', () => {
+  assert.ok(bigEntry, 'big demo entry present');
+  assert.ok((bigEntry.replies ?? []).length >= 10);
+});
+
+test('at least one reply carries relations (data generated)', () => {
+  const withRels = (bigEntry.replies ?? []).filter((r) => (r.relations ?? []).length > 0);
+  assert.ok(withRels.length >= 8, `expected >=8 replies with relations, got ${withRels.length}`);
+});
+
+test('every reply relation has valid offsets, topic, and category', () => {
+  for (const entry of data) {
+    const focusPlain = entry.focusPost.plainText;
+    for (const reply of entry.replies ?? []) {
+      const plain = reply.plainText ?? reply.content;
+      for (const [i, r] of (reply.relations ?? []).entries()) {
+        const label = `${reply.id}[${i}]`;
+        assert.ok(CATEGORIES.has(r.category), `${label} category ${r.category}`);
+        assert.ok(typeof r.topic === 'string' && r.topic.length > 0, `${label} topic`);
+        const focusSlice = focusPlain.slice(r.focusStart, r.focusEnd);
+        assert.ok(focusSlice.length > 0, `${label} focus span non-empty`);
+        assert.equal(focusPlain.indexOf(focusSlice), r.focusStart, `${label} focus offsets exact`);
+        const contentSlice = plain.slice(r.contentStart, r.contentEnd);
+        assert.ok(contentSlice.length > 0, `${label} content span non-empty`);
+        assert.equal(plain.indexOf(contentSlice), r.contentStart, `${label} content offsets exact`);
+        // Comment sub-ranges: zero-length (no bold) or nested inside their span.
+        if (r.focusCommentEnd > r.focusCommentStart) {
+          assert.ok(r.focusCommentStart >= r.focusStart && r.focusCommentEnd <= r.focusEnd, `${label} focusComment nested`);
+        }
+        if (r.contentCommentEnd > r.contentCommentStart) {
+          assert.ok(r.contentCommentStart >= r.contentStart && r.contentCommentEnd <= r.contentEnd, `${label} contentComment nested`);
+        }
+      }
+      // Content spans must not overlap within one reply (reply renderer assumes it).
+      const spans = (reply.relations ?? [])
+        .map((r) => [r.contentStart, r.contentEnd])
+        .sort((a, b) => a[0] - b[0]);
+      for (let i = 1; i < spans.length; i++) {
+        assert.ok(spans[i][0] >= spans[i - 1][1], `${reply.id} content spans overlap`);
+      }
+    }
+  }
+});
+
+test('some replies deliberately carry no relations ("me too" cases)', () => {
+  const bare = (bigEntry.replies ?? []).filter((r) => (r.relations ?? []).length === 0);
+  assert.ok(bare.length >= 3, `expected >=3 relation-free replies, got ${bare.length}`);
+});
+
+test('dual-role posts: >=2 related posts are also thread replies of the focus', () => {
+  const dual = bigEntry.relatedPosts.filter((rp) => rp.inReplyToId === BIG_ENTRY_ID);
+  assert.ok(dual.length >= 2, `expected >=2 dual-role related posts, got ${dual.length}`);
+});
+
+test('"Build quality" is a replies-only topic shared by >=2 replies', () => {
+  const replyTopics = (bigEntry.replies ?? []).flatMap((r) => (r.relations ?? []).map((x) => x.topic));
+  const relatedTopics = bigEntry.relatedPosts.flatMap((rp) => (rp.relations ?? []).map((x) => x.topic));
+  assert.ok(replyTopics.filter((t) => t === 'Build quality').length >= 2);
+  assert.ok(!relatedTopics.includes('Build quality'));
+});
+
+test('reply topics intersect related-post topics (cross-pane demos)', () => {
+  const replyTopics = new Set((bigEntry.replies ?? []).flatMap((r) => (r.relations ?? []).map((x) => x.topic)));
+  const relatedTopics = new Set(bigEntry.relatedPosts.flatMap((rp) => (rp.relations ?? []).map((x) => x.topic)));
+  const shared = [...replyTopics].filter((t) => relatedTopics.has(t));
+  assert.ok(shared.length >= 3, `expected >=3 shared topics, got ${shared.length}: ${[...replyTopics]}`);
+});
+
+test('small entry has 1-5 replies for the tabs-suppressed state', () => {
+  const small = data.find((e) => e.focusPost.id === '112880110824825811');
+  assert.ok(small, 'small entry present');
+  const n = (small.replies ?? []).length;
+  assert.ok(n >= 1 && n <= 5, `expected 1-5 replies, got ${n}`);
+});
+
+test('ranked replies exist for the Top tab', () => {
+  const ranked = (bigEntry.replies ?? []).filter((r) => typeof r.rank === 'number');
+  assert.ok(ranked.length >= 8, `expected >=8 ranked replies, got ${ranked.length}`);
+  const ranks = ranked.map((r) => r.rank);
+  assert.equal(new Set(ranks).size, ranks.length, 'ranks are unique');
+});

--- a/tests/unit/replySort.test.mjs
+++ b/tests/unit/replySort.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sortReplies, buildReplySummary } from '../../src/utils/replySort.mjs';
+
+const mk = (id, created, favs) => ({ id, created_at: created, favourites_count: favs, account: { username: id } });
+
+const A = mk('a', '2024-07-31T09:00:00Z', 5);
+const B = mk('b', '2024-07-31T10:00:00Z', 20);
+const C = mk('c', '2024-07-31T11:00:00Z', 1);
+const D = mk('d', '2024-07-31T12:00:00Z', 8);
+
+const RELS = {
+  a: [{ category: 'framing', topic: 'X' }, { category: 'values', topic: 'Y' }],
+  b: [],
+  c: [{ category: 'questions', topic: 'X' }],
+  d: [{ category: 'framing', topic: 'Z' }],
+};
+const RANKS = { a: 2, c: 1 };
+const opts = { rankOf: (r) => RANKS[r.id], relationsOf: (r) => RELS[r.id] ?? [] };
+
+test('time mode sorts newest first', () => {
+  assert.deepEqual(sortReplies([A, B, C, D], 'time', opts).map((r) => r.id), ['d', 'c', 'b', 'a']);
+});
+
+test('liked mode sorts by favourites desc, newest breaks ties', () => {
+  const E = mk('e', '2024-07-31T13:00:00Z', 8);
+  assert.deepEqual(sortReplies([A, B, C, D, E], 'liked', opts).map((r) => r.id), ['b', 'e', 'd', 'a', 'c']);
+});
+
+test('top mode: ranked replies first by rank asc, then unranked by score', () => {
+  const out = sortReplies([A, B, C, D], 'top', opts).map((r) => r.id);
+  assert.deepEqual(out.slice(0, 2), ['c', 'a'], 'ranked block ordered by rank');
+  // Unranked: d has a relation (score ~2+1+log(9)); b has none but 20 favs (log(21)~1.3) → d first.
+  assert.deepEqual(out.slice(2), ['d', 'b']);
+});
+
+test('sort does not mutate its input', () => {
+  const input = [A, B, C];
+  sortReplies(input, 'time', opts);
+  assert.deepEqual(input.map((r) => r.id), ['a', 'b', 'c']);
+});
+
+test('unknown mode falls back to time', () => {
+  assert.deepEqual(sortReplies([A, B], 'bogus', opts).map((r) => r.id), ['b', 'a']);
+});
+
+test('buildReplySummary digests counts, categories, topics, and samples', () => {
+  const s = buildReplySummary([A, B, C, D], opts);
+  assert.equal(s.total, 4);
+  assert.equal(s.withContributions, 3);
+  assert.deepEqual(s.byCategory[0], ['framing', 2]);
+  assert.ok(s.topTopics.includes('X'));
+  assert.ok(s.sample.length >= 1 && s.sample.length <= 2);
+  assert.equal(s.sample[0].author, 'b', 'most-liked reply sampled first');
+});
+
+test('buildReplySummary extracts a first sentence', () => {
+  const r = { ...mk('s', '2024-07-31T09:00:00Z', 3), plainText: 'First point here. Second point there.' };
+  const s = buildReplySummary([r], { relationsOf: () => [] });
+  assert.equal(s.sample[0].firstSentence, 'First point here.');
+});

--- a/tests/unit/threadFilter.test.mjs
+++ b/tests/unit/threadFilter.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { filterReplies, clusterTopLevel } from '../../src/utils/threadFilter.mjs';
+
+const R = (id, rels) => ({ id, rels });
+const relsOf = (r) => r.rels;
+
+const a = R('a', [{ category: 'framing', topic: 'X', focusStart: 10, focusEnd: 40 }]);
+const b = R('b', [
+  { category: 'framing', topic: 'Y', focusStart: 100, focusEnd: 140 },
+  { category: 'questions', topic: 'X', focusStart: 10, focusEnd: 30 },
+]);
+const c = R('c', []); // no contributions
+const d = R('d', [{ category: 'values', topic: 'Z', focusStart: 200, focusEnd: 240 }]);
+
+test('no active filters returns all replies', () => {
+  assert.deepEqual(filterReplies([a, b, c, d], relsOf, {}).map((r) => r.id), ['a', 'b', 'c', 'd']);
+});
+
+test('category filter uses AND semantics across selected categories', () => {
+  assert.deepEqual(filterReplies([a, b, c, d], relsOf, { filterCategories: new Set(['framing']) }).map((r) => r.id), ['a', 'b']);
+  assert.deepEqual(filterReplies([a, b, c, d], relsOf, { filterCategories: new Set(['framing', 'questions']) }).map((r) => r.id), ['b']);
+});
+
+test('passage filter keeps replies whose relations overlap the span', () => {
+  assert.deepEqual(filterReplies([a, b, c, d], relsOf, { responseFilter: { start: 5, end: 15 } }).map((r) => r.id), ['a', 'b']);
+  assert.deepEqual(filterReplies([a, b, c, d], relsOf, { responseFilter: { start: 500, end: 600 } }).map((r) => r.id), []);
+});
+
+test('topic filter matches relation topics', () => {
+  assert.deepEqual(filterReplies([a, b, c, d], relsOf, { topicFilter: 'X' }).map((r) => r.id), ['a', 'b']);
+  assert.deepEqual(filterReplies([a, b, c, d], relsOf, { topicFilter: 'Z' }).map((r) => r.id), ['d']);
+});
+
+test('filters compose as intersections', () => {
+  const out = filterReplies([a, b, c, d], relsOf, {
+    filterCategories: new Set(['questions']),
+    topicFilter: 'X',
+    responseFilter: { start: 5, end: 15 },
+  });
+  assert.deepEqual(out.map((r) => r.id), ['b']);
+});
+
+test('clusterTopLevel pulls topic matches adjacent to the anchor, anchor stays put', () => {
+  const relsById = {
+    r1: [{ topic: 'T' }], r2: [{ topic: 'U' }], r3: [{ topic: 'T' }],
+    r4: [{ topic: 'T' }], r5: [],
+  };
+  const { order, memberIds } = clusterTopLevel(['r1', 'r2', 'r3', 'r4', 'r5'], (id) => relsById[id] ?? [], 'r3', 'T');
+  // r1 (above match) moves down to just above r3; r4 (below match) is already adjacent below.
+  assert.deepEqual(order, ['r2', 'r1', 'r3', 'r4', 'r5']);
+  assert.deepEqual([...memberIds].sort(), ['r1', 'r3', 'r4']);
+});
+
+test('clusterTopLevel with no matches leaves order intact', () => {
+  const { order, memberIds } = clusterTopLevel(['x', 'y'], () => [], 'x', 'nope');
+  assert.deepEqual(order, ['x', 'y']);
+  assert.deepEqual([...memberIds], ['x']);
+});
+
+test('clusterTopLevel tolerates an anchor missing from the list', () => {
+  const { order } = clusterTopLevel(['x', 'y'], () => [], 'ghost', 'T');
+  assert.deepEqual(order, ['x', 'y']);
+});


### PR DESCRIPTION
## Summary

Closes #142

Brings the listy related-panel treatment into the thread display, behind per-feature experiment flags (flask icon in the top nav). Every feature toggles independently so ablation conditions (U3/U4) stay testable; flags off = today's UI.

## Changes

- **Suppression**: posts already in the thread (focus/ancestors/replies) are hidden from the related panel; counts stay honest
- **Reply contributions**: replies render colored category spans + badges; hovering cross-highlights the focus post
- **Reply sort tabs**: Top / Newest / Most liked (hidden ≤5 replies) + collapsible local summary card (a card, not a tab)
- **Cross-pane filtering**: category chips and passage clicks filter both panes, worn visibly as removable chips above the replies; span clicks relax incompatible chips instead of composing to zero results
- **Symmetric topic grouping**: clicking a contribution span in either pane groups BOTH panes around that topic (rerank in place, one pill per pane, dismissing either clears both). *Deliberate deviation from the Slack spec ("filter the other pane") per Tarik's review — topics never filter, so no dead-end states*
- **Pinned post**: 3-line window of the focused post fixed under the nav once scrolled past; auto-scrolls (line-snapped) to whichever region a hovered span connects to, level-2 focusComment bolding included; click a highlight to filter, click the bar to return
- **X-style reply threading**: one preview reply per branch (OP first, then most-liked), "Show N more replies" expands in place 5 at a time, "Show fewer" collapses; same pattern at top level
- **Badge hover**: category badges cross-highlight the focus post at level 2 and dwell-scroll the card to its contribution
- **Span tooltips**: "Click to show N related posts" (focused) vs "Click to focus on N related posts" (non-focused)
- **Data/infra**: deterministic reply-relation generator (offsets computed from snippets, throws on drift), dual-role posts for the suppression demo, nested-thread fixture; ESLint config added (repo never had one) + 9 pre-existing errors fixed; composer feedback clears when the draft is emptied
- **Bug fixes along the way**: related-stacks context force-guard swallowing re-seeds, reply hover race wiping span highlights, stale FLIP transforms overlapping cards, absolute tag layout overlaps, scroll-to-top on every tab/filter URL write, focus-mark coverage gap for reply-only regions

## How to Test

1. `pnpm dev` → open `/ChineseEVs/posts/112880124583497150` (big demo entry; `/ChineseEVs/posts/112880110824825811` for the ≤5-replies state)
2. Flask icon (top nav) → toggle each experiment flag and compare against flags-off
3. Chip / focus-span / reply-span / related-span clicks — check both panes' pills and the reply filter bar counts
4. Scroll into the replies → pinned post appears; hover reply/related spans → window scrolls to the connected region, 3 full lines, comment phrase bolded
5. Expand/collapse nested branches under Jane Dev's TAA reply
6. `node --test tests/unit/` (29) and `pnpm test:e2e` (18) — both green at tip; `pnpm build` compiles all routes

## Checklist

- [ ] PR is under ~400 changed lines — **knowingly exceeded (~3.2k adds): integration branch for the whole thread-display feature set; commits are review-sized if needed**
- [x] Branch follows naming convention
- [x] Commits reference the issue number
- [x] Tests pass (29 unit, 18 e2e, lint, tsc, prod build)
- [ ] At least one teammate has been requested for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
