### PR TITLE
Fixed-size focus post with robust line-snapped scroll-to-span

### DIFF
--- a/e2e/focus-highlighting.spec.ts
+++ b/e2e/focus-highlighting.spec.ts
@@ -114,67 +114,90 @@ test.describe('Focus-post highlighting', () => {
     expect(ch[0] + ch[1] + ch[2], 'L2 fill should stay pastel/light').toBeGreaterThan(600);
   });
 
-  test('#4 a below-fold highlight opens the BOUNDED reveal (capped + scrolled to the span), then collapses on leave', async ({ page }) => {
+  test('#4 card hover scrolls the FIXED-SIZE focus post to the whole span; height never changes; restores on leave', async ({ page }) => {
     await page.goto(DETAIL_URL);
     const focus = page.locator('[data-testid="focus-reveal"]');
     await expect(focus).toBeVisible();
     await expect(page.getByText('Read more').first()).toBeVisible();
 
     const count = (await page.evaluate(DRIVER)) as number;
-    const collapsedH = await focus.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    const baselineH = await focus.evaluate((el) => Math.round(el.getBoundingClientRect().height));
 
-    // Drive card hover until one links to a region below the fold and the post
-    // opens the bounded reveal.
-    let hoveredCard = -1;
-    let expandedH = collapsedH;
-    for (let i = 0; i < Math.min(count, 12); i++) {
+    // Union-of-painted-marks visibility: the WHOLE span must be visible when it
+    // fits the box, or pinned to the top of the box when it is taller than the
+    // box. Checking only the first mark is exactly the bug this test pins.
+    // lineAligned pins the no-partial-line guarantee: the window may only rest on
+    // whole-line boundaries, so a clipped half-line can never be shown (nor
+    // mistaken for a fully-visible span).
+    const spanState = () =>
+      focus.evaluate((el) => {
+        const box = el.getBoundingClientRect();
+        const lineH = 1.5 * (parseFloat(getComputedStyle(el).fontSize) || 16);
+        const painted = (Array.from(el.querySelectorAll('mark[data-fs]')) as HTMLElement[]).filter(
+          (m) => m.style.backgroundColor
+        );
+        let minTop = Infinity;
+        let maxBottom = -Infinity;
+        for (const m of painted) {
+          const r = m.getBoundingClientRect();
+          if (r.height === 0) continue;
+          if (r.top < minTop) minTop = r.top;
+          if (r.bottom > maxBottom) maxBottom = r.bottom;
+        }
+        const unionH = maxBottom - minTop;
+        return {
+          h: Math.round(box.height),
+          scrollTop: Math.round(el.scrollTop),
+          painted: painted.length,
+          lineAligned: Math.abs(el.scrollTop / lineH - Math.round(el.scrollTop / lineH)) < 0.06,
+          spanShown:
+            painted.length > 0 &&
+            (unionH <= el.clientHeight - 2
+              ? minTop >= box.top - 1.5 && maxBottom <= box.bottom + 1.5 // fits → fully visible
+              : minTop >= box.top - 1.5 && minTop <= box.top + lineH), // taller → start pinned to top line
+        };
+      });
+
+    let anyScrolled = false;
+    for (let i = 0; i < Math.min(count, 10); i++) {
       await page.evaluate((idx: number) => (window as any).__hl.enter(idx, false), i);
-      await page.waitForTimeout(300);
-      expandedH = await focus.evaluate((el) => Math.round(el.getBoundingClientRect().height));
-      if (expandedH > collapsedH + 20) { hoveredCard = i; break; }
+      // Wait for the smooth scroll to SETTLE: the whole span visible AND resting
+      // on a whole-line boundary (mid-animation scrollTop is not line-aligned).
+      await expect
+        .poll(
+          async () => {
+            const s = await spanState();
+            return s.spanShown && s.lineAligned;
+          },
+          {
+            timeout: 5000,
+            message: `card ${i}: the full span union must settle, line-aligned, inside the box`,
+          }
+        )
+        .toBe(true);
+      const st = await spanState();
+      // THE core contract: the box NEVER changes size on hover.
+      expect(st.h, `card ${i}: focus post height must not change on hover`).toBeGreaterThanOrEqual(baselineH - 2);
+      expect(st.h, `card ${i}: focus post height must not change on hover`).toBeLessThanOrEqual(baselineH + 2);
+      if (st.scrollTop > 0) anyScrolled = true;
       await page.evaluate((idx: number) => (window as any).__hl.leave(idx), i);
+      await page.waitForTimeout(200);
     }
-    expect(expandedH, 'a below-fold highlight should open the reveal').toBeGreaterThan(collapsedH + 20);
 
-    // D-EXPAND / R-EXPAND-2: the reveal is BOUNDED — at most ~12 lines / 40vh,
-    // never the full article height (the pre-fix behavior this test used to pin).
-    const capPx = await focus.evaluate(() => {
-      const fs = parseFloat(getComputedStyle(document.querySelector('[data-testid="focus-reveal"]')!).fontSize);
-      return Math.min(1.5 * fs * 12, window.innerHeight * 0.4);
-    });
-    expect(expandedH, 'the reveal must stay within the cap').toBeLessThanOrEqual(Math.ceil(capPx) + 8);
+    // At least one card's span sits below the fold, so internal scrolling must
+    // have engaged somewhere — otherwise the mechanism is dead, not just idle.
+    expect(anyScrolled, 'internal scroll-to-span should engage for below-fold spans').toBe(true);
 
-    // Manual Read-more stays available and independent (no forced full expand).
+    // Manual Read-more stays available and independent throughout.
     await expect(page.getByText('Read more').first()).toBeVisible();
 
-    // Scroll-to-span: the highlighted (inline-painted) mark ends up visible
-    // inside the capped, internally-scrolled box.
+    // After the last leave the box rests where it started: same height,
+    // scrolled back to the top.
     await expect
-      .poll(
-        async () =>
-          focus.evaluate((el) => {
-            const box = el.getBoundingClientRect();
-            const marks = Array.from(el.querySelectorAll('mark[data-fs]')) as HTMLElement[];
-            const painted = marks.filter((m) => m.style.backgroundColor);
-            if (painted.length === 0) return 'no-painted-mark';
-            return painted.some((m) => {
-              const r = m.getBoundingClientRect();
-              return r.top >= box.top - 1 && r.top < box.bottom - 1;
-            })
-              ? 'visible'
-              : 'hidden';
-          }),
-        { timeout: 8000 }
-      )
-      .toBe('visible');
-
-    // Leaving the card restores the collapsed clamp (we only auto-collapse what
-    // we auto-opened).
-    await page.evaluate((idx: number) => (window as any).__hl.leave(idx), hoveredCard);
-    await expect
-      .poll(async () => focus.evaluate((el) => Math.round(el.getBoundingClientRect().height)), { timeout: 8000 })
-      .toBeLessThanOrEqual(collapsedH + 20);
-    await expect(page.getByText('Read more').first()).toBeVisible();
+      .poll(async () => (await spanState()).scrollTop, { timeout: 8000 })
+      .toBeLessThanOrEqual(1);
+    const finalH = await focus.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(finalH).toBe(baselineH);
   });
 
   test('#5 related-card span click groups the panel (anchor) — distinct from the focus-post filter', async ({ page }) => {

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -216,14 +216,15 @@ function cleanPostHtml(html: string, card: PreviewCard | null | undefined): Clea
 // Dwell duration (ms) before focus-post marks become visible on hover.
 const FOCUS_HOVER_DWELL_MS = 1500;
 
-// D-EXPAND (R-EXPAND-2): the auto-reveal is BOUNDED — the box grows to at most
-// this many lines (or 40vh, whichever is smaller) and scrolls internally to the
-// highlighted span, so a hover-preview never balloons the post to full height
-// or shoves the feed below it. Manual "Read more" still fully expands.
-const AUTO_REVEAL_CAP_LINES = 12;
-const AUTO_REVEAL_MAX_HEIGHT = `min(calc(1.5em * ${AUTO_REVEAL_CAP_LINES}), 40vh)`;
-/** One line of context kept above the span the reveal scrolls to. */
-const AUTO_REVEAL_SCROLL_CONTEXT_PX = 24;
+// Fixed-window focus post (decision 2026-07-06; supersedes the bounded-GROW
+// reveal, which read as layout instability): the box NEVER changes height or
+// line count on hover. While a cross-highlight/filter is active the clamped box
+// becomes a programmatically-scrolled window AT THE SAME HEIGHT and scrolls to
+// the whole span union. Scroll offsets snap to whole LINES so the window never
+// shows a clipped half-line (a half-line's span was being mistaken for "shown",
+// so semi-visible spans didn't scroll — the bug this replaces). Manual "Read
+// more" still fully expands; that's the only way to grow the post.
+const POST_LINE_HEIGHT_EM = 1.5;
 
 // Renders the interactive highlight spans for ANY post that has relations, not
 // just the focused one, so feed posts get span hover + click-to-focus. It
@@ -237,14 +238,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   style: React.CSSProperties;
   className?: string;
   isTextExpanded: boolean;
-  /** Bounded auto-reveal is active: the box is capped (AUTO_REVEAL_MAX_HEIGHT)
-   *  and this component scrolls it internally to the highlighted span. */
-  autoRevealed?: boolean;
   focusRelations?: Relation[];
-  /** Ask the parent to open/close the BOUNDED reveal (capped box + internal
-   *  scroll-to-span) when a highlight sits below the clamp. The parent only
-   *  auto-collapses what it auto-opened; manual Read-more is independent. */
-  onAutoReveal?: (reveal: boolean) => void;
   /** Whether this is the focused post. Non-focused feed posts still render the
    *  spans + direct-hover darkening, but skip the store-driven cross-highlight,
    *  the response-filter visual, and the auto-reveal; a span click on them
@@ -261,7 +255,7 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
    *  counts across both panes). Supplied by the detail page; feeds without a
    *  reply pane simply omit it. */
   replyCountForSpans?: (ranges: Array<{ fs: number; fe: number }>) => number;
-}>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded, autoRevealed = false, focusRelations = [], onAutoReveal, active = true, onSpanFocusRequest, relatedCountForSpans, replyCountForSpans }, ref) {
+}>(function ActiveHighlightedContent({ displayText, rawText, style, className, isTextExpanded, focusRelations = [], active = true, onSpanFocusRequest, relatedCountForSpans, replyCountForSpans }, ref) {
   const { hoveredPostId, hoveredRelations, hoveredHighlightRangeIndex, hoveredCategory, responseFilter, filterCategories } = useHighlightStore();
   // Related stacks of the active (focus) post — used to count "N related posts"
   // for the click-to-filter affordance. Mirrored to a ref so the DOM hover
@@ -347,26 +341,28 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
   // Strip non-alphanumerics so the id stays valid inside the `#${id}` CSS rules below.
   const containerIdRef = useRef<string>(`ahc-${useId().replace(/[^a-zA-Z0-9]/g, '')}`);
 
-  // ── Expand-to-reveal (collapsed fold) ─────────────────────────────────────
-  // When a highlighted mark sits below the "Read more" clamp, ask the PARENT to
-  // expand the post via its existing isTextExpanded (Read-more) render. We drive
-  // that state instead of measuring a target height ourselves: lifting the clamp
-  // to measure mis-reports height badly here because nested <mark>s under
-  // display:block inflate the scrollHeight (~6×), so the old manual revealHeight
-  // overshot. The Read-more layout already renders the natural expanded height
-  // correctly, so reuse it. The parent only auto-collapses what WE auto-expanded;
-  // a manual Read-more is left untouched (see handleAutoReveal in the parent).
+  // ── Fixed-window scroll-to-span ───────────────────────────────────────────
+  // The focus post NEVER changes height or line count on hover — any growth
+  // shoves the layout and reads as instability. While a cross-highlight/filter
+  // is active the clamped box becomes a scrolled window at the SAME height (see
+  // mergedStyle) and this effect scrolls it to the WHOLE span union, snapped to
+  // whole lines. Line-snapping is what makes it robust: the window can only ever
+  // rest on whole-line boundaries, so it never shows a clipped half-line and a
+  // half-line's span can never be mistaken for "already shown" (the semi-visible
+  // = no-scroll bug). Everything is computed from the DOM each time, so there is
+  // no expand/collapse state to race on rapid card-to-card hovers.
+  const scrollMode = active && !isTextExpanded && anyMarkVisuallyActive;
 
-  // EXPAND: when a relevant mark is clipped below the fold, request the bounded reveal.
   useLayoutEffect(() => {
     const el = innerRef.current;
-    // Auto-reveal is a FOCUSED-post affordance: anyMarkVisuallyActive reflects the
-    // focus post's filter/cross-highlight, so non-focused feed posts must not react.
-    if (!el || !active || isTextExpanded || autoRevealed || !anyMarkVisuallyActive || !onAutoReveal) return;
-
-    // Only consider the marks we're actually lighting up: every region the hovered
-    // related card links to (by overlap), else the filter/dwell mark. Avoids
-    // expanding the whole article on every sidebar hover.
+    if (!el) return;
+    if (!scrollMode) {
+      // Rest state: park the window back at the top of the clamp.
+      if (el.scrollTop > 0) el.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
+    // Only the marks we're actually lighting up: every region the hovered
+    // related card links to (by overlap), else the filter/dwell mark.
     let marks: HTMLElement[];
     if (crossActive && hoveredRelations) {
       const rels = hoveredRelations;
@@ -380,57 +376,43 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     } else {
       marks = Array.from(el.querySelectorAll('mark'));
     }
-    if (marks.length === 0) return;
-
-    // A mark whose bottom falls past the clamped box bottom is hidden by the fold.
-    const boxBottom = el.getBoundingClientRect().bottom;
-    const clipped = marks.some((m) => m.getBoundingClientRect().bottom > boxBottom + 1);
-    if (clipped) onAutoReveal(true);
-  }, [html, isTextExpanded, autoRevealed, anyMarkVisuallyActive, crossActive, hoveredRelations, visibleMarkIdx, onAutoReveal, active]);
-
-  // SCROLL-TO-SPAN (D-EXPAND): once the bounded reveal is open, scroll the capped
-  // box so the first relevant mark is visible (one line of context above it). If
-  // the span already fits inside the cap, nothing moves. Layout truth comes from
-  // getBoundingClientRect, so the nested-mark scrollHeight inflation that broke
-  // the old measured reveal doesn't apply here.
-  useLayoutEffect(() => {
-    const el = innerRef.current;
-    if (!el || !active || isTextExpanded || !autoRevealed || !anyMarkVisuallyActive) return;
-    let marks: HTMLElement[];
-    if (crossActive && hoveredRelations) {
-      const rels = hoveredRelations;
-      marks = (Array.from(el.querySelectorAll('mark[data-fs]')) as HTMLElement[]).filter((m) => {
-        const a = parseInt(m.getAttribute('data-fs') || 'NaN', 10);
-        const b = parseInt(m.getAttribute('data-fe') || 'NaN', 10);
-        return rels.some((r) => a < r.focusEnd && r.focusStart < b);
-      });
-    } else if (visibleMarkIdx !== null) {
-      marks = Array.from(el.querySelectorAll(`mark[data-range-id="${visibleMarkIdx}"]`));
-    } else {
-      marks = Array.from(el.querySelectorAll('mark'));
+    // Union of the target marks, as offsets into the scrollable content. Client
+    // rects are the layout truth (immune to the nested-mark scrollHeight
+    // inflation that broke the old measured reveal).
+    const box = el.getBoundingClientRect();
+    let unionTop = Infinity;
+    let unionBottom = -Infinity;
+    for (const m of marks) {
+      const r = m.getBoundingClientRect();
+      if (r.height === 0) continue;
+      unionTop = Math.min(unionTop, el.scrollTop + (r.top - box.top));
+      unionBottom = Math.max(unionBottom, el.scrollTop + (r.bottom - box.top));
     }
-    if (marks.length === 0) return;
-    const target = marks.reduce((top, m) =>
-      m.getBoundingClientRect().top < top.getBoundingClientRect().top ? m : top
-    );
-    const boxRect = el.getBoundingClientRect();
-    const markRect = target.getBoundingClientRect();
-    const fullyVisible = markRect.top >= boxRect.top && markRect.bottom <= boxRect.bottom;
-    if (fullyVisible) return;
-    const top = Math.max(0, el.scrollTop + (markRect.top - boxRect.top) - AUTO_REVEAL_SCROLL_CONTEXT_PX);
-    el.scrollTo({ top, behavior: 'smooth' });
-  }, [autoRevealed, isTextExpanded, anyMarkVisuallyActive, crossActive, hoveredRelations, visibleMarkIdx, active, html]);
+    if (unionTop === Infinity) return;
 
-  // COLLAPSE: when nothing is highlighted anymore, restore the collapsed state —
-  // but only if WE auto-opened it (the parent guards a manual Read-more). Reset
-  // the internal scroll so the next reveal starts from the top of the box.
-  useEffect(() => {
-    if (!anyMarkVisuallyActive && onAutoReveal) {
-      onAutoReveal(false);
-      const el = innerRef.current;
-      if (el) el.scrollTop = 0;
-    }
-  }, [anyMarkVisuallyActive, onAutoReveal]);
+    // The clamp is `1.5em` per line and the box is an integer number of those,
+    // so a scrollTop that is a multiple of the line height keeps whole lines top
+    // AND bottom. Work entirely in line indices to guarantee that.
+    const fontPx = parseFloat(getComputedStyle(el).fontSize) || 16;
+    const lineH = POST_LINE_HEIGHT_EM * fontPx;
+    const linesInBox = Math.max(1, Math.round(el.clientHeight / lineH));
+    const firstLine = Math.floor((unionTop + 1) / lineH); // line the span starts on
+    const lastLine = Math.floor((unionBottom - 1) / lineH); // line the span ends on
+    const unionLines = lastLine - firstLine + 1;
+
+    // Choose the window's top line (line-aligned by construction):
+    //  · union fits → center it, leaving whole-line context above and below.
+    //  · union taller than the window → pin its first line to the top.
+    const topLine =
+      unionLines <= linesInBox
+        ? firstLine - Math.floor((linesInBox - unionLines) / 2)
+        : firstLine;
+    const maxLine = Math.max(0, Math.round((el.scrollHeight - el.clientHeight) / lineH));
+    const target = Math.min(maxLine, Math.max(0, topLine)) * lineH;
+
+    if (Math.abs(target - el.scrollTop) < 1) return; // already at the canonical spot
+    el.scrollTo({ top: target, behavior: 'smooth' });
+  }, [scrollMode, crossActive, hoveredRelations, visibleMarkIdx, html]);
 
   // Spec hover model (CSS-driven via classes — never re-parses the article):
   //  · enter the post       → faint ALL its spans (.fp-hovering on the container)
@@ -707,9 +689,23 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     };
   }, []);
 
-  // Expansion is now owned by the parent's isTextExpanded (Read-more) render —
-  // which already supplies the correct clamp/expanded style via the `style` prop.
-  const mergedStyle = style;
+  // Expansion is owned by the parent's isTextExpanded (Read-more) render, which
+  // supplies the clamp/expanded style via the `style` prop. In scroll mode we
+  // keep the SAME box height (maxHeight from the clamp style is preserved) and
+  // only drop the line-clamp so the full text lays out inside the fixed window;
+  // overflow stays HIDDEN (the effect above scrolls it programmatically), so no
+  // scrollbar pops in and nothing shifts but the text. The rendered height
+  // cannot change. (.postClampedText only styles paragraph margins, so the
+  // class stays on in both modes.)
+  const mergedStyle: React.CSSProperties = scrollMode
+    ? {
+        ...style,
+        display: 'block',
+        WebkitLineClamp: 'unset',
+        textOverflow: 'unset',
+        overflow: 'hidden',
+      }
+    : style;
 
   return (
     <div
@@ -821,11 +817,8 @@ function Post({
   const isActive = activePostId === id;
   const [isExpanded, setIsExpanded] = useState(isActive);
   const [isTextExpanded, setIsTextExpanded] = useState(false);
-  // Bounded auto-reveal (D-EXPAND): capped box + internal scroll-to-span,
-  // driven by the highlight layer; independent of the manual Read-more.
-  const [isAutoRevealed, setIsAutoRevealed] = useState(false);
-  // Mirror for handleAutoReveal so it can read the latest without a stale closure
-  // or impure state-updater (see the note there).
+  // NB: the highlight layer's scroll-to-span is fully self-contained inside
+  // ActiveHighlightedContent (fixed-window mode) — no reveal state lives here.
   const isTextExpandedRef = useRef(isTextExpanded);
   isTextExpandedRef.current = isTextExpanded;
   const [hovered, setHovered] = useState(false);
@@ -1088,19 +1081,6 @@ function Post({
     onStackIconClick(newRelatedStacks, id, adjustedPosition);
   };
 
-  // Auto-reveal (D-EXPAND, bounded): the active post's highlight layer asks us to
-  // open the CAPPED reveal box when a highlighted span sits below the Read-more
-  // fold — a separate state from the manual Read-more, which still fully expands.
-  // setState with a boolean is idempotent, so this stays StrictMode-safe without
-  // ref bookkeeping; a manual Read-more simply wins in the style computation.
-  const handleAutoReveal = useCallback((reveal: boolean) => {
-    if (reveal) {
-      if (!isTextExpandedRef.current) setIsAutoRevealed(true);
-    } else {
-      setIsAutoRevealed(false);
-    }
-  }, []);
-
   // Span clicked on a NON-focused feed post: make this post the focus (scroll it
   // to the viewport centre, which is the active-post criterion, and lock it), then
   // apply the "Responses to" filter. The filter is stashed as pending so it
@@ -1124,9 +1104,6 @@ function Post({
   const handleExpandText = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     event.preventDefault();
-    // User now owns the expanded state; the bounded reveal yields to it (and
-    // will re-open from its effect if a cross-highlight is still active later).
-    setIsAutoRevealed(false);
     setIsTextExpanded(true);
     setIsOverflowing(false);
   };
@@ -1134,7 +1111,6 @@ function Post({
   const handleCollapseText = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     event.preventDefault();
-    setIsAutoRevealed(false);
     setIsTextExpanded(false);
     // isOverflowing will be recalculated by the useEffect on next render
   };
@@ -1287,14 +1263,12 @@ function Post({
           displayText={displayText}
           rawText={text}
           isTextExpanded={isTextExpanded}
-          autoRevealed={isAutoRevealed && !isTextExpanded}
           focusRelations={focusRelations}
           active={isActive}
           onSpanFocusRequest={handleSpanFocusRequest}
           relatedCountForSpans={relatedCountForSpans}
           replyCountForSpans={replyCountForSpans}
-          onAutoReveal={handleAutoReveal}
-          className={isTextExpanded || isAutoRevealed ? undefined : 'postClampedText'}
+          className={isTextExpanded ? undefined : 'postClampedText'}
           style={
             isTextExpanded
               ? {
@@ -1306,20 +1280,10 @@ function Post({
                   lineHeight: '1.5',
                   color: '#011445',
                 }
-              : isAutoRevealed
-              ? {
-                  // Bounded auto-reveal (D-EXPAND): grow to the cap, scroll
-                  // internally to the span — never full height, minimal shove.
-                  display: 'block',
-                  overflowY: 'auto',
-                  overflowX: 'hidden',
-                  textOverflow: 'unset',
-                  maxHeight: AUTO_REVEAL_MAX_HEIGHT,
-                  marginTop: '0px',
-                  lineHeight: '1.5',
-                  color: '#011445',
-                }
               : {
+                  // Clamp. The highlight layer switches this box to an
+                  // internally-scrollable mode AT THIS SAME maxHeight while a
+                  // cross-highlight is active (fixed window — never grows).
                   display: '-webkit-box',
                   WebkitBoxOrient: 'vertical',
                   WebkitLineClamp: clampLines,


### PR DESCRIPTION
Fixes the two focus-post reveal defects reported on `/ChineseEVs` (feed + detail).

## Before
On related-card hover the focus post **grew** from the clamp to a taller cap (jarring, shoves the layout), and the internal scroll targeted only the first mark — so a partially-visible span was treated as "already shown" and didn't scroll, the window could rest mid-line showing a clipped half-line, and that half-line's span was then counted as visible.

## After
- **The box never changes height or line count on hover.** It stays at its clamp size; while a cross-highlight/filter is active it becomes a programmatically-scrolled window at the *same* height (overflow hidden — no scrollbar pops in, nothing shifts but the text). Manual "Read more" is the only way to grow the post.
- **Scroll-to-span is deterministic and line-snapped.** It scrolls to the whole span *union* (not the first mark), computed in whole-line indices so the window can only rest on line boundaries — a clipped half-line can never be shown or mistaken for a fully-visible span. Centers the span when it fits, pins its first line to the top when it's taller than the box, and returns to the top on hover-off. No parent reveal-state remains, so there is no expand/collapse round-trip to race on rapid card-to-card hovers.

## Verification
Instrumented sweep over all 13 related cards on the richest thread: box height constant (240px), every scroll offset a multiple of the 24px line height, the full span union visible on every card, back to top on leave. e2e `#4` rewritten to pin the new contract (fixed height + whole-span visibility + line-alignment + restore-on-leave).

Gates: tsc clean · unit 50/50 · prod build ✅ · e2e 23/23 vs the prod build.

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)