### PR TITLE
Scroll to the largest related passage (multi-passage fix)

### DIFF
--- a/e2e/focus-highlighting.spec.ts
+++ b/e2e/focus-highlighting.spec.ts
@@ -114,7 +114,7 @@ test.describe('Focus-post highlighting', () => {
     expect(ch[0] + ch[1] + ch[2], 'L2 fill should stay pastel/light').toBeGreaterThan(600);
   });
 
-  test('#4 card hover scrolls the FIXED-SIZE focus post to the whole span; height never changes; restores on leave', async ({ page }) => {
+  test('#4 card hover scrolls the FIXED-SIZE post to a whole passage; no half-peek; height never changes; restores on leave', async ({ page }) => {
     await page.goto(DETAIL_URL);
     const focus = page.locator('[data-testid="focus-reveal"]');
     await expect(focus).toBeVisible();
@@ -123,12 +123,13 @@ test.describe('Focus-post highlighting', () => {
     const count = (await page.evaluate(DRIVER)) as number;
     const baselineH = await focus.evaluate((el) => Math.round(el.getBoundingClientRect().height));
 
-    // Union-of-painted-marks visibility: the WHOLE span must be visible when it
-    // fits the box, or pinned to the top of the box when it is taller than the
-    // box. Checking only the first mark is exactly the bug this test pins.
-    // lineAligned pins the no-partial-line guarantee: the window may only rest on
-    // whole-line boundaries, so a clipped half-line can never be shown (nor
-    // mistaken for a fully-visible span).
+    // Per-mark classification against the window. A card can relate to several
+    // passages scattered across the post; a fixed window can't show ones that are
+    // lines apart, so the contract is: at least one painted mark is fully visible
+    // (a passage IS shown), NO painted mark half-peeks at an edge (straddles it —
+    // the "By resorting to…" clip this test pins), and the window rests on a whole
+    // line. A single passage taller than the whole box is the one legitimate
+    // straddle (unavoidable) and is excepted.
     const spanState = () =>
       focus.evaluate((el) => {
         const box = el.getBoundingClientRect();
@@ -136,42 +137,39 @@ test.describe('Focus-post highlighting', () => {
         const painted = (Array.from(el.querySelectorAll('mark[data-fs]')) as HTMLElement[]).filter(
           (m) => m.style.backgroundColor
         );
-        let minTop = Infinity;
-        let maxBottom = -Infinity;
+        let anyFullyIn = false;
+        let straddlers = 0;
         for (const m of painted) {
           const r = m.getBoundingClientRect();
           if (r.height === 0) continue;
-          if (r.top < minTop) minTop = r.top;
-          if (r.bottom > maxBottom) maxBottom = r.bottom;
+          const fullyIn = r.top >= box.top - 1.5 && r.bottom <= box.bottom + 1.5;
+          const fullyOut = r.bottom <= box.top + 1.5 || r.top >= box.bottom - 1.5;
+          if (fullyIn) anyFullyIn = true;
+          else if (!fullyOut && r.height <= box.height + 1) straddlers++; // half-peek (not a too-tall passage)
         }
-        const unionH = maxBottom - minTop;
         return {
           h: Math.round(box.height),
           scrollTop: Math.round(el.scrollTop),
           painted: painted.length,
           lineAligned: Math.abs(el.scrollTop / lineH - Math.round(el.scrollTop / lineH)) < 0.06,
-          spanShown:
-            painted.length > 0 &&
-            (unionH <= el.clientHeight - 2
-              ? minTop >= box.top - 1.5 && maxBottom <= box.bottom + 1.5 // fits → fully visible
-              : minTop >= box.top - 1.5 && minTop <= box.top + lineH), // taller → start pinned to top line
+          shownCleanly: painted.length > 0 && anyFullyIn && straddlers === 0,
         };
       });
 
     let anyScrolled = false;
     for (let i = 0; i < Math.min(count, 10); i++) {
       await page.evaluate((idx: number) => (window as any).__hl.enter(idx, false), i);
-      // Wait for the smooth scroll to SETTLE: the whole span visible AND resting
-      // on a whole-line boundary (mid-animation scrollTop is not line-aligned).
+      // Wait for the smooth scroll to SETTLE: a passage shown cleanly (no
+      // half-peek) AND resting on a whole line (mid-animation isn't line-aligned).
       await expect
         .poll(
           async () => {
             const s = await spanState();
-            return s.spanShown && s.lineAligned;
+            return s.shownCleanly && s.lineAligned;
           },
           {
             timeout: 5000,
-            message: `card ${i}: the full span union must settle, line-aligned, inside the box`,
+            message: `card ${i}: a whole passage must settle line-aligned with no half-peek`,
           }
         )
         .toBe(true);

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -376,36 +376,48 @@ const ActiveHighlightedContent = React.forwardRef<HTMLDivElement, {
     } else {
       marks = Array.from(el.querySelectorAll('mark'));
     }
-    // Union of the target marks, as offsets into the scrollable content. Client
-    // rects are the layout truth (immune to the nested-mark scrollHeight
-    // inflation that broke the old measured reveal).
+    // Target marks as content-offset segments (client rects are the layout
+    // truth, immune to the nested-mark scrollHeight inflation that broke the old
+    // measured reveal), sorted top-to-bottom.
     const box = el.getBoundingClientRect();
-    let unionTop = Infinity;
-    let unionBottom = -Infinity;
-    for (const m of marks) {
-      const r = m.getBoundingClientRect();
-      if (r.height === 0) continue;
-      unionTop = Math.min(unionTop, el.scrollTop + (r.top - box.top));
-      unionBottom = Math.max(unionBottom, el.scrollTop + (r.bottom - box.top));
-    }
-    if (unionTop === Infinity) return;
-
-    // The clamp is `1.5em` per line and the box is an integer number of those,
-    // so a scrollTop that is a multiple of the line height keeps whole lines top
-    // AND bottom. Work entirely in line indices to guarantee that.
     const fontPx = parseFloat(getComputedStyle(el).fontSize) || 16;
     const lineH = POST_LINE_HEIGHT_EM * fontPx;
     const linesInBox = Math.max(1, Math.round(el.clientHeight / lineH));
-    const firstLine = Math.floor((unionTop + 1) / lineH); // line the span starts on
-    const lastLine = Math.floor((unionBottom - 1) / lineH); // line the span ends on
-    const unionLines = lastLine - firstLine + 1;
+    const segs: Array<[number, number]> = [];
+    for (const m of marks) {
+      const r = m.getBoundingClientRect();
+      if (r.height === 0) continue;
+      segs.push([el.scrollTop + (r.top - box.top), el.scrollTop + (r.bottom - box.top)]);
+    }
+    if (segs.length === 0) return;
+    segs.sort((a, b) => a[0] - b[0]);
 
-    // Choose the window's top line (line-aligned by construction):
-    //  · union fits → center it, leaving whole-line context above and below.
-    //  · union taller than the window → pin its first line to the top.
+    // A card can relate to several passages scattered across the post; no fixed
+    // window can show passages that are lines apart. Merge the marks into
+    // contiguous passages (a gap under ~0.6 line = wrapped text of one passage;
+    // a whole blank line between = a separate passage) and scroll to the LARGEST
+    // passage so the most related content shows whole. Centering it pushes the
+    // other passages cleanly past the window edges instead of half-peeking there
+    // (the "By resorting to…" fragment clipped at the bottom).
+    const runs: Array<[number, number]> = [];
+    for (const s of segs) {
+      const last = runs[runs.length - 1];
+      if (last && s[0] - last[1] < lineH * 0.6) last[1] = Math.max(last[1], s[1]);
+      else runs.push([s[0], s[1]]);
+    }
+    let run = runs[0];
+    for (const r of runs) if (r[1] - r[0] > run[1] - run[0]) run = r;
+
+    // Line indices → the window can only ever rest on whole-line boundaries, so
+    // it never shows a clipped half-line (top or bottom).
+    const firstLine = Math.floor((run[0] + 1) / lineH); // line the passage starts on
+    const lastLine = Math.floor((run[1] - 1) / lineH); // line the passage ends on
+    const runLines = lastLine - firstLine + 1;
+    //  · passage fits → center it, whole-line context above and below.
+    //  · passage alone taller than the window → pin its first line to the top.
     const topLine =
-      unionLines <= linesInBox
-        ? firstLine - Math.floor((linesInBox - unionLines) / 2)
+      runLines <= linesInBox
+        ? firstLine - Math.floor((linesInBox - runLines) / 2)
         : firstLine;
     const maxLine = Math.max(0, Math.round((el.scrollHeight - el.clientHeight) / lineH));
     const target = Math.min(maxLine, Math.max(0, topLine)) * lineH;


### PR DESCRIPTION
Follow-up to #185. On the feed, related cards that relate to **multiple passages** scattered across the focus post (e.g. one span on line 3 and another on line 11 — a 9-line union) still read as "didn't fully scroll": the earlier fix pinned the union's first line to the top, which shows the first passage and leaves a later one **half-peeking** at the bottom edge (the "By resorting to…" fragment in the report).

## Fix
No fixed window can show passages that are lines apart. So instead of targeting the whole union, group the marks into contiguous **passages** (a sub-line gap = wrapped text of one passage; a whole blank line = a separate passage) and scroll to show the **largest passage** whole, centered and line-snapped. Centering the target passage pushes the others cleanly past the window edges, so nothing half-peeks.

## Verification
Instrumented sweep over the feed's related cards, including the 9- and 12-line-union cards: box height constant (120px), every scroll offset line-aligned, a passage always fully shown, and **zero straddling marks** (no half-peek) on every card. Screenshot confirms the largest passage rendered as five whole lines with the other passage off-screen. e2e `#4` rewritten to pin the new contract — a whole passage shown, line-aligned, and no mark straddling a window edge.

Gates: tsc clean · unit 50/50 · prod build ✅ · e2e 23/23 vs the prod build.

Relates to #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)