### PR TITLE
Build extensible demo data and reconnect Mastodon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
-# Mastodon OAuth application credentials.
-# Register an app on your Mastodon instance (Preferences -> Development ->
-# New application), redirect URI http://localhost:3000/callback, scopes
-# "read write follow", then copy the values into .env.local.
+# Mastodon OAuth application credentials. The secret is server-only; never use
+# a NEXT_PUBLIC_ prefix for it. Register http://localhost:3000/callback (and the
+# production /callback URL) with scopes "read write follow".
 NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_ID=your_client_id_here
-NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_SECRET=your_client_secret_here
+MASTODON_OAUTH_CLIENT_SECRET=your_client_secret_here
+NEXT_PUBLIC_MASTODON_INSTANCE_URL=https://beta.stacky.social
+NEXT_PUBLIC_RELATED_POSTS_API_URL=https://beta.stacky.social:3002
+
+# Optional canonical origin for OAuth redirects behind a reverse proxy.
+# APP_URL=http://localhost:3000
 
 # "development" -> app base URL is http://localhost:3000 (see src/utils/DevMode.tsx)
 NEXT_PUBLIC_MODE=development

--- a/BACKEND_INTEGRATION_AND_STUDY_PLAN.md
+++ b/BACKEND_INTEGRATION_AND_STUDY_PLAN.md
@@ -1,0 +1,196 @@
+# Backend integration and user-study plan
+
+This is a planning artifact only. No changes have been made to the Mastodon fork.
+
+## What exists today
+
+The frontend now consumes the `/ChineseEVs` fixture through a typed, cursor-paginated
+API boundary. The bundled `/api/demo` route simulates latency and backend enrichment;
+`src/services/demoApiClient.ts` is the seam a live adapter can replace.
+
+The server repository is cloned at `/Users/tarikmetin/Desktop/DevWork/server`.
+Its branches have materially different roles:
+
+- `main` is essentially upstream Mastodon 4.3-alpha and has no Stacky related-post API.
+- `dev` contains the Stacky injection work and is the branch to inventory before any
+  migration. It is also substantially behind/diverged from `main`, so it should not
+  be merged blindly.
+- `prod` contains an older production snapshot.
+- `tom-data-injection` is an earlier checkpoint of the injection work.
+
+The `dev` branch already exposes standard Mastodon OAuth and status APIs for login,
+timelines, posting, replies, favourites, bookmarks, and status context. It also has
+custom `/inject-data/*` routes that create external accounts/posts through ActivityPub
+internals, tag injected statuses, suppress outgoing federation for injected objects,
+and maintain a synthetic favourite count.
+
+Important gaps in that custom path:
+
+- Access is restricted by a hard-coded IP address and the controller still contains
+  an authentication TODO. It should use a scoped service credential, not network
+  location as identity.
+- The `modify` action is a dry run.
+- Request bodies and debug details are printed to logs.
+- The create/delete pipeline bypasses several normal remote verification checks.
+- The Mastodon post service calls the curate service synchronously at a hard-coded
+  `https://beta.stacky.social:3002` URL and does not define robust timeouts/retries.
+- Related-stack reads are not implemented in this repository; port `3002` is a
+  separate curate/index service that must be inventoried independently.
+
+## Recommended target boundary
+
+Keep Mastodon as the source of truth for identity, original posts, thread hierarchy,
+and user actions. Keep relation/LLM output in a separate enrichment service. Do not
+rewrite the canonical Mastodon status body.
+
+| Frontend need | Live source | Notes |
+|---|---|---|
+| Login/current user | Mastodon OAuth + `verify_credentials` | Prefer authorization-code + PKCE/BFF; never ship a client secret in `NEXT_PUBLIC_*`. |
+| Home/tag feeds | Mastodon timeline endpoints | Preserve Mastodon's `Link` cursor headers and normalize them in the client adapter. |
+| Full post | Mastodon status endpoint | Canonical, unmodified content. |
+| Ancestors/descendants | Mastodon status context endpoint | Already returns both collections. |
+| Post/reply | Mastodon status create endpoint | Use an idempotency key for retries. |
+| Like/bookmark | Mastodon favourite/bookmark endpoints | Keep the existing optimistic UI and revert on failure. |
+| Related posts | Enrichment service | Cursor page keyed by canonical Mastodon status IDs. Empty results are a normal success. |
+| Contextual AI edit | Enrichment service | Return edit text, reason, provenance/version, and original-content hash; never overwrite the status. |
+
+A proposed related-post response shape:
+
+```json
+{
+  "items": [
+    {
+      "status": {},
+      "relations": [],
+      "contextual_edit": {
+        "content": "...",
+        "reason": "Makes the evidence-to-claim connection explicit.",
+        "model": "...",
+        "version": 1,
+        "source_content_hash": "..."
+      }
+    }
+  ],
+  "next_cursor": "opaque-token-or-null",
+  "has_more": true
+}
+```
+
+The enrichment endpoint should return HTTP 200 with `items: []` when no related posts
+exist. The UI should retain the selected focus post and show the existing calm empty
+state, not hide the panel or report an error.
+
+## Migration sequence
+
+1. **Establish a reproducible server baseline.** Record the deployed commit and
+   database schema, compare `dev` with `prod`, then rebase the small Stacky-specific
+   changes onto a supported Mastodon release in isolated commits. Add request specs
+   before changing behavior.
+2. **Connect standard Mastodon capabilities first.** Implement a live adapter behind
+   the same frontend service interface used by the simulator. Wire OAuth/current user,
+   tag/home timelines, status/context, create/reply, favourite, and bookmark. Run the
+   demo and live adapters in parallel behind a flag until their normalized entities
+   pass the same contract tests.
+3. **Harden curated import.** Replace `/inject-data/*` with a versioned internal API,
+   scoped service tokens, JSON-schema validation, idempotency keys, audit records, and
+   Sidekiq jobs. Provide validate/dry-run, import-status, retry, and delete/rollback
+   operations. Remove parameter logging and hard-coded caller IPs.
+4. **Import `#ChineseEVs` topologically.** Create/resolve authors first, import root
+   statuses, then replies in parent-before-child order. Persist a mapping from fixture
+   IDs/source URIs to Mastodon status IDs. Apply the public `ChineseEVs` tag separately
+   from private provenance tags. Re-run the import to prove idempotency.
+5. **Connect enrichment.** Index status create/update/delete asynchronously using an
+   outbox/job pattern. Add cursor-paginated related reads. Store relations and
+   contextual edits against canonical status IDs and an original-content hash so a
+   stale edit is never shown after the source changes.
+6. **Exercise merge scenarios.** Cover zero, one, ten, and hundreds of related posts;
+   deleted/private/muted related statuses; missing topics; stale enrichments; failed
+   enrichment calls; and mixed injected/user-created conversations.
+7. **Release progressively.** Internal seed users, then study participants, then a
+   small production cohort. Track latency/error budgets separately for Mastodon and
+   enrichment so related-post failures never block ordinary social actions.
+
+## Curated import checklist
+
+- Confirm the source and reuse rights for every post and avatar.
+- Decide whether imported authors represent real identities, pseudonymous study
+  identities, or clearly labeled synthetic accounts.
+- Use stable source URIs and a unique `(source, external_id)` constraint.
+- Preserve original timestamps and reply relationships.
+- Sanitize HTML through Mastodon's normal formatting path.
+- Keep injected/synthetic engagement separate from real user engagement in storage;
+  decide explicitly whether the UI shows a combined or split count.
+- Make import deletion reversible and auditable.
+- Ensure injected objects cannot federate unless that is an explicit product decision.
+
+## Formative usability study
+
+### Questions
+
+1. Can people understand why a related post is relevant without coaching?
+2. Does the “Modified by AI” disclosure increase comprehension without implying that
+   the original author wrote the added words?
+3. Can people distinguish the compact contextual edit from the canonical full post?
+4. Do pagination, loading, and empty-related states feel responsive and trustworthy?
+5. Can people complete ordinary social tasks (login, post, reply, like, bookmark) while
+   using related-post exploration?
+
+### Suggested design
+
+Run a formative, moderated study with 12–18 participants split between frequent social
+media users and people who regularly read long discussion threads. Counterbalance two
+conditions:
+
+- **A:** related highlighting with original text only;
+- **B:** related highlighting plus the contextual AI disclosure and track changes.
+
+Use the same posts but rotate task order. Do not compare an obviously polished
+condition with a broken control; both must include identical navigation and latency.
+
+### Tasks
+
+1. Sign in and find the `#ChineseEVs` discussion.
+2. Explain the focus post's main claim in one sentence.
+3. Choose a related post and explain why it is connected.
+4. Inspect a “Modified by AI” disclosure and identify which words came from the
+   original author versus the AI.
+5. Open that post full screen, find an ancestor and a descendant, then return.
+6. Like and bookmark a post, write a reply, and verify each action persists.
+7. Continue to later feed/related pages.
+8. Select a post with no related results and say what they expect to happen next.
+
+### Measures
+
+- Task completion and critical errors.
+- Time to first meaningful feed content and time to identify a relevant response.
+- Relation-comprehension accuracy, scored blind from the participant's explanation.
+- AI provenance comprehension: “Who wrote the green text?” and “Was the original post
+  changed?”
+- Trust/confidence after each condition (7-point scale).
+- Perceived speed after initial load and pagination (7-point scale).
+- UMUX-Lite or SUS at the end, plus a short preference interview.
+
+Instrument only study-relevant events: timeline page requested/rendered, related panel
+opened, empty panel shown, AI badge hover/focus/click, diff visible duration, related
+post opened, full-post back navigation, like/bookmark/reply attempt/result, and request
+latency/error. Use random study IDs; do not record post drafts or free-form content
+without explicit consent.
+
+### Pilot acceptance checks
+
+- At least 80% correctly identify AI-added versus original wording.
+- At least 80% successfully open a related post and return to the same panel state.
+- Zero participants interpret an empty related panel as a crash.
+- No pagination duplicates or omissions in a scripted 100-item fixture.
+- Optimistic actions reconcile correctly under 300 ms, 1.5 s, and failed requests.
+- Keyboard-only participants can reveal and dismiss the diff and retain visible focus.
+
+## Decisions needed before backend implementation
+
+- Which server branch/commit is actually deployed at `beta.stacky.social`?
+- Where is the curate/index service that owns port `3002`?
+- Should contextual edits be generated at ingestion time or on demand, and who approves
+  them before study use?
+- Are imported counts meant to simulate historical engagement or remain visibly
+  separate from real engagement?
+- What retention/consent policy applies to study telemetry and participant replies?

--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ pnpm install
 pnpm dev
 ```
 
-Then open <http://localhost:3000/ChineseEVs>. The feed, its post-detail pages,
-and the related-posts panel render entirely from local mock JSON
-(`src/app/FakeData/listy-injection.json`). Likes, bookmarks, and replies all
-work and persist locally in your browser via localStorage — nothing leaves
-your machine.
+Then open <http://localhost:3000/ChineseEVs>. The feed calls a bundled simulated
+backend (`/api/demo`) that serves cursor-paginated data from the local fixture
+with realistic latency. Likes, bookmarks, and replies all work and persist
+locally in your browser via localStorage — nothing leaves your machine.
 
 ## Prerequisites
 
@@ -54,7 +53,7 @@ reply-sort, thread-filter, reply-relations, and experiment-flag helpers.
 
 ## Connecting a live Mastodon-compatible backend (optional)
 
-Most of the app runs fully offline: the `/ChineseEVs` demo plus the `/home`,
+Most of the app runs fully offline: the `/ChineseEVs` simulated API plus the `/home`,
 `/search`, `/user`, `/bookmarks`, and `/liked` feeds are backed by a local
 store in your browser's localStorage. Only the legacy live-mode surfaces
 (`/posts/[id]`, `/tag`, `/oldversion`, `/explore`, `/annotation`) call the
@@ -107,6 +106,10 @@ Five terms recur throughout the UI, the docs, and the code:
   ratio slider) and its `@aside` parallel route for the related-posts panel.
 - `src/components/` — Reusable UI components (posts, related-posts panel,
   navigation, etc.).
+- `src/services/` — Typed frontend API clients. `demoApiClient.ts` is the swap
+  boundary between the bundled simulated route and a future live service.
+- `src/app/api/demo/` — Simulated backend handlers with delay, cursor pagination,
+  and backend-shaped AI enrichment metadata.
 - `src/utils/` — Helpers (Mastodon actions, the localStorage-backed store,
   experiment flags, dev-mode base URL, and more).
 - `src/app/FakeData/` — Local mock data used by the demo and the e2e tests.

--- a/e2e/callback.spec.ts
+++ b/e2e/callback.spec.ts
@@ -14,4 +14,38 @@ test.describe('OAuth callback', () => {
     await expect(backLink).toBeVisible();
     await expect(backLink).toHaveAttribute('href', '/');
   });
+
+  test('stores only the returned user session and continues to the real home timeline', async ({ page }) => {
+    await page.route('**/api/auth/mastodon/callback', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        accessToken: 'test-access-token',
+        account: {
+          id: 'account-1',
+          username: 'river',
+          acct: 'river',
+          display_name: 'River Chen',
+          avatar: '/avatar/stacky_default.PNG',
+        },
+        instance: 'https://beta.stacky.social',
+      }),
+    }));
+    await page.route('https://beta.stacky.social/api/v1/timelines/home**', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    }));
+
+    await page.goto('/callback?code=test-code&state=test-state');
+    await expect(page).toHaveURL(/\/home$/);
+    const session = await page.evaluate(() => ({
+      token: localStorage.getItem('accessToken'),
+      account: JSON.parse(localStorage.getItem('currentUser') || 'null'),
+      instance: localStorage.getItem('mastodonInstance'),
+    }));
+    expect(session.token).toBe('test-access-token');
+    expect(session.account.acct).toBe('river');
+    expect(session.instance).toBe('https://beta.stacky.social');
+  });
 });

--- a/e2e/chineseevs-feed.spec.ts
+++ b/e2e/chineseevs-feed.spec.ts
@@ -41,27 +41,36 @@ test.describe('ChineseEVs feed', () => {
     await expect(page.getByRole('button', { name: 'Bookmark' }).first()).toBeVisible();
   });
 
-  test('explains contextual AI edits with track-changes markup only in the related panel', async ({ page }) => {
+  test('shows contextual AI edits in place without resizing the related card', async ({ page }) => {
     await page.goto('/ChineseEVs');
 
     const aside = page.getByTestId('col-aside');
     const badge = aside.getByRole('button', { name: 'Modified by AI' }).first();
     await expect(badge).toBeVisible();
+    const card = badge.locator('xpath=ancestor::*[@data-post-id][1]');
+    const beforeHover = await card.boundingBox();
+    const inlineDiff = card.locator('[data-ai-inline-diff]');
+    await expect(inlineDiff).toHaveAttribute('aria-hidden', 'true');
+
     await badge.hover();
 
-    const disclosure = aside.getByRole('note', { name: 'Changes made by AI' });
-    await expect(disclosure).toBeVisible();
-    await expect(disclosure.locator('del').first()).toBeVisible();
-    await expect(disclosure.locator('ins').first()).toBeVisible();
-    await expect(disclosure).toContainText('original post is preserved');
+    await expect(aside.getByRole('note')).toHaveCount(0);
+    await expect(inlineDiff).toHaveAttribute('aria-hidden', 'false');
+    await expect(inlineDiff.locator('del').first()).toBeVisible();
+    await expect(inlineDiff.locator('ins').first()).toBeVisible();
+    const afterHover = await card.boundingBox();
+    expect(beforeHover).not.toBeNull();
+    expect(afterHover).not.toBeNull();
+    expect(afterHover!.width).toBeCloseTo(beforeHover!.width, 2);
+    expect(afterHover!.height).toBeCloseTo(beforeHover!.height, 2);
 
-    // Keyboard users get the same explanation and can dismiss it predictably.
+    // Keyboard users get the same in-card treatment and can dismiss it.
     await page.keyboard.press('Escape');
-    await expect(disclosure).toBeHidden();
+    await expect(inlineDiff).toHaveAttribute('aria-hidden', 'true');
     await badge.focus();
-    await expect(disclosure).toBeVisible();
+    await expect(inlineDiff).toHaveAttribute('aria-hidden', 'false');
     await page.keyboard.press('Escape');
-    await expect(disclosure).toBeHidden();
+    await expect(inlineDiff).toHaveAttribute('aria-hidden', 'true');
 
     // Full post content remains an ordinary post; AI provenance belongs only
     // to compact related cards where the missing context needs explanation.

--- a/e2e/chineseevs-feed.spec.ts
+++ b/e2e/chineseevs-feed.spec.ts
@@ -49,9 +49,12 @@ test.describe('ChineseEVs feed', () => {
     await expect(badge).toBeVisible();
     const card = badge.locator('xpath=ancestor::*[@data-post-id][1]');
     const beforeHover = await card.boundingBox();
-    const originalText = card.locator('.ai-edit-original-text');
+    const editedText = card.locator('[data-ai-edited-default]');
     const inlineDiff = card.locator('[data-ai-inline-diff]');
-    const originalContentHeight = await originalText.evaluate((element) => {
+    const insertedText = (await inlineDiff.locator('ins').first().innerText()).trim();
+    await expect(editedText).toContainText(insertedText);
+    await expect(editedText).toHaveAttribute('aria-hidden', 'false');
+    const editedContentHeight = await editedText.evaluate((element) => {
       const range = document.createRange();
       range.selectNodeContents(element);
       return range.getBoundingClientRect().height;
@@ -61,6 +64,7 @@ test.describe('ChineseEVs feed', () => {
     await badge.hover();
 
     await expect(aside.getByRole('note')).toHaveCount(0);
+    await expect(editedText).toHaveAttribute('aria-hidden', 'true');
     await expect(inlineDiff).toHaveAttribute('aria-hidden', 'false');
     await expect(inlineDiff.locator('del').first()).toBeVisible();
     await expect(inlineDiff.locator('ins').first()).toBeVisible();
@@ -74,11 +78,12 @@ test.describe('ChineseEVs feed', () => {
     expect(afterHover).not.toBeNull();
     expect(afterHover!.width).toBeCloseTo(beforeHover!.width, 2);
     expect(afterHover!.height).toBeCloseTo(beforeHover!.height, 2);
-    expect(diffContentHeight).toBeGreaterThanOrEqual(originalContentHeight - 1);
+    expect(diffContentHeight).toBeGreaterThanOrEqual(editedContentHeight - 1);
 
     // Keyboard users get the same in-card treatment and can dismiss it.
     await page.keyboard.press('Escape');
     await expect(inlineDiff).toHaveAttribute('aria-hidden', 'true');
+    await expect(editedText).toHaveAttribute('aria-hidden', 'false');
     await badge.focus();
     await expect(inlineDiff).toHaveAttribute('aria-hidden', 'false');
     await page.keyboard.press('Escape');

--- a/e2e/chineseevs-feed.spec.ts
+++ b/e2e/chineseevs-feed.spec.ts
@@ -1,17 +1,25 @@
 import { test, expect } from '@playwright/test';
 import mockData from '../src/app/FakeData/listy-injection.json';
 
-// The research feed at /ChineseEVs is rendered entirely from local mock
-// JSON — no backend needed. Its detail route /ChineseEVs/posts/[id]
-// mirrors a single post. (The fixture keeps its historical filename
-// listy-injection.json; the route was renamed /listy-injection -> /ChineseEVs.)
+// The research feed at /ChineseEVs calls a simulated backend route backed by
+// the local fixture, so no external server is needed. Its detail route
+// /ChineseEVs/posts/[id] mirrors a single post.
 
 // First focus-post id from the mock data, used by the detail-view test.
 const firstFocusId = (mockData as any)[0].focusPost.id as string;
 
 test.describe('ChineseEVs feed', () => {
   test('renders the hashtag header, stats, post cards and interactions', async ({ page }) => {
+    const firstPageResponse = page.waitForResponse((response) =>
+      response.url().includes('/api/demo/timelines/chinese-evs') && response.status() === 200
+    );
     await page.goto('/ChineseEVs');
+    const firstPage = await (await firstPageResponse).json();
+
+    // The simulated backend returns a bounded cursor page, not the whole fixture.
+    expect(firstPage.items).toHaveLength(2);
+    expect(firstPage.nextCursor).toBeTruthy();
+    expect(firstPage.stats.posts).toBeGreaterThan(2);
 
     // Hashtag header + stat labels.
     await expect(page.getByText('#ChineseEVs')).toBeVisible();
@@ -21,7 +29,8 @@ test.describe('ChineseEVs feed', () => {
 
     // At least 2 post cards.
     const cards = page.locator('[data-post-id]');
-    expect(await cards.count()).toBeGreaterThanOrEqual(2);
+    await expect(cards.first()).toBeVisible();
+    await expect(cards.nth(1)).toBeVisible();
 
     // "Read more" affordance (collapsed posts) — present on at least one card.
     await expect(page.getByText('Read more').first()).toBeVisible();
@@ -30,6 +39,34 @@ test.describe('ChineseEVs feed', () => {
     await expect(page.getByRole('button', { name: 'Reply' }).first()).toBeVisible();
     await expect(page.getByRole('button', { name: 'Like' }).first()).toBeVisible();
     await expect(page.getByRole('button', { name: 'Bookmark' }).first()).toBeVisible();
+  });
+
+  test('explains contextual AI edits with track-changes markup only in the related panel', async ({ page }) => {
+    await page.goto('/ChineseEVs');
+
+    const aside = page.getByTestId('col-aside');
+    const badge = aside.getByRole('button', { name: 'Modified by AI' }).first();
+    await expect(badge).toBeVisible();
+    await badge.hover();
+
+    const disclosure = aside.getByRole('note', { name: 'Changes made by AI' });
+    await expect(disclosure).toBeVisible();
+    await expect(disclosure.locator('del').first()).toBeVisible();
+    await expect(disclosure.locator('ins').first()).toBeVisible();
+    await expect(disclosure).toContainText('original post is preserved');
+
+    // Keyboard users get the same explanation and can dismiss it predictably.
+    await page.keyboard.press('Escape');
+    await expect(disclosure).toBeHidden();
+    await badge.focus();
+    await expect(disclosure).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(disclosure).toBeHidden();
+
+    // Full post content remains an ordinary post; AI provenance belongs only
+    // to compact related cards where the missing context needs explanation.
+    await page.goto('/ChineseEVs/posts/149288649?from=143195604');
+    await expect(page.getByTestId('feed').locator('[data-ai-edit]')).toHaveCount(0);
   });
 
   test('opens a post detail view without an error boundary', async ({ page }) => {

--- a/e2e/chineseevs-feed.spec.ts
+++ b/e2e/chineseevs-feed.spec.ts
@@ -49,7 +49,13 @@ test.describe('ChineseEVs feed', () => {
     await expect(badge).toBeVisible();
     const card = badge.locator('xpath=ancestor::*[@data-post-id][1]');
     const beforeHover = await card.boundingBox();
+    const originalText = card.locator('.ai-edit-original-text');
     const inlineDiff = card.locator('[data-ai-inline-diff]');
+    const originalContentHeight = await originalText.evaluate((element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      return range.getBoundingClientRect().height;
+    });
     await expect(inlineDiff).toHaveAttribute('aria-hidden', 'true');
 
     await badge.hover();
@@ -58,11 +64,17 @@ test.describe('ChineseEVs feed', () => {
     await expect(inlineDiff).toHaveAttribute('aria-hidden', 'false');
     await expect(inlineDiff.locator('del').first()).toBeVisible();
     await expect(inlineDiff.locator('ins').first()).toBeVisible();
+    const diffContentHeight = await inlineDiff.evaluate((element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      return range.getBoundingClientRect().height;
+    });
     const afterHover = await card.boundingBox();
     expect(beforeHover).not.toBeNull();
     expect(afterHover).not.toBeNull();
     expect(afterHover!.width).toBeCloseTo(beforeHover!.width, 2);
     expect(afterHover!.height).toBeCloseTo(beforeHover!.height, 2);
+    expect(diffContentHeight).toBeGreaterThanOrEqual(originalContentHeight - 1);
 
     // Keyboard users get the same in-card treatment and can dismiss it.
     await page.keyboard.press('Escape');

--- a/e2e/home-feed.spec.ts
+++ b/e2e/home-feed.spec.ts
@@ -16,11 +16,53 @@ test.describe('Home timeline', () => {
   });
 
   test('shows real related responses and AI edits for an annotated focus post', async ({ page }) => {
+    // An existing participant may have the older, addition-only enrichment in
+    // localStorage. Read-only demo annotations should refresh without resetting
+    // their likes, bookmarks, follows, or authored posts.
+    await page.evaluate(() => {
+      const key = 'stacky:localStore:v1';
+      const state = JSON.parse(localStorage.getItem(key) || 'null');
+      const stacks = state?.posts?.['152053690']?.relatedStacks;
+      const michael = stacks?.find((stack: any) => stack.topPost?.id === '143196877');
+      if (michael) {
+        michael.topPost.rewrite = {
+          content: "To connect China's battery-factory lead with supply-chain practice, I work in sustainability for a leading European global brand that has 1000+ suppliers across the world.",
+          significant: true,
+          editSummary: 'Stale addition-only demo rewrite.',
+        };
+        localStorage.setItem(key, JSON.stringify(state));
+      }
+    });
+    await page.reload();
+
     const focus = page.locator('[data-store-feed-post="152053690"]');
     await focus.evaluate((element) => element.scrollIntoView({ block: 'center' }));
     await expect(focus.getByTestId('post')).toHaveAttribute('data-active', 'true');
     await expect(page.locator('[data-related-card]')).toHaveCount(10);
-    await expect(page.getByRole('button', { name: 'Modified by AI' }).first()).toBeVisible();
+
+    const michaelCard = page.locator('[data-post-id="143196877"]');
+    const badge = michaelCard.getByRole('button', { name: 'Modified by AI' });
+    const editedText = michaelCard.locator('[data-ai-edited-default]');
+    const inlineDiff = michaelCard.locator('[data-ai-inline-diff]');
+    await expect(badge).toBeVisible();
+    await expect(editedText).toContainText('I work on sustainability for a major European brand');
+    await expect(inlineDiff).toHaveAttribute('aria-hidden', 'true');
+    const beforeHover = await michaelCard.boundingBox();
+
+    await badge.hover();
+
+    await expect(inlineDiff).toHaveAttribute('aria-hidden', 'false');
+    const deletedText = (await inlineDiff.locator('del').allTextContents()).join('');
+    const insertedText = (await inlineDiff.locator('ins').allTextContents()).join('');
+    expect(deletedText).toContain('in');
+    expect(deletedText).toContain('leading');
+    expect(deletedText).toContain('global');
+    expect(insertedText).toContain("To connect China's battery-factory lead");
+    expect(insertedText).toContain('on');
+    expect(insertedText).toContain('major');
+    const afterHover = await michaelCard.boundingBox();
+    expect(afterHover?.width).toBeCloseTo(beforeHover!.width, 2);
+    expect(afterHover?.height).toBeCloseTo(beforeHover!.height, 2);
   });
 
   test('keeps the right column blank and the feed width stable for a post with no relations', async ({ page }) => {

--- a/e2e/home-feed.spec.ts
+++ b/e2e/home-feed.spec.ts
@@ -13,6 +13,26 @@ test.describe('Home timeline', () => {
     await expect(
       page.locator('[data-store-feed-post="152052643"]').getByText('Replying to @totem'),
     ).toBeVisible();
+    // Ana's source count is 20 even though this curated demo only includes four
+    // thread descendants and 103 separately-related posts. Neither collection
+    // is added to the visible reply counter.
+    await expect(
+      page.locator('[data-store-feed-post="152053690"]').getByRole('button', { name: 'Reply' }),
+    ).toContainText('20');
+  });
+
+  test('repairs a stale persisted reply count from the authoritative seed', async ({ page }) => {
+    await page.evaluate(() => {
+      const key = 'stacky:localStore:v1';
+      const state = JSON.parse(localStorage.getItem(key) || 'null');
+      state.posts['152053690'].replies_count = 123;
+      localStorage.setItem(key, JSON.stringify(state));
+    });
+    await page.reload();
+
+    await expect(
+      page.locator('[data-store-feed-post="152053690"]').getByRole('button', { name: 'Reply' }),
+    ).toContainText('20');
   });
 
   test('shows real related responses and AI edits for an annotated focus post', async ({ page }) => {

--- a/e2e/home-feed.spec.ts
+++ b/e2e/home-feed.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Home timeline', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/home');
+    await expect(page.getByRole('heading', { name: 'Home', level: 1 })).toBeVisible();
+  });
+
+  test('renders a structured starter timeline with reply provenance', async ({ page }) => {
+    await expect(page.locator('[data-store-feed-post]')).toHaveCount(6);
+    await expect(page.getByText('Curated and followed conversations')).toBeVisible();
+    await expect(page.getByTestId('reply-context')).toHaveCount(3);
+    await expect(
+      page.locator('[data-store-feed-post="152052643"]').getByText('Replying to @totem'),
+    ).toBeVisible();
+  });
+
+  test('shows real related responses and AI edits for an annotated focus post', async ({ page }) => {
+    const focus = page.locator('[data-store-feed-post="152053690"]');
+    await focus.evaluate((element) => element.scrollIntoView({ block: 'center' }));
+    await expect(focus.getByTestId('post')).toHaveAttribute('data-active', 'true');
+    await expect(page.locator('[data-related-card]')).toHaveCount(10);
+    await expect(page.getByRole('button', { name: 'Modified by AI' }).first()).toBeVisible();
+  });
+
+  test('keeps the right column blank and the feed width stable for a post with no relations', async ({ page }) => {
+    const focus = page.locator('[data-store-feed-post="152053690"]');
+    await focus.evaluate((element) => element.scrollIntoView({ block: 'center' }));
+    await expect(page.locator('[data-related-card]').first()).toBeVisible();
+    const feedWidthWithRelations = (await page.getByTestId('feed').boundingBox())?.width;
+
+    const ordinaryReply = page.locator('[data-store-feed-post="152052643"]');
+    await ordinaryReply.evaluate((element) => element.scrollIntoView({ block: 'center' }));
+    await expect(ordinaryReply.getByTestId('post')).toHaveAttribute('data-active', 'true');
+    await expect(page.locator('[data-related-card]')).toHaveCount(0);
+    await expect(page.getByTestId('home-related-empty')).toBeAttached();
+    await expect(page.getByText('No related responses for this post.')).toHaveCount(0);
+
+    const feedWidthWithoutRelations = (await page.getByTestId('feed').boundingBox())?.width;
+    expect(feedWidthWithRelations).toBeDefined();
+    expect(feedWidthWithoutRelations).toBeCloseTo(feedWidthWithRelations!, 2);
+  });
+
+  test('uses the full reading width and hides the desktop related column on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Home', level: 1 })).toBeVisible();
+
+    const feedBox = await page.getByTestId('feed').boundingBox();
+    expect(feedBox?.width).toBeGreaterThan(340);
+    await expect(page.getByTestId('col-aside')).toBeHidden();
+  });
+});

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,57 +1,35 @@
 import { test, expect } from '@playwright/test';
 
-// Study Mode is the primary participant entry; Mastodon OAuth remains available
-// as the visually-secondary production login path.
 test.describe('Landing page', () => {
-  test('renders the primary study entry, secondary login, and branding', async ({ page }) => {
+  test('makes real account access primary and the JSON demo explicit', async ({ page }) => {
     await page.goto('/');
 
-    // Headline + subtitle.
-    await expect(page.getByText('Explore CrossWeave')).toBeVisible();
-    await expect(page.getByText('AI-Curated Democratic Discourse')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Start study session' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Follow the conversation. See how ideas connect.' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Sign in to CrossWeave' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
 
-    // Instance input (labelled "Mastodon Instance") + Login button.
-    await expect(page.getByLabel('Mastodon Instance')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Continue with Mastodon' })).toBeVisible();
+    const createAccount = page.getByRole('link', { name: /Create an account/ });
+    await expect(createAccount).toHaveAttribute('href', 'https://beta.stacky.social/auth/sign_up');
+    await expect(page.getByRole('button', { name: /Explore the JSON demo/ })).toBeVisible();
 
-    // Brand lockup: the CrossWeave mark (one inline SVG) + wordmark.
-    await expect(page.getByRole('img', { name: 'CrossWeave logo' })).toHaveCount(1);
     await expect(page.getByText('CrossWeave', { exact: true })).toBeVisible();
+    await expect(page.getByRole('img', { name: 'CrossWeave logo' })).toHaveCount(1);
   });
 
-  test('rejects an invalid instance domain without navigating', async ({ page }) => {
+  test('starts OAuth through the same-origin secure route', async ({ page }) => {
+    await page.route('**/api/auth/mastodon/start', (route) => route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<p>OAuth handoff intercepted</p>',
+    }));
+    const requestPromise = page.waitForRequest('**/api/auth/mastodon/start');
+
     await page.goto('/');
+    await page.getByRole('button', { name: 'Sign in' }).click();
 
-    await page.getByLabel('Mastodon Instance').fill('notadomain');
-    await page.getByRole('button', { name: 'Continue with Mastodon' }).click();
-
-    // Validation message appears (form regex: ^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$).
-    await expect(page.getByText(/valid instance domain/i)).toBeVisible();
-
-    // No navigation occurred — still on "/".
-    expect(new URL(page.url()).pathname).toBe('/');
-  });
-
-  test('a valid instance builds the OAuth authorize URL', async ({ page }) => {
-    await page.goto('/');
-
-    // Block any outbound request to the chosen instance so we don't actually
-    // leave the app — we only want to inspect the URL the form builds.
-    await page.route('https://mastodon.social/**', (route) => route.abort());
-
-    const reqPromise = page.waitForRequest(/\/oauth\/authorize\?/);
-
-    await page.getByLabel('Mastodon Instance').fill('mastodon.social');
-    await page.getByRole('button', { name: 'Continue with Mastodon' }).click();
-
-    const req = await reqPromise;
-    const url = req.url();
-    expect(url).toContain('client_id=');
-    expect(url).toContain('redirect_uri=');
-    expect(url).toContain('response_type=code');
-    expect(url).toContain('scope=');
-    expect(url).toContain('state=mastodon.social');
+    const request = await requestPromise;
+    expect(new URL(request.url()).pathname).toBe('/api/auth/mastodon/start');
+    await expect(page.getByText('OAuth handoff intercepted')).toBeVisible();
   });
 
   test('starts and ends a clean local participant session', async ({ page }) => {
@@ -67,8 +45,9 @@ test.describe('Landing page', () => {
       sessionStorage.setItem('previousPath:/somewhere', '/old');
     });
 
-    await page.getByRole('button', { name: 'Start study session' }).click();
+    await page.getByRole('button', { name: /Explore the JSON demo/ }).click();
     await expect(page).toHaveURL(/\/home$/);
+    await expect(page.locator('[data-feed-mode="json-demo"]')).toBeVisible();
     await expect(page.getByRole('button', { name: 'End study session' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Experiment settings' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Logout' })).toHaveCount(0);
@@ -103,8 +82,6 @@ test.describe('Landing page', () => {
 
     await page.reload();
     await expect(page.getByRole('button', { name: 'End study session' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Experiment settings' })).toHaveCount(0);
-    await expect(page.getByRole('button', { name: 'Logout' })).toHaveCount(0);
 
     await page.getByRole('button', { name: 'End study session' }).click();
     await expect(page).toHaveURL(/\/$/);

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -48,9 +48,9 @@ test.describe('Landing page', () => {
     await page.getByRole('button', { name: /Explore the JSON demo/ }).click();
     await expect(page).toHaveURL(/\/home$/);
     await expect(page.locator('[data-feed-mode="json-demo"]')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'End study session' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Log out' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Experiment settings' })).toHaveCount(0);
-    await expect(page.getByRole('button', { name: 'Logout' })).toHaveCount(0);
+    await expect(page.getByTestId('nav-logout')).toBeVisible();
 
     const active = await page.evaluate(() => {
       const session = JSON.parse(localStorage.getItem('crossweave:studySession:v1') || 'null');
@@ -81,9 +81,9 @@ test.describe('Landing page', () => {
     expect(active.sessionStorageLength).toBe(0);
 
     await page.reload();
-    await expect(page.getByRole('button', { name: 'End study session' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Log out' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'End study session' }).click();
+    await page.getByRole('button', { name: 'Log out' }).click();
     await expect(page).toHaveURL(/\/$/);
     const ended = await page.evaluate(() => ({
       studySession: localStorage.getItem('crossweave:studySession:v1'),

--- a/e2e/mastodon-backend.spec.ts
+++ b/e2e/mastodon-backend.spec.ts
@@ -65,6 +65,23 @@ test.describe('Mastodon-backed client mode', () => {
     expect(authorization).toMatch(/^Bearer backend-token-/);
   });
 
+  test('blends an explicitly followed demo feed into authenticated Home', async ({ page }) => {
+    await page.route('https://beta.stacky.social/api/v1/timelines/home**', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    }));
+
+    await page.goto('/ChineseEVs');
+    await page.getByRole('button', { name: 'Follow demo feed' }).click();
+    await expect(page.getByText('Following demo feed', { exact: true }).first()).toBeVisible();
+
+    await page.goto('/home');
+    await expect(page.locator('[data-feed-mode="mastodon"]')).toBeVisible();
+    await expect(page.locator('[data-feed-origin="demo"]').first()).toBeVisible();
+    await expect(page.getByText('Your Mastodon home timeline is empty.')).toHaveCount(0);
+  });
+
   test('publishes through Mastodon and prepends the canonical returned status', async ({ page }) => {
     await page.route('https://beta.stacky.social/api/v1/timelines/home**', (route) => route.fulfill({
       status: 200,

--- a/e2e/mastodon-backend.spec.ts
+++ b/e2e/mastodon-backend.spec.ts
@@ -79,7 +79,9 @@ test.describe('Mastodon-backed client mode', () => {
     await page.goto('/home');
     await expect(page.locator('[data-feed-mode="mastodon"]')).toBeVisible();
     await expect(page.locator('[data-feed-origin="demo"]').first()).toBeVisible();
+    await expect(page.locator('[data-related-card]').first()).toBeVisible();
     await expect(page.getByText('Your Mastodon home timeline is empty.')).toHaveCount(0);
+    await expect(page.getByRole('main')).toHaveCSS('background-color', 'rgb(252, 251, 245)');
   });
 
   test('publishes through Mastodon and prepends the canonical returned status', async ({ page }) => {

--- a/e2e/mastodon-backend.spec.ts
+++ b/e2e/mastodon-backend.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const account = {
+  id: 'account-1',
+  username: 'river',
+  acct: 'river',
+  display_name: 'River Chen',
+  avatar: '/avatar/stacky_default.PNG',
+};
+
+function status(id: string, content: string) {
+  return {
+    id,
+    content: `<p>${content}</p>`,
+    created_at: '2026-08-05T12:00:00.000Z',
+    account,
+    replies_count: 2,
+    favourites_count: 7,
+    favourited: false,
+    bookmarked: false,
+    media_attachments: [],
+    card: null,
+  };
+}
+
+async function authenticate(page: Page, accessToken: string) {
+  await page.addInitScript(({ account, accessToken }) => {
+    localStorage.setItem('accessToken', accessToken);
+    localStorage.setItem('currentUser', JSON.stringify(account));
+  }, { account, accessToken });
+}
+
+test.describe('Mastodon-backed client mode', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    // The app cache is intentionally module-scoped. A unique user token keeps
+    // each browser contract isolated, just as separate users are in production.
+    await authenticate(page, `backend-token-${testInfo.testId}-${testInfo.retry}`);
+    await page.route('https://beta.stacky.social:3002/stacks/**/related', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ relatedStacks: [], size: 0 }),
+    }));
+    await page.route('https://beta.stacky.social:3002/posts/feedback', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ advice: [], praise: [], simulatedReplies: [] }),
+    }));
+  });
+
+  test('loads the authenticated home timeline with its bearer token instead of JSON fixtures', async ({ page }) => {
+    let authorization = '';
+    await page.route('https://beta.stacky.social/api/v1/timelines/home**', (route) => {
+      authorization = route.request().headers().authorization || '';
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([status('live-1', 'A post returned by the Mastodon home timeline.')]),
+      });
+    });
+
+    await page.goto('/home');
+    await expect(page.locator('[data-feed-mode="mastodon"]')).toBeVisible();
+    await expect(page.getByText('A post returned by the Mastodon home timeline.')).toBeVisible();
+    await expect(page.locator('[data-store-feed-post]')).toHaveCount(0);
+    expect(authorization).toMatch(/^Bearer backend-token-/);
+  });
+
+  test('publishes through Mastodon and prepends the canonical returned status', async ({ page }) => {
+    await page.route('https://beta.stacky.social/api/v1/timelines/home**', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([status('live-1', 'Existing backend post')]),
+    }));
+
+    let requestBody: unknown;
+    let authorization = '';
+    await page.route('https://beta.stacky.social/api/v1/statuses', async (route) => {
+      requestBody = route.request().postDataJSON();
+      authorization = route.request().headers().authorization || '';
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(status('live-2', 'A newly published backend post')),
+      });
+    });
+
+    await page.goto('/home');
+    const composer = page.getByLabel('Create a post');
+    await composer.getByLabel('Post text').fill('A newly published backend post');
+    await composer.getByRole('button', { name: 'Post' }).click();
+
+    await expect(page.getByText('A newly published backend post')).toBeVisible();
+    expect(requestBody).toEqual({ status: 'A newly published backend post' });
+    expect(authorization).toMatch(/^Bearer backend-token-/);
+  });
+
+  test('follows Mastodon Link pagination once and stops at the final page', async ({ page }) => {
+    const requestedMaxIds: Array<string | null> = [];
+    await page.route('https://beta.stacky.social/api/v1/timelines/home**', (route) => {
+      const requestUrl = new URL(route.request().url());
+      const maxId = requestUrl.searchParams.get('max_id');
+      requestedMaxIds.push(maxId);
+      if (maxId) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([status('live-final', 'The final paginated post')]),
+        });
+      }
+      const firstPage = Array.from({ length: 40 }, (_, index) => status(`live-${index + 1}`, `Backend page post ${index + 1}`));
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: {
+          link: '<https://beta.stacky.social/api/v1/timelines/home?max_id=next-page-cursor>; rel="next"',
+          'access-control-expose-headers': 'Link',
+        },
+        body: JSON.stringify(firstPage),
+      });
+    });
+
+    await page.goto('/home');
+    await expect(page.getByText('Backend page post 1')).toBeVisible();
+    const loadMore = page.getByRole('button', { name: 'Load more' });
+    await expect(loadMore).toBeAttached();
+    // Invoke the currently-mounted footer in one page task. Virtuoso may
+    // replace its footer during Playwright's normal scroll-to-action cycle.
+    await page.evaluate(() => {
+      const button = Array.from(document.querySelectorAll('button'))
+        .find((candidate) => candidate.textContent?.includes('Load more'));
+      if (button instanceof HTMLButtonElement && !button.disabled) button.click();
+    });
+    await expect.poll(() => requestedMaxIds.some((cursor) => cursor !== null)).toBe(true);
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await expect(page.getByText('The final paginated post')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Load more' })).toHaveCount(0);
+    expect(requestedMaxIds.some((cursor) => cursor === 'next-page-cursor' || cursor === 'live-40')).toBe(true);
+  });
+
+  test('persists likes and bookmarks through Mastodon in authenticated mode', async ({ page }) => {
+    await page.route('https://beta.stacky.social/api/v1/timelines/home**', (route) => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([status('live-1', 'Backend interaction target')]),
+    }));
+
+    const requests: string[] = [];
+    await page.route('https://beta.stacky.social/api/v1/statuses/live-1/favourite', (route) => {
+      requests.push(`${route.request().method()} ${new URL(route.request().url()).pathname}`);
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ favourited: true }) });
+    });
+    await page.route('https://beta.stacky.social/api/v1/statuses/live-1/bookmark', (route) => {
+      requests.push(`${route.request().method()} ${new URL(route.request().url()).pathname}`);
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ bookmarked: true }) });
+    });
+
+    await page.goto('/home');
+    const postCard = page.locator('[data-post-id="live-1"] [data-testid="post"]').first();
+    await postCard.getByRole('button', { name: 'Like', exact: true }).click();
+    await postCard.getByRole('button', { name: 'Bookmark', exact: true }).click();
+    await expect.poll(() => requests.length).toBe(2);
+    expect(requests).toEqual([
+      'POST /api/v1/statuses/live-1/favourite',
+      'POST /api/v1/statuses/live-1/bookmark',
+    ]);
+  });
+});

--- a/e2e/study-local-flows.spec.ts
+++ b/e2e/study-local-flows.spec.ts
@@ -49,6 +49,24 @@ test.describe('study-mode local flows', () => {
     await expect(page.getByText('Local reply')).toBeVisible();
   });
 
+  test('increments a seeded post reply count once and keeps it after reload', async ({ page }) => {
+    const sourceCount = (mockData as any)[0].focusPost.replies_count as number;
+    await page.goto(`/ChineseEVs/posts/${firstFocusId}`);
+
+    const focusCard = page.locator(`[data-post-id="${firstFocusId}"]`).first();
+    const replyCount = focusCard.getByRole('button', { name: 'Reply' });
+    await expect(replyCount).toContainText(String(sourceCount));
+
+    await page.getByPlaceholder('Post your reply').first().fill('Counted.');
+    await page.getByRole('button', { name: 'Submit' }).first().click();
+    await expect(page.getByText('Reply posted', { exact: true })).toBeVisible();
+    await expect(replyCount).toContainText(String(sourceCount + 1));
+
+    await page.reload();
+    const reloadedFocus = page.locator(`[data-post-id="${firstFocusId}"]`).first();
+    await expect(reloadedFocus.getByRole('button', { name: 'Reply' })).toContainText(String(sourceCount + 1));
+  });
+
   test('like and bookmark confirmations offer working single-step Undo', async ({ page }) => {
     await page.goto(`/ChineseEVs/posts/${firstFocusId}`);
 

--- a/src/app/(shell)/@aside/home/page.tsx
+++ b/src/app/(shell)/@aside/home/page.tsx
@@ -26,8 +26,9 @@ export default function HomeAside() {
     );
   }
 
-  // PRIORITY 2 — active post: show its related panel, or a graceful empty state
-  // (your own posts, for example, have no related responses).
+  // PRIORITY 2 — active post: show its related panel when the payload contains
+  // responses. Posts with no relations keep the column geometrically stable but
+  // intentionally render no message, card, or invented fallback content.
   if (activePostId) {
     if (relatedStacks && relatedStacks.length > 0) {
       return (
@@ -50,19 +51,10 @@ export default function HomeAside() {
         </div>
       );
     }
-    return (
-      <div style={{ width: "100%", paddingTop: "0.5rem" }} role="status" aria-live="polite">
-        <div style={{ padding: "1rem 0" }}>
-          <div style={{ fontSize: 14, fontWeight: 700, color: "#374151", marginBottom: 6 }}>
-            Related Posts
-          </div>
-          <div style={{ fontSize: 12, color: "#94a3b8", lineHeight: 1.45 }}>
-            No related responses for this post.
-          </div>
-        </div>
-      </div>
-    );
+    return <div data-testid="home-related-empty" aria-hidden="true" style={{ width: "100%", minHeight: 1 }} />;
   }
 
-  return null;
+  // A blank mount keeps the Home feed width stable before the first post is
+  // selected; otherwise the shell would jump from one column to two on load.
+  return <div data-testid="home-related-empty" aria-hidden="true" style={{ width: "100%", minHeight: 1 }} />;
 }

--- a/src/app/(shell)/ChineseEVs/URL_SCHEMA.md
+++ b/src/app/(shell)/ChineseEVs/URL_SCHEMA.md
@@ -6,7 +6,7 @@ The `/ChineseEVs/*` routes are the research prototype ("baby stacky") for the fu
 
 | Path | Purpose | Data source |
 |---|---|---|
-| `/ChineseEVs` | Feed view (hashtag stream + per-post in-page thread) | `src/app/FakeData/listy-injection.json` |
+| `/ChineseEVs` | Feed view (hashtag stream + per-post in-page thread) | Cursor-paginated `/api/demo/timelines/chinese-evs` contract backed by the fixture |
 | `/ChineseEVs/posts/[id]` | Post-detail with threaded replies + related-post aside | Same JSON, resolver in `src/utils/mockPostResolver.ts` |
 
 The post-detail route mirrors the future `/posts/[id]` route. The same React components are shared (`Post`, `ThreadedReplyList`, `RelatedStacks`, `BackButton`, `ReplySection`) and the same URL-sync hook (`useUrlSync`) is reused, so the URL contract carries over verbatim.

--- a/src/app/(shell)/ChineseEVs/page.tsx
+++ b/src/app/(shell)/ChineseEVs/page.tsx
@@ -14,6 +14,7 @@ import { registerNavigateCallback } from "../../../utils/highlightStore";
 import ReplySection from "../../../components/ReplySection";
 import { useLocalStore, useHydrated, getHashtagAuthors, followAll, unfollowAll, areAllFollowing } from "../../../utils/localStore";
 import { DEMO_TIMELINE_PAGE_SIZE, getChineseEvTimelinePage, type TimelineStats } from "../../../services/demoApiClient";
+import { getMockReplyCount } from "../../../utils/mockPostResolver";
 
 // ── Thread line constants ────────────────────────────────────────────────────
 const THREAD_LINE_COLOR = "#ccd1dc";
@@ -25,7 +26,7 @@ function toTopPost(rp: RelatedPostMock) {
   return {
     id: rp.id,
     created_at: rp.created_at,
-    replies_count: rp.replies_count,
+    replies_count: getMockReplyCount(rp.id),
     favourites_count: rp.favourites_count,
     favourited: rp.favourited,
     bookmarked: rp.bookmarked,
@@ -77,7 +78,7 @@ function toPostData(entry: ListyInjectionEntry) {
     account: entry.focusPost.account.acct,
     avatar: entry.focusPost.account.avatar,
     createdAt: entry.focusPost.created_at,
-    replies_count: entry.focusPost.replies_count,
+    replies_count: getMockReplyCount(entry.focusPost.id),
     stackCount: entry.relatedPosts.length,
     favouritesCount: entry.focusPost.favourites_count,
     favourited: entry.focusPost.favourited,
@@ -177,7 +178,7 @@ function syntheticEntryFromRelated(rp: RelatedPostMock, parentEntry: ListyInject
       account: rp.account,
       created_at: rp.created_at,
       favourites_count: rp.favourites_count,
-      replies_count: rp.replies_count,
+      replies_count: getMockReplyCount(rp.id),
       favourited: rp.favourited,
       bookmarked: rp.bookmarked,
     },
@@ -194,7 +195,7 @@ function replyToPostData(reply: FocusPostMock) {
     account: reply.account.acct,
     avatar: reply.account.avatar,
     createdAt: reply.created_at,
-    replies_count: reply.replies_count,
+    replies_count: getMockReplyCount(reply.id),
     stackCount: -1,
     favouritesCount: reply.favourites_count,
     favourited: reply.favourited,
@@ -381,7 +382,7 @@ export default function ListyInjectionPage() {
             account: rp.account,
             created_at: rp.created_at,
             favourites_count: rp.favourites_count,
-            replies_count: rp.replies_count,
+            replies_count: getMockReplyCount(rp.id),
             favourited: rp.favourited,
             bookmarked: rp.bookmarked,
           });
@@ -739,7 +740,11 @@ export default function ListyInjectionPage() {
         author={postData.author}
         account={postData.account}
         avatar={postData.avatar}
-        repliesCount={postData.replies_count}
+        repliesCount={
+          hydrated
+            ? localPosts[postData.postId]?.replies_count ?? postData.replies_count
+            : postData.replies_count
+        }
         createdAt={postData.createdAt}
         stackCount={-1}
         favouritesCount={postData.favouritesCount}
@@ -925,6 +930,7 @@ export default function ListyInjectionPage() {
   // Follow every demo participant so the JSON-backed conversation is blended
   // into Home. This stays local until the curated corpus is imported to Mastodon.
   const hydrated = useHydrated();
+  const localPosts = useLocalStore((snapshot) => snapshot.posts);
   const hashtagFollowed = useLocalStore(() => areAllFollowing(getHashtagAuthors()));
   const handleFollowHashtag = () => {
     const authors = getHashtagAuthors();

--- a/src/app/(shell)/ChineseEVs/page.tsx
+++ b/src/app/(shell)/ChineseEVs/page.tsx
@@ -1,21 +1,19 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { Text, Paper, Box, Group, Divider, Button } from "@mantine/core";
+import { Text, Paper, Box, Group, Divider, Button, Skeleton } from "@mantine/core";
 import { IconArrowLeft } from "@tabler/icons-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useRouter } from "next/navigation";
 import { notifications } from "@mantine/notifications";
 import Post from "../../../components/Posts/Post";
-import mockData from "../../FakeData/listy-injection.json";
-import type { ListyInjectionData, ListyInjectionEntry, RelatedPostMock, FocusPostMock, Relation, CategoryKey } from "../../../types/PostType";
+import type { ListyInjectionEntry, RelatedPostMock, FocusPostMock, Relation, CategoryKey } from "../../../types/PostType";
 import { useRelatedStacks } from "../related-stacks-context";
 import { firstTypeRelations } from "../../../utils/relationFirstType.mjs";
 import { registerNavigateCallback } from "../../../utils/highlightStore";
 import ReplySection from "../../../components/ReplySection";
 import { useLocalStore, useHydrated, getHashtagAuthors, followAll, unfollowAll, areAllFollowing } from "../../../utils/localStore";
-
-const entries = mockData as unknown as ListyInjectionData;
+import { DEMO_TIMELINE_PAGE_SIZE, getChineseEvTimelinePage, type TimelineStats } from "../../../services/demoApiClient";
 
 // ── Thread line constants ────────────────────────────────────────────────────
 const THREAD_LINE_COLOR = "#ccd1dc";
@@ -34,7 +32,11 @@ function toTopPost(rp: RelatedPostMock) {
     content: rp.content,
     account: { avatar: rp.account.avatar, display_name: rp.account.display_name, acct: rp.account.acct },
     content_rewritten: "",
-    rewrite: { content: rp.rewrite?.content ?? rp.content, significant: rp.rewrite?.significant ?? false },
+    rewrite: {
+      content: rp.rewrite?.content ?? rp.content,
+      significant: rp.rewrite?.significant ?? false,
+      editSummary: rp.rewrite?.editSummary,
+    },
     // First contribution type only per highlight (relationFirstType.mjs) — the
     // backend now emits one relation PER TYPE on the same span, which rendered
     // as stacked two-colour bands on every highlight.
@@ -211,24 +213,97 @@ function replyToPostData(reply: FocusPostMock) {
 export default function ListyInjectionPage() {
   const router = useRouter();
   const { setFromPost, activePostId: ctxActivePostId } = useRelatedStacks();
+  const [entries, setEntries] = useState<ListyInjectionEntry[]>([]);
+  const [timelineStats, setTimelineStats] = useState<TimelineStats | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const pageSentinelRef = useRef<HTMLDivElement | null>(null);
+  const inFlightCursorsRef = useRef(new Map<string, symbol>());
   const [activePostId, setActivePostId] = useState<string | null>(null);
   const activePostIdRef = useRef<string | null>(null);
   const setFromPostRef = useRef(setFromPost);
   setFromPostRef.current = setFromPost;
   const postRefs = useRef<Array<HTMLDivElement | null>>([]);
 
+  const loadTimelinePage = useCallback(async (
+    cursor: string | null,
+    append: boolean,
+    signal?: AbortSignal,
+  ) => {
+    const requestKey = cursor ?? "__first__";
+    if (inFlightCursorsRef.current.has(requestKey)) return;
+    const requestToken = Symbol(requestKey);
+    inFlightCursorsRef.current.set(requestKey, requestToken);
+    setLoadError(null);
+    if (append) setLoadingMore(true);
+    else setInitialLoading(true);
+
+    try {
+      const page = await getChineseEvTimelinePage(cursor, { signal });
+      setEntries((current) => {
+        if (!append) return page.items;
+        const seen = new Set(current.map((entry) => entry.focusPost.id));
+        return [...current, ...page.items.filter((entry) => !seen.has(entry.focusPost.id))];
+      });
+      setTimelineStats(page.stats);
+      setNextCursor(page.nextCursor);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
+      setLoadError(error instanceof Error ? error.message : "The demo timeline could not be loaded.");
+    } finally {
+      if (inFlightCursorsRef.current.get(requestKey) === requestToken) {
+        inFlightCursorsRef.current.delete(requestKey);
+      }
+      if (append) setLoadingMore(false);
+      else setInitialLoading(false);
+    }
+  }, []);
+
+  // The page knows only the API contract. The bundled route currently serves
+  // the JSON fixture with latency; a live service can replace its base URL.
+  useEffect(() => {
+    const controller = new AbortController();
+    const inFlightCursors = inFlightCursorsRef.current;
+    void loadTimelinePage(null, false, controller.signal);
+    return () => {
+      // React Strict Mode immediately re-runs effects in development. Release
+      // this subscription synchronously so the replacement can share the
+      // underlying client request instead of being mistaken for a duplicate.
+      inFlightCursors.delete("__first__");
+      controller.abort();
+    };
+  }, [loadTimelinePage]);
+
+  // Near-viewport preloading keeps the next cursor page ready without fetching
+  // the entire collection up front. The visible button remains a manual/a11y
+  // fallback when IntersectionObserver is unavailable.
+  useEffect(() => {
+    const node = pageSentinelRef.current;
+    if (!node || !nextCursor || loadingMore || loadError) return;
+    if (typeof IntersectionObserver === "undefined") return;
+    const observer = new IntersectionObserver((observations) => {
+      if (observations.some((observation) => observation.isIntersecting)) {
+        void loadTimelinePage(nextCursor, true);
+      }
+    }, { rootMargin: "300px 0px" });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [loadError, nextCursor, loadingMore, loadTimelinePage]);
+
   // ── Lookup maps ────────────────────────────────────────────────────────────
   const entryMap = useMemo(() => {
     const map = new Map<string, ListyInjectionEntry>();
     for (const e of entries) map.set(e.focusPost.id, e);
     return map;
-  }, []);
+  }, [entries]);
 
   const allRelatedPosts = useMemo(() => {
     const map = new Map<string, { rp: RelatedPostMock; parentEntry: ListyInjectionEntry }>();
     for (const e of entries) for (const rp of e.relatedPosts) if (!map.has(rp.id)) map.set(rp.id, { rp, parentEntry: e });
     return map;
-  }, []);
+  }, [entries]);
 
   /**
    * Global parent map (childId → parentId) derived from inherent thread hierarchy:
@@ -268,7 +343,7 @@ export default function ListyInjectionPage() {
       }
     }
     return map;
-  }, []);
+  }, [entries]);
 
   /** childrenByParent[parentId] = ids of posts whose inherent parent is parentId */
   const childrenByParent = useMemo(() => {
@@ -314,7 +389,7 @@ export default function ListyInjectionPage() {
       }
     }
     return map;
-  }, []);
+  }, [entries]);
 
   /** Walk inherent parent chain. Returns oldest-ancestor-first (root → parent). */
   const getAncestorChain = useCallback((id: string): string[] => {
@@ -519,7 +594,7 @@ export default function ListyInjectionPage() {
   }, [getRelatedStacks]);
 
   // ── Feed mode posts ────────────────────────────────────────────────────────
-  const posts = useMemo(() => entries.map(toPostData), []);
+  const posts = useMemo(() => entries.map(toPostData), [entries]);
   // Keep postsRef in sync so the popstate-driven back path can re-seed feed
   // mode without `posts` having to be declared above it.
   postsRef.current = posts;
@@ -584,7 +659,7 @@ export default function ListyInjectionPage() {
       sessionStorage.removeItem("scrollY:/ChineseEVs");
       sessionStorage.removeItem("activeFeedPost:/ChineseEVs");
     }
-  }, []);
+  }, [posts, activePostId, ctxActivePostId, setFromPost]);
 
   // Keep ref in sync
   useEffect(() => { activePostIdRef.current = activePostId; }, [activePostId]);
@@ -841,8 +916,11 @@ export default function ListyInjectionPage() {
   }
 
   // ── Feed mode content ──────────────────────────────────────────────────────
-  const totalRelated = posts.reduce((sum, p) => sum + p.relatedStacks.length, 0);
+  const totalRelated = timelineStats?.responses ?? posts.reduce((sum, p) => sum + p.relatedStacks.length, 0);
   const uniqueAuthors = new Set(posts.flatMap(p => p.relatedStacks.map(s => s.topPost.account.display_name)));
+  const totalPosts = timelineStats?.posts ?? posts.length;
+  const participantCount = timelineStats?.participants ?? uniqueAuthors.size;
+  const remainingPosts = Math.max(0, totalPosts - posts.length);
 
   // "Follow hashtag" follows every participant so the whole conversation lands on
   // Home. Gated on mount (the follow state lives in localStorage) to match SSR.
@@ -905,11 +983,11 @@ export default function ListyInjectionPage() {
         <Divider my="md" />
         <Group style={{ justifyContent: "center", gap: "2rem" }}>
           <div>
-            <Text size="lg" style={{ textAlign: "center" }}>{posts.length}</Text>
+            <Text size="lg" style={{ textAlign: "center" }}>{totalPosts}</Text>
             <Text size="sm" c="dimmed" style={{ textAlign: "center" }}>Posts</Text>
           </div>
           <div>
-            <Text size="lg" style={{ textAlign: "center" }}>{uniqueAuthors.size}</Text>
+            <Text size="lg" style={{ textAlign: "center" }}>{participantCount}</Text>
             <Text size="sm" c="dimmed" style={{ textAlign: "center" }}>Participants</Text>
           </div>
           <div>
@@ -920,6 +998,35 @@ export default function ListyInjectionPage() {
       </Paper>
 
       <Box style={{ width: "100%", position: "relative" }}>
+        {initialLoading && posts.length === 0 && (
+          <div data-testid="demo-feed-loading" aria-label="Loading posts">
+            {[0, 1].map((index) => (
+              <Paper key={index} withBorder p="lg" mb="sm" radius="md">
+                <Group mb="md">
+                  <Skeleton circle height={40} />
+                  <div style={{ flex: 1 }}>
+                    <Skeleton height={10} width="34%" mb={8} />
+                    <Skeleton height={8} width="22%" />
+                  </div>
+                </Group>
+                <Skeleton height={10} mb={8} />
+                <Skeleton height={10} mb={8} />
+                <Skeleton height={10} width="72%" />
+              </Paper>
+            ))}
+          </div>
+        )}
+
+        {loadError && posts.length === 0 && (
+          <Paper withBorder p="lg" radius="md" role="alert" data-testid="demo-feed-error">
+            <Text fw={700} size="sm" mb={4}>Posts didn&apos;t load</Text>
+            <Text c="dimmed" size="xs" mb="md">{loadError}</Text>
+            <Button size="xs" variant="light" onClick={() => void loadTimelinePage(null, false)}>
+              Try again
+            </Button>
+          </Paper>
+        )}
+
         {posts.map((post, index) => (
           <div
             key={post.postId}
@@ -930,6 +1037,26 @@ export default function ListyInjectionPage() {
             {renderPost(post)}
           </div>
         ))}
+
+        {nextCursor && (
+          <div ref={pageSentinelRef} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6, margin: "18px 0" }}>
+            <Button
+              variant="light"
+              loading={loadingMore}
+              disabled={loadingMore}
+              data-testid="demo-load-more"
+              onClick={() => void loadTimelinePage(nextCursor, true)}
+            >
+              Load {Math.min(DEMO_TIMELINE_PAGE_SIZE, remainingPosts)} more posts
+            </Button>
+            <Text size="xs" c="dimmed" aria-live="polite">
+              {posts.length} of {totalPosts} loaded
+            </Text>
+            {loadError && (
+              <Text size="xs" c="red" role="alert">Couldn&apos;t load the next page. Try again.</Text>
+            )}
+          </div>
+        )}
         <div style={{ height: "60vh" }} />
       </Box>
     </div>

--- a/src/app/(shell)/ChineseEVs/page.tsx
+++ b/src/app/(shell)/ChineseEVs/page.tsx
@@ -922,8 +922,8 @@ export default function ListyInjectionPage() {
   const participantCount = timelineStats?.participants ?? uniqueAuthors.size;
   const remainingPosts = Math.max(0, totalPosts - posts.length);
 
-  // "Follow hashtag" follows every participant so the whole conversation lands on
-  // Home. Gated on mount (the follow state lives in localStorage) to match SSR.
+  // Follow every demo participant so the JSON-backed conversation is blended
+  // into Home. This stays local until the curated corpus is imported to Mastodon.
   const hydrated = useHydrated();
   const hashtagFollowed = useLocalStore(() => areAllFollowing(getHashtagAuthors()));
   const handleFollowHashtag = () => {
@@ -935,14 +935,14 @@ export default function ListyInjectionPage() {
     const notificationId = `chinese-evs-follow-${Date.now()}`;
     notifications.show({
       id: notificationId,
-      title: wasFollowing ? "Hashtag unfollowed" : "Following #ChineseEVs",
+      title: wasFollowing ? "Demo feed unfollowed" : "Following demo feed",
       color: "blue",
       message: (
         <Group gap="xs" justify="space-between" wrap="nowrap">
           <Text size="sm">
             {wasFollowing
-              ? "Posts from this discussion were removed from Home."
-              : "Posts from this discussion will now appear on Home."}
+              ? "These curated posts were removed from Home."
+              : "These curated posts now appear on Home alongside Mastodon posts."}
           </Text>
           <Button
             variant="subtle"
@@ -977,7 +977,7 @@ export default function ListyInjectionPage() {
             size="sm"
             onClick={handleFollowHashtag}
           >
-            {hydrated && hashtagFollowed ? "Following hashtag" : "Follow hashtag"}
+            {hydrated && hashtagFollowed ? "Following demo feed" : "Follow demo feed"}
           </Button>
         </Group>
         <Divider my="md" />
@@ -995,6 +995,9 @@ export default function ListyInjectionPage() {
             <Text size="sm" c="dimmed" style={{ textAlign: "center" }}>Responses</Text>
           </div>
         </Group>
+        <Text size="xs" c="dimmed" mt="md">
+          Demo follows are saved on this device until the curated posts move to Mastodon.
+        </Text>
       </Paper>
 
       <Box style={{ width: "100%", position: "relative" }}>

--- a/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
+++ b/src/app/(shell)/ChineseEVs/posts/[id]/page.tsx
@@ -19,10 +19,12 @@ import {
   getMockRecommended,
   getMockFocusRelations,
   getMockReplyRelations,
+  getMockReplyCount,
   getMockPlainText,
   mockHasPost,
   type MockPostType,
 } from "../../../../../utils/mockPostResolver";
+import { resolveReplyCount } from "../../../../../utils/replyCount.mjs";
 import type { Relation } from "../../../../../types/PostType";
 import { getCurrentUser } from "../../../../../utils/getCurrentUser";
 import { useLocalStore, useHydrated, getComments, type Post as StorePost } from "../../../../../utils/localStore";
@@ -666,7 +668,16 @@ export default function MockPostView({ params }: { params: { id: string } }) {
   // -------------------- Load mock + local study data --------------------
   useEffect(() => {
     const mockPost = getMockPost(id);
-    const p = mockPost ?? (storePost as unknown as MockPostType | undefined) ?? null;
+    const p = mockPost
+      ? {
+          ...mockPost,
+          replies_count: resolveReplyCount(
+            getMockReplyCount(id),
+            0,
+            userComments.length,
+          ),
+        }
+      : (storePost as unknown as MockPostType | undefined) ?? null;
     if (!p) {
       setPost(null);
       return;
@@ -715,7 +726,7 @@ export default function MockPostView({ params }: { params: { id: string } }) {
     const user = getCurrentUser();
     if (user) setCurrentUser(user);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, flags.suppressThreadPosts, storePost, localState.posts, hydrated]);
+  }, [id, flags.suppressThreadPosts, storePost, localState.posts, hydrated, userComments.length]);
 
   // Defer the reply thread to the next task so the focus post + ancestors
   // paint immediately instead of blocking on one big synchronous render.

--- a/src/app/(shell)/Shell.tsx
+++ b/src/app/(shell)/Shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useMediaQuery } from "@mantine/hooks";
 import { HoverTooltip } from "../../components/HoverTooltip";
 import { TopNav, TOP_NAV_HEIGHT } from "../../components/NavBar/TopNav";
 import { RelatedStacksProvider } from "./related-stacks-context";
@@ -23,12 +24,14 @@ export default function Shell({
     aside: React.ReactNode;
 }) {
     const { ratio, setRatio, reset } = useFeedRatio();
+    const isNarrowViewport = useMediaQuery("(max-width: 48rem)", false);
 
     const groupRef = useRef<HTMLDivElement | null>(null);
     // Live width of the group minus the slider, so px drag-deltas map to ratio.
     const groupInnerRef = useRef<number>(1);
     const asideRef = useRef<HTMLDivElement | null>(null);
     const [hasAside, setHasAside] = useState(false);
+    const showAside = hasAside && !isNarrowViewport;
 
     // Measure the content group for the slider's px → ratio conversion.
     useEffect(() => {
@@ -57,7 +60,7 @@ export default function Shell({
     }, []);
 
     useEffect(() => {
-        if (!hasAside) return;
+        if (!showAside) return;
         const routeRightGutterWheel = (event: WheelEvent) => {
             const aside = asideRef.current;
             if (!aside || event.defaultPrevented || event.clientY < TOP_NAV_HEIGHT) return;
@@ -86,7 +89,7 @@ export default function Shell({
 
         window.addEventListener("wheel", routeRightGutterWheel, { passive: false });
         return () => window.removeEventListener("wheel", routeRightGutterWheel);
-    }, [hasAside]);
+    }, [showAside]);
 
     const onSliderResize = (deltaPx: number) => {
         const inner = groupInnerRef.current || 1;
@@ -123,11 +126,12 @@ export default function Shell({
                         // the focus/feed cards compress to icon-only when narrow.
                         containerType: "inline-size",
                         // With an aside, take the slider-controlled share of the row.
-                        // Without one (home / liked / bookmarks / search), render a
+                        // Without one (liked / bookmarks / search, or on a narrow
+                        // viewport), render a
                         // single centered reading column instead of a too-wide
                         // full-bleed feed — keeps the composer and posts aligned and
                         // consistent with the feed width when the aside is present.
-                        ...(hasAside
+                        ...(showAside
                             ? { flexGrow: ratio, flexBasis: 0, minWidth: 0 }
                             : { width: "100%", maxWidth: 760, margin: "0 auto" }),
                     }}
@@ -135,7 +139,7 @@ export default function Shell({
                     {children}
                 </div>
 
-                {hasAside && (
+                {showAside && (
                     <ResizableDivider
                         ariaLabel="Resize feed and related panels"
                         onResize={onSliderResize}
@@ -156,11 +160,11 @@ export default function Shell({
                     className="aside-scroll"
                     ref={asideRef}
                     style={{
-                        ...(hasAside
+                        ...(showAside
                             ? { flexGrow: 1 - ratio, flexBasis: 0 }
                             : { flexGrow: 0, flexBasis: 0 }),
                         minWidth: 0,
-                        display: hasAside ? "block" : "none",
+                        display: showAside ? "block" : "none",
                         alignSelf: "flex-start",
                         position: "sticky",
                         top: TOP_NAV_HEIGHT,

--- a/src/app/(shell)/bookmarks/page.tsx
+++ b/src/app/(shell)/bookmarks/page.tsx
@@ -1,8 +1,19 @@
 "use client";
+import { Loader } from '@mantine/core';
 import Posts from '../../../components/Posts/Posts';
+import { MASTODON_INSTANCE_URL } from '../../../utils/mastodonApi';
+import { useAccessToken } from '../../../utils/useAccessToken';
 
 export default function Bookmarks() {
+    const { token, ready } = useAccessToken();
+    if (!ready) return <div style={{ display: 'grid', minHeight: 180, placeItems: 'center' }}><Loader size="sm" /></div>;
     return (
-        <Posts source="bookmarks" loadStackInfo showSubmitAndSearch showLoadMore={false} />
+        <Posts
+            apiUrl={token ? `${MASTODON_INSTANCE_URL}/api/v1/bookmarks` : undefined}
+            source={token ? undefined : 'bookmarks'}
+            loadStackInfo
+            showSubmitAndSearch
+            showLoadMore={Boolean(token)}
+        />
     );
 }

--- a/src/app/(shell)/home/Home.module.css
+++ b/src/app/(shell)/home/Home.module.css
@@ -1,0 +1,69 @@
+.timeline {
+  overflow: clip;
+  width: 100%;
+  background: #ffffff;
+  border: 1px solid #d9d7cd;
+  border-radius: 14px;
+  box-shadow: 0 10px 30px rgba(20, 33, 61, 0.055);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 76px;
+  padding: 0.9rem 1.1rem 0.8rem;
+  background: rgba(252, 251, 245, 0.96);
+  border-bottom: 1px solid #deddd6;
+}
+
+.title {
+  margin: 0;
+  color: #14213d;
+  font-size: 1.25rem;
+  font-weight: 760;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+}
+
+.subtitle {
+  margin: 0.22rem 0 0;
+  color: #6f7787;
+  font-size: 0.78rem;
+  line-height: 1.3;
+}
+
+.latest {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  flex: 0 0 auto;
+  color: #52617d;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.latest span {
+  width: 7px;
+  height: 7px;
+  background: #4e8f78;
+  border: 2px solid #dcebe5;
+  border-radius: 999px;
+  box-sizing: content-box;
+}
+
+@media (max-width: 40rem) {
+  .timeline {
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
+  }
+
+  .header {
+    min-height: 68px;
+    padding-inline: 0.9rem;
+  }
+}

--- a/src/app/(shell)/home/Home.module.css
+++ b/src/app/(shell)/home/Home.module.css
@@ -1,7 +1,9 @@
 .timeline {
   overflow: clip;
   width: 100%;
-  background: #ffffff;
+  /* Let the warm CrossWeave canvas show through the space between white cards,
+     matching the curated demo feed instead of producing white gutters. */
+  background: #fcfbf5;
   border: 1px solid #d9d7cd;
   border-radius: 14px;
   box-shadow: 0 10px 30px rgba(20, 33, 61, 0.055);

--- a/src/app/(shell)/home/page.tsx
+++ b/src/app/(shell)/home/page.tsx
@@ -30,6 +30,7 @@ export default function Home() {
                     <Posts
                         apiUrl={token ? `${MASTODON_INSTANCE_URL}/api/v1/timelines/home` : undefined}
                         source={token ? undefined : 'home'}
+                        includeFollowedDemo={Boolean(token)}
                         loadStackInfo
                         showSubmitAndSearch
                         showLoadMore={Boolean(token)}

--- a/src/app/(shell)/home/page.tsx
+++ b/src/app/(shell)/home/page.tsx
@@ -1,14 +1,27 @@
 "use client";
 import React from 'react';
 import Posts from '../../../components/Posts/Posts';
+import classes from './Home.module.css';
 
 export default function Home() {
     return (
-        <Posts
-            source="home"
-            loadStackInfo
-            showSubmitAndSearch
-            showLoadMore={false}
-        />
+        <main className={classes.timeline} aria-labelledby="home-title">
+            <header className={classes.header}>
+                <div>
+                    <h1 id="home-title" className={classes.title}>Home</h1>
+                    <p className={classes.subtitle}>Curated and followed conversations</p>
+                </div>
+                <div className={classes.latest} aria-label="Timeline sorted by latest activity">
+                    <span aria-hidden="true" />
+                    Latest
+                </div>
+            </header>
+            <Posts
+                source="home"
+                loadStackInfo
+                showSubmitAndSearch
+                showLoadMore={false}
+            />
+        </main>
     );
 }

--- a/src/app/(shell)/home/page.tsx
+++ b/src/app/(shell)/home/page.tsx
@@ -1,9 +1,14 @@
 "use client";
 import React from 'react';
+import { Loader } from '@mantine/core';
 import Posts from '../../../components/Posts/Posts';
+import { MASTODON_INSTANCE_URL } from '../../../utils/mastodonApi';
+import { useAccessToken } from '../../../utils/useAccessToken';
 import classes from './Home.module.css';
 
 export default function Home() {
+    const { token, ready } = useAccessToken();
+
     return (
         <main className={classes.timeline} aria-labelledby="home-title">
             <header className={classes.header}>
@@ -16,12 +21,21 @@ export default function Home() {
                     Latest
                 </div>
             </header>
-            <Posts
-                source="home"
-                loadStackInfo
-                showSubmitAndSearch
-                showLoadMore={false}
-            />
+            {!ready ? (
+                <div style={{ display: 'grid', minHeight: 180, placeItems: 'center' }} aria-label="Loading your timeline">
+                    <Loader color="blue" size="sm" />
+                </div>
+            ) : (
+                <div data-feed-mode={token ? 'mastodon' : 'json-demo'}>
+                    <Posts
+                        apiUrl={token ? `${MASTODON_INSTANCE_URL}/api/v1/timelines/home` : undefined}
+                        source={token ? undefined : 'home'}
+                        loadStackInfo
+                        showSubmitAndSearch
+                        showLoadMore={Boolean(token)}
+                    />
+                </div>
+            )}
         </main>
     );
 }

--- a/src/app/(shell)/liked/page.tsx
+++ b/src/app/(shell)/liked/page.tsx
@@ -1,8 +1,19 @@
 "use client";
+import { Loader } from '@mantine/core';
 import Posts from '../../../components/Posts/Posts';
+import { MASTODON_INSTANCE_URL } from '../../../utils/mastodonApi';
+import { useAccessToken } from '../../../utils/useAccessToken';
 
 export default function Liked() {
+    const { token, ready } = useAccessToken();
+    if (!ready) return <div style={{ display: 'grid', minHeight: 180, placeItems: 'center' }}><Loader size="sm" /></div>;
     return (
-        <Posts source="liked" loadStackInfo showSubmitAndSearch showLoadMore={false} />
+        <Posts
+            apiUrl={token ? `${MASTODON_INSTANCE_URL}/api/v1/favourites` : undefined}
+            source={token ? undefined : 'liked'}
+            loadStackInfo
+            showSubmitAndSearch
+            showLoadMore={Boolean(token)}
+        />
     );
 }

--- a/src/app/LandingPage.module.css
+++ b/src/app/LandingPage.module.css
@@ -1,47 +1,209 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@700&display=swap');
-
-.title {
-    color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
-    font-size: rem(50px);
-    font-weight: 900;
-    font-family: 'Roboto', sans-serif;
-
-   
+.page {
+  --navy: #14213d;
+  --cream: #fcfbf5;
+  --green: #4e8f78;
+  min-height: 100vh;
+  color: var(--navy);
+  background:
+    radial-gradient(circle at 14% 18%, rgba(78, 143, 120, 0.1), transparent 27rem),
+    radial-gradient(circle at 84% 76%, rgba(216, 167, 46, 0.1), transparent 25rem),
+    var(--cream);
 }
 
+.weaveRail {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 2;
+  display: grid;
+  width: 7px;
+  grid-template-rows: repeat(4, 1fr);
+}
 
-.landingPageContent {
-    min-height: 100vh;
-    padding: 2rem 1rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-  }
-  
-  .container {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-  }
-  
-  .logo {
-    width: 200px; 
-    height: auto;
-    margin-bottom: 2rem;
-  }
-  .subtitle {
-    margin-top: 0.5rem;
-    margin-bottom: 2rem;
-    font-size: 1.25rem; 
-  }
-  
-  .paper {
-    width: 100%;
-    max-width: 460px;
-    padding: 2rem;
-    background: rgba(255, 255, 255, 0.92);
-    box-shadow: 0 16px 45px rgba(28, 43, 74, 0.08);
-  }
+.weaveRail span:nth-child(1) { background: #d97757; }
+.weaveRail span:nth-child(2) { background: #d8a72e; }
+.weaveRail span:nth-child(3) { background: #4e8f78; }
+.weaveRail span:nth-child(4) { background: #5a71a8; }
+
+.shell {
+  width: min(1160px, calc(100% - 3rem));
+  margin: 0 auto;
+  padding: 2.25rem 0 3rem;
+}
+
+.brandBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid rgba(20, 33, 61, 0.12);
+}
+
+.instanceLabel {
+  color: #657086;
+  font-size: 0.78rem;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(340px, 0.72fr);
+  gap: clamp(3rem, 8vw, 7.5rem);
+  align-items: center;
+  min-height: calc(100vh - 9rem);
+  padding: 3rem 0 4rem;
+}
+
+.introduction { position: relative; }
+
+.kicker,
+.cardEyebrow {
+  color: var(--green);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.headline {
+  max-width: 720px;
+  margin: 0.75rem 0 1.2rem;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(2.85rem, 5.5vw, 5.15rem);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 0.98;
+}
+
+.lede {
+  max-width: 620px;
+  color: #52617d;
+  font-size: clamp(1rem, 1.5vw, 1.14rem);
+  line-height: 1.7;
+}
+
+.steps {
+  display: grid;
+  gap: 0.95rem;
+  max-width: 590px;
+  margin: 2rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.steps li { display: flex; gap: 0.8rem; align-items: flex-start; }
+.steps li > span {
+  display: grid;
+  flex: 0 0 25px;
+  width: 25px;
+  height: 25px;
+  place-items: center;
+  margin-top: 1px;
+  color: #fff;
+  background: var(--green);
+  border-radius: 50%;
+}
+.steps strong { display: block; font-size: 0.95rem; }
+.steps small { display: block; margin-top: 0.12rem; color: #697386; font-size: 0.83rem; line-height: 1.45; }
+
+.threadPreview {
+  position: relative;
+  display: grid;
+  grid-template-columns: 7px minmax(150px, 1fr) 80px;
+  gap: 1rem;
+  width: min(510px, 90%);
+  height: 114px;
+  margin-top: 2.5rem;
+  padding: 1rem;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.56);
+  border: 1px solid rgba(20, 33, 61, 0.09);
+  border-radius: 14px;
+}
+.previewRail { display: grid; overflow: hidden; border-radius: 8px; }
+.previewRail i:nth-child(1) { background: #d97757; }
+.previewRail i:nth-child(2) { background: #d8a72e; }
+.previewRail i:nth-child(3) { background: #4e8f78; }
+.previewRail i:nth-child(4) { background: #5a71a8; }
+.previewPost { display: grid; grid-template-columns: 30px 1fr; gap: 0.75rem; align-content: start; padding: 0.35rem 0; }
+.previewPost b { width: 30px; height: 30px; background: #d9ddd8; border-radius: 50%; }
+.previewPost span { display: grid; gap: 0.55rem; padding-top: 0.25rem; }
+.previewPost i { display: block; height: 7px; background: #d9ddd8; border-radius: 8px; }
+.previewPost i:last-child { width: 72%; }
+.previewPost:nth-of-type(4) { position: absolute; left: 66px; bottom: 6px; width: 55%; transform: scale(0.75); transform-origin: left bottom; }
+.previewBranch { position: absolute; left: 48px; top: 46px; width: 20px; height: 46px; border: solid #bcc4c7; border-width: 0 0 2px 2px; border-radius: 0 0 0 14px; }
+.previewContext { display: grid; align-content: center; gap: 7px; padding-left: 0.8rem; border-left: 1px solid #c7cbc4; }
+.previewContext em { height: 8px; background: rgba(78, 143, 120, 0.28); border-radius: 8px; }
+.previewContext em:nth-child(2) { background: rgba(90, 113, 168, 0.25); }
+.previewContext em:nth-child(3) { width: 70%; background: rgba(216, 167, 46, 0.28); }
+
+.accessCard {
+  padding: clamp(1.5rem, 4vw, 2.2rem);
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(20, 33, 61, 0.13);
+  border-radius: 20px;
+  box-shadow: 0 22px 65px rgba(20, 33, 61, 0.11);
+  backdrop-filter: blur(12px);
+}
+
+.cardHeader { margin-bottom: 1.55rem; }
+.cardTitle {
+  margin: 0.45rem 0 0.5rem;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+}
+.cardCopy { color: #626d81; font-size: 0.92rem; line-height: 1.55; }
+
+.primaryButton { height: 48px; background: var(--navy); font-weight: 750; }
+.primaryButton:hover { background: #27385d; }
+.createButton { height: 44px; margin-top: 0.8rem; color: var(--navy); border-color: #9fa7b4; font-weight: 700; }
+.createButton:hover { background: #f4f4ef; }
+.privacyCopy { margin: 0.8rem 0 0; color: #7a8291; font-size: 0.72rem; line-height: 1.5; }
+.divider { margin: 1.55rem 0 1.1rem; color: #7a8291; font-size: 0.73rem; }
+
+.demoButton {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.85rem 0.95rem;
+  color: var(--navy);
+  text-align: left;
+  background: #f5f4ed;
+  border: 1px solid #deddd3;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
+}
+.demoButton:hover { background: #efeee5; border-color: #babbae; transform: translateY(-1px); }
+.demoButton strong { display: block; font-size: 0.86rem; }
+.demoButton small { display: block; margin-top: 0.18rem; color: #747d8d; font-size: 0.71rem; }
+.terms { margin-top: 1.1rem; color: #7a8291; font-size: 0.7rem; line-height: 1.5; text-align: center; }
+.terms a { color: #52617d; }
+
+@media (max-width: 58rem) {
+  .layout { grid-template-columns: 1fr; gap: 2.5rem; min-height: auto; }
+  .introduction { padding-top: 1rem; }
+  .accessCard { width: min(100%, 480px); }
+  .threadPreview { display: none; }
+}
+
+@media (max-width: 36rem) {
+  .shell { width: min(100% - 2rem, 1160px); padding-top: 1.3rem; }
+  .brandBar { padding-bottom: 1.2rem; }
+  .instanceLabel { display: none; }
+  .layout { padding: 2rem 0; }
+  .headline { font-size: 2.7rem; }
+  .lede { font-size: 0.98rem; }
+  /* The account action is the mobile page's primary job. The desktop checklist
+     is supporting context; hiding it here keeps Sign in in the first viewport. */
+  .steps { display: none; }
+  .accessCard { padding: 1.25rem; border-radius: 15px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .demoButton { transition: none; }
+}

--- a/src/app/api/auth/mastodon/callback/route.ts
+++ b/src/app/api/auth/mastodon/callback/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { MASTODON_INSTANCE_URL, type MastodonAccount } from '../../../../../utils/mastodonApi';
+
+export const dynamic = 'force-dynamic';
+
+const OAUTH_STATE_COOKIE = 'crossweave_oauth_state';
+const OAUTH_REDIRECT_COOKIE = 'crossweave_oauth_redirect';
+
+interface CallbackBody {
+  code?: string;
+  state?: string;
+}
+
+function clearOAuthCookies(response: NextResponse): NextResponse {
+  response.headers.set('Cache-Control', 'no-store');
+  response.cookies.set(OAUTH_STATE_COOKIE, '', { path: '/', maxAge: 0 });
+  response.cookies.set(OAUTH_REDIRECT_COOKIE, '', { path: '/', maxAge: 0 });
+  return response;
+}
+
+export async function POST(request: NextRequest) {
+  let body: CallbackBody;
+  try {
+    body = await request.json() as CallbackBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid callback request.' }, { status: 400 });
+  }
+
+  const expectedState = request.cookies.get(OAUTH_STATE_COOKIE)?.value;
+  const redirectUri = request.cookies.get(OAUTH_REDIRECT_COOKIE)?.value;
+  if (!body.code || !body.state || !expectedState || body.state !== expectedState || !redirectUri) {
+    return clearOAuthCookies(
+      NextResponse.json({ error: 'This login attempt is invalid or has expired.' }, { status: 400 }),
+    );
+  }
+
+  const clientId = process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_ID;
+  // The fallback keeps existing deployments working during the environment
+  // variable migration. It is deliberately referenced only in this server route.
+  const clientSecret = process.env.MASTODON_OAUTH_CLIENT_SECRET
+    || process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    return clearOAuthCookies(
+      NextResponse.json({ error: 'Mastodon login is not configured.' }, { status: 503 }),
+    );
+  }
+
+  try {
+    const tokenResponse = await fetch(`${MASTODON_INSTANCE_URL}/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: redirectUri,
+        grant_type: 'authorization_code',
+        code: body.code,
+        scope: 'read write follow',
+      }),
+      cache: 'no-store',
+    });
+    const tokenData = await tokenResponse.json().catch(() => null) as { access_token?: string; error?: string } | null;
+    if (!tokenResponse.ok || !tokenData?.access_token) {
+      return clearOAuthCookies(
+        NextResponse.json({ error: 'Mastodon rejected this login attempt.' }, { status: 401 }),
+      );
+    }
+
+    const accountResponse = await fetch(`${MASTODON_INSTANCE_URL}/api/v1/accounts/verify_credentials`, {
+      headers: { Authorization: `Bearer ${tokenData.access_token}` },
+      cache: 'no-store',
+    });
+    const account = await accountResponse.json().catch(() => null) as MastodonAccount | null;
+    if (!accountResponse.ok || !account?.id) {
+      return clearOAuthCookies(
+        NextResponse.json({ error: 'Your account could not be verified.' }, { status: 401 }),
+      );
+    }
+
+    return clearOAuthCookies(NextResponse.json({
+      accessToken: tokenData.access_token,
+      account,
+      instance: MASTODON_INSTANCE_URL,
+    }));
+  } catch (error) {
+    console.error('Mastodon OAuth callback failed:', error);
+    return clearOAuthCookies(
+      NextResponse.json({ error: 'Mastodon is unavailable. Please try again.' }, { status: 502 }),
+    );
+  }
+}

--- a/src/app/api/auth/mastodon/revoke/route.ts
+++ b/src/app/api/auth/mastodon/revoke/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { MASTODON_INSTANCE_URL } from '../../../../../utils/mastodonApi';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const authorization = request.headers.get('authorization');
+  const token = authorization?.replace(/^Bearer\s+/i, '').trim();
+  const clientId = process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.MASTODON_OAUTH_CLIENT_SECRET
+    || process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_SECRET;
+
+  if (!token) return NextResponse.json({ error: 'No token supplied.' }, { status: 400 });
+  if (!clientId || !clientSecret) {
+    return NextResponse.json({ error: 'Mastodon login is not configured.' }, { status: 503 });
+  }
+
+  try {
+    const response = await fetch(`${MASTODON_INSTANCE_URL}/oauth/revoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ client_id: clientId, client_secret: clientSecret, token }),
+      cache: 'no-store',
+    });
+    if (!response.ok) {
+      return NextResponse.json({ error: 'Mastodon did not revoke this session.' }, { status: 502 });
+    }
+    return new NextResponse(null, { status: 204, headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    console.error('Mastodon token revocation failed:', error);
+    return NextResponse.json({ error: 'Mastodon is unavailable.' }, { status: 502 });
+  }
+}

--- a/src/app/api/auth/mastodon/start/route.ts
+++ b/src/app/api/auth/mastodon/start/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { MASTODON_INSTANCE_URL } from '../../../../../utils/mastodonApi';
+
+export const dynamic = 'force-dynamic';
+
+const OAUTH_STATE_COOKIE = 'crossweave_oauth_state';
+const OAUTH_REDIRECT_COOKIE = 'crossweave_oauth_redirect';
+const OAUTH_SCOPES = 'read write follow';
+
+function appOrigin(request: NextRequest): string {
+  return (process.env.APP_URL || request.nextUrl.origin).replace(/\/$/, '');
+}
+
+export async function GET(request: NextRequest) {
+  const clientId = process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_ID;
+  if (!clientId) {
+    return NextResponse.json(
+      { error: 'Mastodon login is not configured.' },
+      { status: 503 },
+    );
+  }
+
+  const state = crypto.randomUUID();
+  const redirectUri = `${appOrigin(request)}/callback`;
+  const authorizationUrl = new URL('/oauth/authorize', MASTODON_INSTANCE_URL);
+  authorizationUrl.searchParams.set('client_id', clientId);
+  authorizationUrl.searchParams.set('redirect_uri', redirectUri);
+  authorizationUrl.searchParams.set('response_type', 'code');
+  authorizationUrl.searchParams.set('scope', OAUTH_SCOPES);
+  authorizationUrl.searchParams.set('state', state);
+
+  const response = NextResponse.redirect(authorizationUrl);
+  response.headers.set('Cache-Control', 'no-store');
+  const cookieOptions = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge: 10 * 60,
+  };
+  response.cookies.set(OAUTH_STATE_COOKIE, state, cookieOptions);
+  response.cookies.set(OAUTH_REDIRECT_COOKIE, redirectUri, cookieOptions);
+  return response;
+}

--- a/src/app/api/demo/timelines/chinese-evs/route.ts
+++ b/src/app/api/demo/timelines/chinese-evs/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import mockData from "../../../../FakeData/listy-injection.json";
+import type { ListyInjectionData } from "../../../../../types/PostType";
+import { withContextualAiRewrites } from "../../../../../data/contextualAiRewrites";
+import { paginateByCursor } from "../../../../../utils/cursorPagination.mjs";
+
+export const dynamic = "force-dynamic";
+
+const entries = (mockData as unknown as ListyInjectionData).map(withContextualAiRewrites);
+const DEFAULT_PAGE_SIZE = 2;
+const MAX_PAGE_SIZE = 10;
+
+const stats = {
+  posts: entries.length,
+  responses: entries.reduce((sum, entry) => sum + entry.relatedPosts.length, 0),
+  participants: new Set(
+    entries.flatMap((entry) => entry.relatedPosts.map((post) => post.account.acct)),
+  ).size,
+};
+
+function simulatedDelay(cursor: string | null): number {
+  const configured = Number(process.env.DEMO_API_DELAY_MS);
+  if (Number.isFinite(configured) && configured >= 0) return Math.min(configured, 5_000);
+  const jitterSeed = cursor ? cursor.charCodeAt(cursor.length - 1) : 17;
+  return 320 + (jitterSeed % 5) * 55;
+}
+
+export async function GET(request: NextRequest) {
+  const cursor = request.nextUrl.searchParams.get("cursor");
+  const requestedLimit = Number(request.nextUrl.searchParams.get("limit") ?? DEFAULT_PAGE_SIZE);
+  const limit = Number.isFinite(requestedLimit)
+    ? Math.min(MAX_PAGE_SIZE, Math.max(1, Math.floor(requestedLimit)))
+    : DEFAULT_PAGE_SIZE;
+  const delayMs = simulatedDelay(cursor);
+
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+  try {
+    const page = paginateByCursor(entries, {
+      cursor,
+      limit,
+      idOf: (entry) => entry.focusPost.id,
+    });
+
+    return NextResponse.json(
+      {
+        ...page,
+        stats,
+        meta: {
+          simulated: true,
+          delayMs,
+          generatedAt: new Date().toISOString(),
+        },
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+          "X-Stacky-Data-Source": "simulated-backend",
+        },
+      },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Invalid pagination request" },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/src/app/callback/Callback.module.css
+++ b/src/app/callback/Callback.module.css
@@ -1,0 +1,38 @@
+.page {
+  display: grid;
+  min-height: 100vh;
+  padding: 1.5rem;
+  place-items: center;
+  color: #14213d;
+  background:
+    radial-gradient(circle at 25% 20%, rgba(78, 143, 120, 0.12), transparent 24rem),
+    #fcfbf5;
+}
+
+.card {
+  display: grid;
+  width: min(100%, 430px);
+  padding: 2.25rem;
+  place-items: center;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(20, 33, 61, 0.13);
+  border-radius: 18px;
+  box-shadow: 0 20px 55px rgba(20, 33, 61, 0.1);
+}
+
+.statusIcon {
+  display: grid;
+  width: 58px;
+  height: 58px;
+  margin: 2rem 0 1rem;
+  color: #fff;
+  place-items: center;
+  background: #eef1f5;
+  border-radius: 50%;
+}
+.statusIcon[data-status='success'] { background: #4e8f78; }
+.statusIcon[data-status='error'] { background: #b8574b; }
+.card h1 { margin: 0; font-family: Georgia, 'Times New Roman', serif; font-size: 1.8rem; }
+.message { margin-top: 0.55rem; color: #667085; line-height: 1.55; }
+.actions { display: grid; gap: 1rem; width: 100%; margin-top: 1.5rem; }

--- a/src/app/callback/page.tsx
+++ b/src/app/callback/page.tsx
@@ -1,134 +1,94 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
+import { Anchor, Button, Loader, Text } from '@mantine/core';
+import { IconAlertCircle, IconCheck } from '@tabler/icons-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { notifications } from '@mantine/notifications';
-import { Anchor, Center, Loader, Stack, Text } from '@mantine/core';
-import { Suspense } from 'react';
-import {BASE_URL} from "../../utils/DevMode";
+import { CrossweaveLogo } from '../../components/NavBar/CrossweaveLogo';
+import classes from './Callback.module.css';
 
-const clientId = process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_ID;
-const clientSecret = process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_SECRET;
-
-const redirectUri = `${BASE_URL}/callback`;
+type CallbackState = 'loading' | 'success' | 'error';
 
 function CallbackPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const hasProcessedRef = useRef(false);
-  const [error, setError] = useState(false);
-
+  const [status, setStatus] = useState<CallbackState>('loading');
+  const [message, setMessage] = useState('Confirming your Stacky account…');
 
   useEffect(() => {
     if (hasProcessedRef.current) return;
     hasProcessedRef.current = true;
 
-    const fetchAccessToken = async (code: string, instance: string) => {
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    if (!code || !state) {
+      setStatus('error');
+      setMessage('The login response was incomplete. Please start again.');
+      return;
+    }
+
+    if (localStorage.getItem('accessToken')) {
+      router.replace('/home');
+      return;
+    }
+
+    const finishLogin = async () => {
       try {
-        const response = await fetch(`${instance}/oauth/token`, {
+        const response = await fetch('/api/auth/mastodon/callback', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            client_id: clientId,
-            client_secret: clientSecret,
-            redirect_uri: redirectUri,
-            grant_type: 'authorization_code',
-            code,
-          }),
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code, state }),
         });
-
-        const data = await response.json();
-        if (response.ok) {
-          const accessToken = data.access_token;
-          localStorage.setItem('accessToken', accessToken);
-
-          // get user info
-          const userResponse = await fetch(`${instance}/api/v1/accounts/verify_credentials`, {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-            },
-          });
-          const userData = await userResponse.json();
-          if (userResponse.ok) {
-            localStorage.setItem('currentUser', JSON.stringify(userData));
-            notifications.show({
-              title: 'Success',
-              message: 'Login successful. User info stored in localStorage.',
-              color: 'green',
-            });
-            router.push('/home'); // direct to home page
-          } else {
-            console.error('Failed to fetch user info:', userData);
-            notifications.show({
-              title: 'Error',
-              message: 'Failed to fetch user info.',
-              color: 'red',
-            });
-            setError(true);
-          }
-        } else {
-          console.error('Error response from token endpoint:', data);
-          throw new Error(data.error || 'Unknown error');
+        const data = await response.json().catch(() => null);
+        if (!response.ok || !data?.accessToken || !data?.account) {
+          throw new Error(data?.error || 'Login could not be completed.');
         }
+
+        localStorage.setItem('accessToken', data.accessToken);
+        localStorage.setItem('currentUser', JSON.stringify(data.account));
+        localStorage.setItem('mastodonInstance', data.instance);
+        const accountName = data.account.display_name || `@${data.account.acct}`;
+        setStatus('success');
+        setMessage(`Signed in as ${accountName}`);
+        notifications.show({ title: 'Welcome to CrossWeave', message: `Signed in as @${data.account.acct}.`, color: 'green' });
+        const timeout = window.setTimeout(() => router.replace('/home'), 500);
+        return () => window.clearTimeout(timeout);
       } catch (error) {
-        notifications.show({
-          title: 'Error',
-          message: 'Login failed.',
-          color: 'red',
-        });
-        console.error('Error during token exchange:', error);
-        setError(true);
+        console.error('Mastodon login failed:', error);
+        setStatus('error');
+        setMessage(error instanceof Error ? error.message : 'Login could not be completed.');
       }
     };
 
-    const code = searchParams.get('code');
-    const state = searchParams.get('state');
-    const instance = `https://${state}`;
-    console.log('Authorization code:', code);
-    if (!code || !state) {
-      setError(true);
-      return;
-    }
-    if (localStorage.getItem('accessToken')) {
-      router.push('/home');
-      return;
-    }
-    fetchAccessToken(code, instance);
-  }, [searchParams, router]);
-
-  // On failure, send the user back to the login page after a short delay so
-  // they aren't stranded on a stalled spinner. The "Back to login" link below
-  // lets them leave immediately.
-  useEffect(() => {
-    if (!error) return;
-    const t = setTimeout(() => router.push('/'), 4000);
-    return () => clearTimeout(t);
-  }, [error, router]);
-
-  if (error) {
-    return (
-      <Center my={45}>
-        <Stack align="center" gap="xs">
-          <Text fw={500}>Login failed.</Text>
-          <Text size="sm" c="dimmed">Redirecting you to the login page…</Text>
-          <Anchor href="/">Back to login</Anchor>
-        </Stack>
-      </Center>
-    );
-  }
+    void finishLogin();
+  }, [router, searchParams]);
 
   return (
-    <Center>
-      <Loader color="blue" size={41} my={45} />
-    </Center>
+    <main className={classes.page}>
+      <section className={classes.card} aria-live="polite">
+        <CrossweaveLogo height={34} />
+        <div className={classes.statusIcon} data-status={status}>
+          {status === 'loading' && <Loader size={30} color="blue" />}
+          {status === 'success' && <IconCheck size={32} aria-hidden="true" />}
+          {status === 'error' && <IconAlertCircle size={32} aria-hidden="true" />}
+        </div>
+        <h1>{status === 'loading' ? 'Signing you in' : status === 'success' ? 'You’re signed in' : 'Login failed.'}</h1>
+        <Text className={classes.message}>{message}</Text>
+        {status === 'error' && (
+          <div className={classes.actions}>
+            <Button component="a" href="/api/auth/mastodon/start" color="dark">Try again</Button>
+            <Anchor href="/">Back to login</Anchor>
+          </div>
+        )}
+      </section>
+    </main>
   );
 }
-
 export default function Callback() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense fallback={<main className={classes.page}><Loader /></main>}>
       <CallbackPage />
     </Suspense>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,114 +1,129 @@
 'use client';
 
-import {useState} from 'react';
-import { Text, Button, TextInput, Center, Container, Paper, Divider, Stack } from '@mantine/core';
-import { useForm } from '@mantine/form';
-import { notifications } from '@mantine/notifications';
+import { useState } from 'react';
+import { Anchor, Button, Divider, Text } from '@mantine/core';
+import { IconArrowRight, IconCheck, IconExternalLink, IconUserPlus } from '@tabler/icons-react';
 import { useRouter } from 'next/navigation';
 import { CrossweaveLogo } from '../components/NavBar/CrossweaveLogo';
+import { MASTODON_INSTANCE_URL } from '../utils/mastodonApi';
+import { prepareForMastodonLogin, startStudySession } from '../utils/studyMode';
 import classes from './LandingPage.module.css';
-import {BASE_URL} from "../utils/DevMode";
-import { prepareForMastodonLogin, startStudySession } from "../utils/studyMode";
 
-
-
-interface FormValues {
-  instanceDomain: string;
-}
-
-const redirectUri = `${BASE_URL}/callback`;
-const scopes = 'read write follow';
+const ACCOUNT_REGISTRATION_URL = `${MASTODON_INSTANCE_URL}/auth/sign_up`;
 
 export default function LandingPage() {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
-  const form = useForm<FormValues>({
-    initialValues: {
-      instanceDomain: '',
-    },
-    validate: {
-      instanceDomain: (value) =>
-          /^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value)
-              ? null
-              : 'Please enter a valid instance domain, e.g., mastodon.social or beta.stacky.social',
-    },
-  });
-
   const handleLogin = () => {
     prepareForMastodonLogin();
     setIsLoading(true);
-    notifications.show({
-      title: 'Logging in',
-      message: 'Attempting to Login to Mastodon...',
-    });
-    const clientId = process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_ID;
-    const instanceUrl = `https://${form.values.instanceDomain}`;
-    const authorizationUrl = `${instanceUrl}/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scopes}&state=${form.values.instanceDomain}`;
-    console.log("Authorization URL:", authorizationUrl);
-    window.location.href = authorizationUrl;
+    window.location.assign('/api/auth/mastodon/start');
   };
 
-  const handleStartStudy = () => {
+  const handleStartDemo = () => {
     startStudySession();
     router.push('/home');
   };
 
-
   return (
-    <>
-      <Center className={classes.landingPageContent}>
-        <Container size={460} className={classes.container}>
-          <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
-            <CrossweaveLogo height={56} />
-          </div>
-          <Text c="dimmed" ta="center" size="md" className={classes.subtitle}>
-            AI-Curated Democratic Discourse
-          </Text>
+    <main className={classes.page}>
+      <div className={classes.weaveRail} aria-hidden="true">
+        <span /><span /><span /><span />
+      </div>
 
-          <Paper radius="lg" p="xl" withBorder className={classes.paper}>
-            <Stack gap="sm">
-              <Text size="xl" fw={700} ta="center">
-                Explore CrossWeave
-              </Text>
-              <Text size="sm" c="dimmed" ta="center">
-                Start with a fresh participant profile. No account or password is required.
-              </Text>
-              <Button
-                type="button"
-                fullWidth
-                size="md"
-                mt="sm"
-                radius="xl"
-                color="teal"
-                onClick={handleStartStudy}
-                data-testid="start-study-session"
-              >
-                Start study session
-              </Button>
-            </Stack>
+      <div className={classes.shell}>
+        <header className={classes.brandBar}>
+          <CrossweaveLogo height={38} />
+          <Text className={classes.instanceLabel}>A social space on Stacky</Text>
+        </header>
 
-            <Divider label="or" labelPosition="center" my="xl" />
-
-            <Text size="sm" fw={600} ta="center" mb="md" c="dimmed">
-              Continue with a Mastodon account
+        <div className={classes.layout}>
+          <section className={classes.introduction} aria-labelledby="welcome-title">
+            <Text className={classes.kicker}>Social conversation, with the missing context restored</Text>
+            <h1 id="welcome-title" className={classes.headline}>
+              Follow the conversation.<br />See how ideas connect.
+            </h1>
+            <Text className={classes.lede}>
+              CrossWeave is a Mastodon-powered community where posts stay familiar,
+              while related perspectives, evidence, and questions appear alongside them.
             </Text>
 
-            <form onSubmit={form.onSubmit(handleLogin)}>
-              <TextInput
-                required
-                radius="lg"
-                label="Mastodon Instance"
-                placeholder="instance domain"
-                {...form.getInputProps('instanceDomain')}
-              />
-              <Button type="submit" fullWidth loading={isLoading} mt="lg" radius="xl" color="gray" variant="light">
-                Continue with Mastodon
-              </Button>
-            </form>
-          </Paper>
-        </Container>
-      </Center>
-    </>
+            <ol className={classes.steps} aria-label="What you can do in CrossWeave">
+              <li><span><IconCheck size={16} /></span><div><strong>Read your real home timeline</strong><small>Posts from people you follow, fetched from Stacky.</small></div></li>
+              <li><span><IconCheck size={16} /></span><div><strong>Post and respond normally</strong><small>Your posts, likes, and bookmarks are saved to Mastodon.</small></div></li>
+              <li><span><IconCheck size={16} /></span><div><strong>Explore related responses</strong><small>CrossWeave adds context without changing the original post.</small></div></li>
+            </ol>
+
+            <div className={classes.threadPreview} aria-hidden="true">
+              <div className={classes.previewRail}><i /><i /><i /><i /></div>
+              <div className={classes.previewPost}><b /><span><i /><i /></span></div>
+              <div className={classes.previewBranch} />
+              <div className={classes.previewPost}><b /><span><i /><i /></span></div>
+              <div className={classes.previewContext}><em /><em /><em /></div>
+            </div>
+          </section>
+
+          <section className={classes.accessCard} aria-labelledby="access-title">
+            <div className={classes.cardHeader}>
+              <Text className={classes.cardEyebrow}>Your account</Text>
+              <h2 id="access-title" className={classes.cardTitle}>Sign in to CrossWeave</h2>
+              <Text className={classes.cardCopy}>
+                Continue with your Stacky account. You will confirm access on the Mastodon sign-in page.
+              </Text>
+            </div>
+
+            <Button
+              fullWidth
+              size="lg"
+              radius="md"
+              className={classes.primaryButton}
+              rightSection={<IconArrowRight size={18} />}
+              loading={isLoading}
+              onClick={handleLogin}
+              data-testid="mastodon-sign-in"
+            >
+              Sign in
+            </Button>
+
+            <Button
+              component="a"
+              href={ACCOUNT_REGISTRATION_URL}
+              fullWidth
+              size="md"
+              radius="md"
+              variant="outline"
+              className={classes.createButton}
+              leftSection={<IconUserPlus size={18} />}
+              rightSection={<IconExternalLink size={15} />}
+              data-testid="create-account"
+            >
+              Create an account
+            </Button>
+
+            <Text className={classes.privacyCopy}>
+              CrossWeave never receives your password. Authentication is handled by the Stacky Mastodon server.
+            </Text>
+
+            <Divider label="Want to look around first?" labelPosition="center" className={classes.divider} />
+
+            <button className={classes.demoButton} type="button" onClick={handleStartDemo} data-testid="start-study-session">
+              <span>
+                <strong>Explore the JSON demo</strong>
+                <small>No account needed · changes stay on this device</small>
+              </span>
+              <IconArrowRight size={18} />
+            </button>
+
+            <Text className={classes.terms}>
+              By continuing, you agree to follow the community rules.{' '}
+              <Anchor href={`${MASTODON_INSTANCE_URL}/about`} target="_blank" rel="noreferrer">
+                About this server
+              </Anchor>
+            </Text>
+          </section>
+        </div>
+      </div>
+    </main>
   );
 }

--- a/src/components/AiModifiedDisclosure.tsx
+++ b/src/components/AiModifiedDisclosure.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React, { useEffect, useId, useMemo, useRef, useState } from "react";
+import { IconSparkles } from "@tabler/icons-react";
+import { createWordDiffExcerpt } from "../utils/wordDiff.mjs";
+
+type AiModifiedDisclosureProps = {
+  originalContent: string;
+  rewrittenContent: string;
+  editSummary?: string;
+};
+
+/** Editorial track-changes disclosure used only on compact related-post cards. */
+export default function AiModifiedDisclosure({
+  originalContent,
+  rewrittenContent,
+  editSummary,
+}: AiModifiedDisclosureProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const popoverId = useId();
+  const diff = useMemo(
+    () => createWordDiffExcerpt(originalContent, rewrittenContent),
+    [originalContent, rewrittenContent],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const dismissOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", dismissOnEscape);
+    return () => document.removeEventListener("keydown", dismissOnEscape);
+  }, [open]);
+
+  return (
+    <div
+      ref={rootRef}
+      className="ai-edit-disclosure"
+      data-ai-edit
+      onClick={(event) => event.stopPropagation()}
+      onPointerEnter={(event) => {
+        if (event.pointerType !== "touch") setOpen(true);
+      }}
+      onPointerLeave={(event) => {
+        if (event.pointerType !== "touch") setOpen(false);
+      }}
+      onFocus={() => setOpen(true)}
+      onBlur={(event) => {
+        const next = event.relatedTarget;
+        if (!(next instanceof Node) || !rootRef.current?.contains(next)) setOpen(false);
+      }}
+    >
+      <button
+        type="button"
+        className="ai-edit-badge"
+        aria-expanded={open}
+        aria-controls={popoverId}
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen((current) => !current);
+        }}
+      >
+        <IconSparkles size={12} stroke={2} aria-hidden />
+        Modified by AI
+      </button>
+
+      {open && (
+        <div id={popoverId} className="ai-edit-popover" role="note" aria-label="Changes made by AI">
+          <div className="ai-edit-popover-heading">
+            <span>Context edit</span>
+            <span className="ai-edit-legend" aria-hidden>
+              <i className="ai-edit-legend-delete" /> removed
+              <i className="ai-edit-legend-insert" /> added
+            </span>
+          </div>
+          <p className="ai-edit-summary">
+            {editSummary || "AI added context to clarify why this post is related."}
+          </p>
+          <p className="ai-edit-diff" aria-label="AI-edited text">
+            {diff.map((chunk, index) => {
+              if (chunk.kind === "delete") return <del key={index}>{chunk.text}</del>;
+              if (chunk.kind === "insert") return <ins key={index}>{chunk.text}</ins>;
+              return <React.Fragment key={index}>{chunk.text}</React.Fragment>;
+            })}
+          </p>
+          <p className="ai-edit-original-note">The original post is preserved when you open it.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/AiModifiedDisclosure.tsx
+++ b/src/components/AiModifiedDisclosure.tsx
@@ -1,92 +1,67 @@
 "use client";
 
-import React, { useEffect, useId, useMemo, useRef, useState } from "react";
+import React, { useEffect, useId, useRef } from "react";
 import { IconSparkles } from "@tabler/icons-react";
-import { createWordDiffExcerpt } from "../utils/wordDiff.mjs";
 
 type AiModifiedDisclosureProps = {
-  originalContent: string;
-  rewrittenContent: string;
+  active: boolean;
   editSummary?: string;
+  onActiveChange: (active: boolean) => void;
 };
 
-/** Editorial track-changes disclosure used only on compact related-post cards. */
+/** Controls the in-card track-changes layer without opening a tooltip. */
 export default function AiModifiedDisclosure({
-  originalContent,
-  rewrittenContent,
+  active,
   editSummary,
+  onActiveChange,
 }: AiModifiedDisclosureProps) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement | null>(null);
-  const popoverId = useId();
-  const diff = useMemo(
-    () => createWordDiffExcerpt(originalContent, rewrittenContent),
-    [originalContent, rewrittenContent],
-  );
+  const descriptionId = useId();
+  const lastPointerTypeRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!open) return;
+    if (!active) return;
     const dismissOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
+      if (event.key === "Escape") onActiveChange(false);
     };
     document.addEventListener("keydown", dismissOnEscape);
     return () => document.removeEventListener("keydown", dismissOnEscape);
-  }, [open]);
+  }, [active, onActiveChange]);
 
   return (
-    <div
-      ref={rootRef}
+    <span
       className="ai-edit-disclosure"
       data-ai-edit
       onClick={(event) => event.stopPropagation()}
+      onPointerDown={(event) => {
+        lastPointerTypeRef.current = event.pointerType;
+      }}
       onPointerEnter={(event) => {
-        if (event.pointerType !== "touch") setOpen(true);
+        if (event.pointerType !== "touch") onActiveChange(true);
       }}
       onPointerLeave={(event) => {
-        if (event.pointerType !== "touch") setOpen(false);
+        if (event.pointerType !== "touch") onActiveChange(false);
       }}
-      onFocus={() => setOpen(true)}
-      onBlur={(event) => {
-        const next = event.relatedTarget;
-        if (!(next instanceof Node) || !rootRef.current?.contains(next)) setOpen(false);
-      }}
+      onFocus={() => onActiveChange(true)}
+      onBlur={() => onActiveChange(false)}
     >
       <button
         type="button"
         className="ai-edit-badge"
-        aria-expanded={open}
-        aria-controls={popoverId}
+        aria-pressed={active}
+        aria-describedby={descriptionId}
         onClick={(event) => {
           event.stopPropagation();
-          setOpen((current) => !current);
+          if (lastPointerTypeRef.current === "touch") onActiveChange(!active);
+          else onActiveChange(true);
         }}
       >
         <IconSparkles size={12} stroke={2} aria-hidden />
         Modified by AI
       </button>
-
-      {open && (
-        <div id={popoverId} className="ai-edit-popover" role="note" aria-label="Changes made by AI">
-          <div className="ai-edit-popover-heading">
-            <span>Context edit</span>
-            <span className="ai-edit-legend" aria-hidden>
-              <i className="ai-edit-legend-delete" /> removed
-              <i className="ai-edit-legend-insert" /> added
-            </span>
-          </div>
-          <p className="ai-edit-summary">
-            {editSummary || "AI added context to clarify why this post is related."}
-          </p>
-          <p className="ai-edit-diff" aria-label="AI-edited text">
-            {diff.map((chunk, index) => {
-              if (chunk.kind === "delete") return <del key={index}>{chunk.text}</del>;
-              if (chunk.kind === "insert") return <ins key={index}>{chunk.text}</ins>;
-              return <React.Fragment key={index}>{chunk.text}</React.Fragment>;
-            })}
-          </p>
-          <p className="ai-edit-original-note">The original post is preserved when you open it.</p>
-        </div>
-      )}
-    </div>
+      <span id={descriptionId} className="ai-edit-sr-only">
+        Hover or focus to show tracked edits directly in this post.
+        {editSummary ? ` ${editSummary}` : ""}
+      </span>
+    </span>
   );
 }

--- a/src/components/AiModifiedDisclosure.tsx
+++ b/src/components/AiModifiedDisclosure.tsx
@@ -59,7 +59,8 @@ export default function AiModifiedDisclosure({
         Modified by AI
       </button>
       <span id={descriptionId} className="ai-edit-sr-only">
-        Hover or focus to show tracked edits directly in this post.
+        This post shows the edited wording by default. Hover or focus to reveal
+        additions and removals directly in place.
         {editSummary ? ` ${editSummary}` : ""}
       </span>
     </span>

--- a/src/components/NavBar/TopNav.tsx
+++ b/src/components/NavBar/TopNav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Group, ActionIcon, Tooltip, Box, Button } from "@mantine/core";
+import { Group, ActionIcon, Tooltip, Box } from "@mantine/core";
 import {
     IconHome,
     IconMessages,
@@ -27,7 +27,7 @@ const LINKS = [
 
 /**
  * Horizontal sticky top nav bar (D-NAV): logo on the left, condensed icon
- * links, and a Logout button on the right.
+ * links, and a compact log-out action on the right.
  * Replaces the old left nav column + collapse burger.
  */
 export function TopNav() {
@@ -62,7 +62,7 @@ export function TopNav() {
         }
     };
 
-    const handleEndStudySession = () => {
+    const handleStudyLogOut = () => {
         endStudySession();
         router.push("/");
     };
@@ -118,35 +118,19 @@ export function TopNav() {
                     );
                 })}
 
-                {studyMode ? (
-                    <Button
-                        variant="light"
+                {!studyMode && <ExperimentPanel />}
+                <Tooltip label="Log out" withArrow>
+                    <ActionIcon
+                        variant="subtle"
                         color="red"
-                        size="xs"
-                        radius="xl"
-                        leftSection={<IconLogout size={16} stroke={1.8} />}
-                        data-testid="end-study-session"
-                        onClick={handleEndStudySession}
+                        size="lg"
+                        aria-label="Log out"
+                        data-testid="nav-logout"
+                        onClick={studyMode ? handleStudyLogOut : handleLogOut}
                     >
-                        End study session
-                    </Button>
-                ) : (
-                    <>
-                        <ExperimentPanel />
-                        <Tooltip label="Logout" withArrow>
-                            <ActionIcon
-                                variant="subtle"
-                                color="red"
-                                size="lg"
-                                aria-label="Logout"
-                                data-testid="nav-logout"
-                                onClick={handleLogOut}
-                            >
-                                <IconLogout size={20} stroke={1.8} />
-                            </ActionIcon>
-                        </Tooltip>
-                    </>
-                )}
+                        <IconLogout size={20} stroke={1.8} />
+                    </ActionIcon>
+                </Tooltip>
             </Group>
         </Box>
     );

--- a/src/components/NavBar/TopNav.tsx
+++ b/src/components/NavBar/TopNav.tsx
@@ -14,10 +14,6 @@ import CrossweaveLogo from "./CrossweaveLogo";
 import { ExperimentPanel } from "./ExperimentPanel";
 import { endStudySession, useStudyMode } from "../../utils/studyMode";
 
-const MastodonInstanceUrl = "https://beta.stacky.social";
-const clientId = process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_ID;
-const clientSecret = process.env.NEXT_PUBLIC_MASTODON_OAUTH_CLIENT_SECRET;
-
 /** Height of the sticky top nav bar (used by the shell for sticky offsets). */
 export const TOP_NAV_HEIGHT = 56;
 
@@ -44,14 +40,9 @@ export function TopNav() {
             typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
         try {
             if (accessToken) {
-                await fetch(`${MastodonInstanceUrl}/oauth/revoke`, {
+                await fetch('/api/auth/mastodon/revoke', {
                     method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                        client_id: clientId,
-                        client_secret: clientSecret,
-                        token: accessToken,
-                    }),
+                    headers: { Authorization: `Bearer ${accessToken}` },
                 });
             }
         } catch (error) {
@@ -63,6 +54,7 @@ export function TopNav() {
             localStorage.removeItem("accessToken");
             localStorage.removeItem("currentUser");
             localStorage.removeItem("authCode");
+            localStorage.removeItem("mastodonInstance");
             // Session-scoped scroll/back-navigation keys shouldn't outlive the
             // login either.
             sessionStorage.clear();

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { LoadingOverlay, Button, Box, Paper, Text, Anchor } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import Link from 'next/link';
@@ -17,6 +17,7 @@ import {
     useLocalStore,
     useHydrated,
     getHomeFeed,
+    getFollowedDemoFeed,
     getBookmarks,
     getLiked,
     getPost,
@@ -162,6 +163,8 @@ interface PostListProps {
     setActivePostId: (id: string | null) => void;
     showLoadMore?: boolean;
     ready: boolean;
+    /** Blend explicitly followed JSON posts into an authenticated timeline. */
+    includeFollowedDemo?: boolean;
     /** When set, the feed reads reactively from the localStore instead of fetching `apiUrl`. */
     source?: FeedSource;
 }
@@ -187,6 +190,7 @@ const ApiFeed: React.FC<PostListProps> = ({
     setActivePostId,
     showLoadMore = false,
     ready,
+    includeFollowedDemo = false,
 }) => {
     // Check cache synchronously during initialization to avoid a loading flash.
     // Stored in a ref so subsequent renders don't re-evaluate the cache check.
@@ -197,6 +201,25 @@ const ApiFeed: React.FC<PostListProps> = ({
     const hasCachedData = !!cachedSnapshot.current;
 
     const [posts, setPosts] = useState<PostType[]>(() => cachedSnapshot.current?.posts ?? []);
+    const localHydrated = useHydrated();
+    const followedDemoStorePosts = useLocalStore(() => getFollowedDemoFeed());
+    const followedDemoPosts = useMemo(
+        () => includeFollowedDemo && localHydrated
+            ? followedDemoStorePosts.map(storeToPost)
+            : [],
+        [followedDemoStorePosts, includeFollowedDemo, localHydrated],
+    );
+    const followedDemoIds = useMemo(
+        () => new Set(followedDemoPosts.map((post) => post.postId)),
+        [followedDemoPosts],
+    );
+    const displayPosts = useMemo(() => {
+        const unique = new Map<string, PostType>();
+        for (const post of [...posts, ...followedDemoPosts]) unique.set(post.postId, post);
+        return Array.from(unique.values()).sort(
+            (a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt),
+        );
+    }, [posts, followedDemoPosts]);
     const [loading, setLoading] = useState(() => !hasCachedData);
     const [loadingMore, setLoadingMore] = useState(false);
     const [maxId, setMaxId] = useState<string | null>(() => cachedSnapshot.current?.maxId ?? null);
@@ -259,7 +282,7 @@ const ApiFeed: React.FC<PostListProps> = ({
     // Mirror reactive values into refs so the scroll listener can attach ONCE
     // (stable deps) and still read the latest posts/activePostId/callbacks. This
     // avoids re-subscribing the window scroll listener on every posts update.
-    const postsRef = useRef(posts); postsRef.current = posts;
+    const postsRef = useRef(displayPosts); postsRef.current = displayPosts;
     const activePostIdRef = useRef(activePostId); activePostIdRef.current = activePostId;
     const handleStackIconClickRef = useRef(handleStackIconClick); handleStackIconClickRef.current = handleStackIconClick;
     const setActivePostIdRef = useRef(setActivePostId); setActivePostIdRef.current = setActivePostId;
@@ -549,8 +572,8 @@ const ApiFeed: React.FC<PostListProps> = ({
     // If the first post is already highlighted before its stacks load,
     // publish its related stacks to the aside once they arrive
     useEffect(() => {
-        if (!loadStackInfo || posts.length === 0) return;
-        const first = posts[0];
+        if (!loadStackInfo || displayPosts.length === 0) return;
+        const first = displayPosts[0];
         if (
             activePostId === first.postId &&
             Array.isArray(first.relatedStacks) &&
@@ -563,14 +586,14 @@ const ApiFeed: React.FC<PostListProps> = ({
             handleStackIconClick(first.relatedStacks, first.postId, adjustedPosition);
             hasPublishedFirstPostStacksRef.current = true;
         }
-    }, [posts, activePostId, loadStackInfo, handleStackIconClick]);
+    }, [displayPosts, activePostId, loadStackInfo, handleStackIconClick]);
 
     // Auto-highlight the first post once on initial page load only,
     // and wait until related stacks info is available when loadStackInfo is true
     useEffect(() => {
-        if (hasAutoHighlightedFirstPostRef.current || posts.length === 0 || activePostId) return;
+        if (hasAutoHighlightedFirstPostRef.current || displayPosts.length === 0 || activePostId) return;
 
-        const firstPost = posts[0];
+        const firstPost = displayPosts[0];
         if (loadStackInfo) {
             if (firstPost.stackCount === null) return;
         }
@@ -582,7 +605,7 @@ const ApiFeed: React.FC<PostListProps> = ({
         setActivePostId(firstPost.postId);
         handleStackIconClick(firstPost.relatedStacks, firstPost.postId, adjustedPosition);
         hasAutoHighlightedFirstPostRef.current = true;
-    }, [posts, activePostId, handleStackIconClick, setActivePostId, loadStackInfo]);
+    }, [displayPosts, activePostId, handleStackIconClick, setActivePostId, loadStackInfo]);
 
     const loadStackDataInBatches = useCallback(async (posts: PostType[], batchSize: number) => {
         for (let i = 0; i < posts.length; i += batchSize) {
@@ -646,6 +669,7 @@ const ApiFeed: React.FC<PostListProps> = ({
     const renderPost = (_index: number, post: PostType) => (
         <div
             data-post-id={post.postId}
+            data-feed-origin={followedDemoIds.has(post.postId) ? 'demo' : 'mastodon'}
             ref={(node) => registerPostNodeRef.current(node, post.postId)}
         >
             <Post
@@ -702,16 +726,16 @@ const ApiFeed: React.FC<PostListProps> = ({
     return (
         <Box style={{ width: '100%', position: 'relative', minHeight: 80 }}>
             <LoadingOverlay visible={loading} overlayProps={{ radius: "sm", blur: 2 }} />
-            {!loading && posts.length === 0 && (
+            {!loading && displayPosts.length === 0 && (
                 <Paper withBorder radius="md" p="xl" style={{ textAlign: 'center', marginTop: 16 }} data-testid="api-feed-empty">
                     <Text fw={600}>{emptyCopy}</Text>
                     <Text size="sm" c="dimmed" mt={4}>There is nothing to show from the server right now.</Text>
                 </Paper>
             )}
-            {!loading && posts.length > 0 && (
+            {!loading && displayPosts.length > 0 && (
                 <Virtuoso
                     useWindowScroll
-                    data={posts}
+                    data={displayPosts}
                     itemContent={renderPost}
                     computeItemKey={(_index: number, post: PostType) => post.postId}
                     // Auto-load the next page when the user nears the end (in

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { LoadingOverlay, Button, Box, Paper, Text, Anchor } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import Link from 'next/link';
@@ -7,6 +7,12 @@ import { Virtuoso } from 'react-virtuoso';
 import { PostType } from '../types/PostType';
 import Post from './Posts/Post';
 import axios from 'axios';
+import {
+    MASTODON_STATUS_CREATED_EVENT,
+    RELATED_POSTS_API_URL,
+    type MastodonStatus,
+} from '../utils/mastodonApi';
+import { nextMaxIdFromLink } from '../utils/mastodonPagination.mjs';
 import {
     useLocalStore,
     useHydrated,
@@ -70,13 +76,40 @@ function storeToPost(post: StorePost): PostType {
     };
 }
 
-const MastodonInstanceUrl = 'https://beta.stacky.social:3002';
+function mastodonStatusToPost(post: MastodonStatus, loadStackInfo: boolean): PostType {
+    return {
+        postId: post.id,
+        text: post.content,
+        author: post.account.display_name || post.account.username,
+        account: post.account.acct,
+        avatar: post.account.avatar,
+        createdAt: post.created_at,
+        replies: post.replies_count as unknown as PostType['replies'],
+        replies_count: post.replies_count,
+        stackCount: loadStackInfo ? null : -1,
+        favouritesCount: post.favourites_count,
+        favourited: post.favourited,
+        bookmarked: post.bookmarked,
+        mediaAttachments: (post.media_attachments || []).map((attachment) => attachment.url),
+        relatedStacks: [],
+        focusRelations: [],
+        inReplyToId: typeof post.in_reply_to_id === 'string' ? post.in_reply_to_id : null,
+        replyingToAccount: null,
+        previewCard: post.card ? {
+            title: post.card.title,
+            description: post.card.description,
+            image: post.card.image || undefined,
+            url: post.card.url,
+        } : null,
+    };
+}
 
 // Module-level cache survives component remounts during SPA navigation
 // without the size limits of sessionStorage
 interface PostListCache {
     posts: PostType[];
     maxId: string | null;
+    hasMore: boolean;
     timestamp: number;
     fetchedAt: number;
 }
@@ -167,6 +200,9 @@ const ApiFeed: React.FC<PostListProps> = ({
     const [loading, setLoading] = useState(() => !hasCachedData);
     const [loadingMore, setLoadingMore] = useState(false);
     const [maxId, setMaxId] = useState<string | null>(() => cachedSnapshot.current?.maxId ?? null);
+    const maxIdRef = useRef<string | null>(maxId);
+    maxIdRef.current = maxId;
+    const [hasMore, setHasMore] = useState(() => cachedSnapshot.current?.hasMore ?? Boolean(cachedSnapshot.current?.maxId));
     const hasAutoHighlightedFirstPostRef = useRef(false);
     const hasPublishedFirstPostStacksRef = useRef(false);
     const scrollStopTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -174,6 +210,7 @@ const ApiFeed: React.FC<PostListProps> = ({
     const manualActiveIdRef = useRef<string | null>(null);
     const manualLockRef = useRef(false);
     const fetchKeyRef = useRef<string | null>(null);
+    const loadMoreInFlightRef = useRef(false);
     const restoredScrollRef = useRef(false);
 
     // Currently-viewport-intersecting post nodes, keyed by data-post-id. Kept up
@@ -258,30 +295,6 @@ const ApiFeed: React.FC<PostListProps> = ({
         fetchPosts();
     }, [apiUrl, accessToken, loadStackInfo, ready]);
 
-    const mapResponseToPosts = (data: any[]): PostType[] =>
-        data.map((post: any) => ({
-            postId: post.id,
-            text: post.content,
-            author: post.account.username,
-            account: post.account.acct,
-            avatar: post.account.avatar,
-            createdAt: post.created_at,
-            replies: post.replies_count,
-            replies_count: post.replies_count,
-            stackCount: loadStackInfo ? null : -1,
-            favouritesCount: post.favourites_count,
-            favourited: post.favourited,
-            bookmarked: post.bookmarked,
-            mediaAttachments: (post.media_attachments || []).map((m: any) => m.url),
-            relatedStacks: [],
-            previewCard: post.card ? {
-                title: post.card.title,
-                description: post.card.description,
-                image: post.card.image || undefined,
-                url: post.card.url,
-            } : null
-        }));
-
     const fetchPosts = async (isLoadMore = false) => {
         try {
             if (isLoadMore) {
@@ -297,20 +310,30 @@ const ApiFeed: React.FC<PostListProps> = ({
                 headers,
                 params: {
                     limit: 40,
-                    ...(maxId && { max_id: maxId }) // 如果有 maxId 就加上 max_id 参数
+                    ...(isLoadMore && maxIdRef.current && { max_id: maxIdRef.current })
                 }
             });
 
-            const data: PostType[] = mapResponseToPosts(response.data);
+            const data: PostType[] = (response.data as MastodonStatus[])
+                .map((post) => mastodonStatusToPost(post, loadStackInfo));
 
-            setPosts((prevPosts) => isLoadMore ? [...prevPosts, ...data] : data);
-            if (data.length > 0) {
-                setMaxId(data[data.length - 1].postId);
-            }
+            setPosts((prevPosts) => {
+                if (!isLoadMore) return data;
+                const seen = new Set(prevPosts.map((post) => post.postId));
+                return [...prevPosts, ...data.filter((post) => !seen.has(post.postId))];
+            });
+            const linkedNextId = nextMaxIdFromLink(response.headers.link);
+            // Link is authoritative. The full-page fallback supports older or
+            // proxied Mastodon responses that strip the header.
+            const nextId = linkedNextId ?? (data.length === 40 ? data[data.length - 1]?.postId ?? null : null);
+            maxIdRef.current = nextId;
+            setMaxId(nextId);
+            setHasMore(Boolean(nextId));
 
-            if (loadStackInfo) {
-                await loadStackDataInBatches(data, 2);
-            }
+            // Timeline content is the critical path. Related metadata hydrates
+            // after the posts are visible, so a slow auxiliary service never
+            // blocks reading or pagination.
+            if (loadStackInfo) void loadStackDataInBatches(data, 2);
         } catch (error) {
             console.error('Error fetching Mastodon data:', error);
             notifications.show({
@@ -321,12 +344,14 @@ const ApiFeed: React.FC<PostListProps> = ({
         } finally {
             setLoading(false);
             setLoadingMore(false);
+            if (isLoadMore) loadMoreInFlightRef.current = false;
         }
     };
 
     const handleLoadMore = () => {
-        if (loadingMore || loading) return;
-        fetchPosts(true);
+        if (loadingMore || loading || !hasMore || !maxIdRef.current || loadMoreInFlightRef.current) return;
+        loadMoreInFlightRef.current = true;
+        void fetchPosts(true);
     };
 
     const getScrollAnchor = (): { postId: string; offsetFromViewport: number } | null => {
@@ -353,7 +378,8 @@ const ApiFeed: React.FC<PostListProps> = ({
                 params: { limit: 40 },
             });
 
-            const freshPosts: PostType[] = mapResponseToPosts(response.data);
+            const freshPosts: PostType[] = (response.data as MastodonStatus[])
+                .map((post) => mastodonStatusToPost(post, loadStackInfo));
 
             // Capture scroll anchor before updating state
             const anchor = getScrollAnchor();
@@ -383,10 +409,11 @@ const ApiFeed: React.FC<PostListProps> = ({
                 return merged;
             });
 
-            // Update maxId for Load More continuity
-            if (freshPosts.length > 0) {
-                setMaxId(freshPosts[freshPosts.length - 1].postId);
-            }
+            const linkedNextId = nextMaxIdFromLink(response.headers.link);
+            const nextId = linkedNextId ?? (freshPosts.length === 40 ? freshPosts[freshPosts.length - 1]?.postId ?? null : null);
+            maxIdRef.current = nextId;
+            setMaxId(nextId);
+            setHasMore(Boolean(nextId));
 
             // Restore scroll position after merge
             if (anchor) {
@@ -557,16 +584,14 @@ const ApiFeed: React.FC<PostListProps> = ({
         hasAutoHighlightedFirstPostRef.current = true;
     }, [posts, activePostId, handleStackIconClick, setActivePostId, loadStackInfo]);
 
-    const loadStackDataInBatches = async (posts: PostType[], batchSize: number) => {
+    const loadStackDataInBatches = useCallback(async (posts: PostType[], batchSize: number) => {
         for (let i = 0; i < posts.length; i += batchSize) {
             const batch = posts.slice(i, i + batchSize);
             await Promise.all(batch.map(async (post) => {
                 try {
-                    const headers: Record<string, string> = {};
-                    if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
-                    const response = await axios.get(`${MastodonInstanceUrl}/stacks/${post.postId}/related`, { headers });
-                    const stackData = response.data.relatedStacks || [];
-                    const stackCount = response.data.size;
+                    const response = await axios.get(`${RELATED_POSTS_API_URL}/stacks/${post.postId}/related`);
+                    const stackData = Array.isArray(response.data.relatedStacks) ? response.data.relatedStacks : [];
+                    const stackCount = Number.isFinite(response.data.size) ? response.data.size : stackData.length;
                     setPosts((prevPosts) =>
                         prevPosts.map((p) =>
                             p.postId === post.postId
@@ -575,11 +600,35 @@ const ApiFeed: React.FC<PostListProps> = ({
                         )
                     );
                 } catch (error) {
-                    console.error(`Error fetching stack data for post ${post.postId}:`, error);
+                    // Most Mastodon statuses will not have CrossWeave relations.
+                    // Resolve those lookups to a stable empty value so focus and
+                    // pagination never wait forever on an optional service.
+                    console.warn(`No related-post data for ${post.postId}:`, error);
+                    setPosts((prevPosts) =>
+                        prevPosts.map((candidate) =>
+                            candidate.postId === post.postId
+                                ? { ...candidate, stackCount: 0, relatedStacks: [] }
+                                : candidate
+                        )
+                    );
                 }
             }));
         }
-    };
+    }, []);
+
+    // A successful composer POST returns the canonical Mastodon status. Insert
+    // it immediately, then hydrate related-post metadata in the background.
+    useEffect(() => {
+        const onStatusCreated = (event: Event) => {
+            const status = (event as CustomEvent<MastodonStatus>).detail;
+            if (!status?.id) return;
+            const created = mastodonStatusToPost(status, loadStackInfo);
+            setPosts((current) => [created, ...current.filter((post) => post.postId !== created.postId)]);
+            if (loadStackInfo) void loadStackDataInBatches([created], 1);
+        };
+        window.addEventListener(MASTODON_STATUS_CREATED_EVENT, onStatusCreated);
+        return () => window.removeEventListener(MASTODON_STATUS_CREATED_EVENT, onStatusCreated);
+    }, [loadStackInfo, loadStackDataInBatches]);
 
     // Save to in-memory cache whenever posts update (even partially loaded stacks)
     useEffect(() => {
@@ -587,11 +636,12 @@ const ApiFeed: React.FC<PostListProps> = ({
         cacheSet(cacheKeyFor(apiUrl, accessToken), {
             posts,
             maxId,
+            hasMore,
             timestamp: Date.now(),
             fetchedAt: Date.now(),
         });
         pruneCache(postListCacheMap, MAX_CACHE_ENTRIES);
-    }, [posts, loading, apiUrl, maxId, accessToken]);
+    }, [posts, loading, apiUrl, maxId, hasMore, accessToken]);
 
     const renderPost = (_index: number, post: PostType) => (
         <div
@@ -630,7 +680,7 @@ const ApiFeed: React.FC<PostListProps> = ({
     );
 
     const Footer = () => {
-        if (!showLoadMore || loading) return null;
+        if (!showLoadMore || loading || !hasMore) return null;
         return (
             <div style={{ textAlign: 'center', margin: '20px 0' }}>
                 <Button onClick={handleLoadMore} disabled={loadingMore}
@@ -641,10 +691,24 @@ const ApiFeed: React.FC<PostListProps> = ({
         );
     };
 
+    const emptyCopy = apiUrl.includes('/bookmarks')
+        ? 'No Mastodon bookmarks yet.'
+        : apiUrl.includes('/favourites')
+            ? 'No liked Mastodon posts yet.'
+            : apiUrl.includes('/timelines/home')
+                ? 'Your Mastodon home timeline is empty.'
+                : 'No posts found.';
+
     return (
         <Box style={{ width: '100%', position: 'relative', minHeight: 80 }}>
             <LoadingOverlay visible={loading} overlayProps={{ radius: "sm", blur: 2 }} />
-            {!loading && (
+            {!loading && posts.length === 0 && (
+                <Paper withBorder radius="md" p="xl" style={{ textAlign: 'center', marginTop: 16 }} data-testid="api-feed-empty">
+                    <Text fw={600}>{emptyCopy}</Text>
+                    <Text size="sm" c="dimmed" mt={4}>There is nothing to show from the server right now.</Text>
+                </Paper>
+            )}
+            {!loading && posts.length > 0 && (
                 <Virtuoso
                     useWindowScroll
                     data={posts}
@@ -652,7 +716,7 @@ const ApiFeed: React.FC<PostListProps> = ({
                     computeItemKey={(_index: number, post: PostType) => post.postId}
                     // Auto-load the next page when the user nears the end (in
                     // addition to the explicit Load more button in the footer).
-                    endReached={showLoadMore ? () => handleLoadMore() : undefined}
+                    endReached={showLoadMore && hasMore ? () => handleLoadMore() : undefined}
                     increaseViewportBy={600}
                     components={{ Footer }}
                 />

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -13,6 +13,7 @@ import {
     getHomeFeed,
     getBookmarks,
     getLiked,
+    getPost,
     type Post as StorePost,
 } from '../utils/localStore';
 
@@ -44,6 +45,7 @@ function selectStoreFeed(source: FeedSource): StorePost[] {
  *  Mirrors PostList's `mapResponseToPosts` so store posts render identically to
  *  REST posts (the `replies` field is set to the count, as the REST path does). */
 function storeToPost(post: StorePost): PostType {
+    const parent = post.in_reply_to_id ? getPost(post.in_reply_to_id) : undefined;
     return {
         postId: post.id,
         text: post.content,
@@ -61,6 +63,9 @@ function storeToPost(post: StorePost): PostType {
             typeof m === 'string' ? m : m.url
         ),
         relatedStacks: Array.isArray(post.relatedStacks) ? post.relatedStacks : [],
+        focusRelations: Array.isArray(post.focusRelations) ? post.focusRelations : [],
+        inReplyToId: post.in_reply_to_id ?? null,
+        replyingToAccount: parent?.account.acct ?? null,
         previewCard: null,
     };
 }
@@ -618,6 +623,8 @@ const ApiFeed: React.FC<PostListProps> = ({
                     setActivePostId(id);
                 }}
                 initialCard={post.previewCard || null}
+                focusRelations={post.focusRelations}
+                replyingToAccount={post.replyingToAccount}
             />
         </div>
     );
@@ -682,6 +689,61 @@ const StoreFeed: React.FC<PostListProps & { source: FeedSource }> = ({
     // immediately after mount.
     const posts: PostType[] = hydrated ? storePosts.map(storeToPost) : [];
 
+    // Keep Home's related pane synced to the post nearest the viewport center,
+    // matching the API-backed feed. This makes relation discovery passive and
+    // predictable: scroll onto a focus post and its related responses appear;
+    // scroll onto an ordinary reply and the stable right column becomes blank.
+    const activePostIdRef = useRef(activePostId);
+    activePostIdRef.current = activePostId;
+    const postsRef = useRef(posts);
+    postsRef.current = posts;
+    const postMapRef = useRef(new Map(posts.map((post) => [post.postId, post])));
+    postMapRef.current = new Map(posts.map((post) => [post.postId, post]));
+    const stackHandlerRef = useRef(handleStackIconClick);
+    stackHandlerRef.current = handleStackIconClick;
+
+    useEffect(() => {
+        if (source !== 'home' || !hydrated || postsRef.current.length === 0) return;
+        let scrollTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const evaluate = () => {
+            const viewportCenter = window.innerHeight / 2;
+            let best: { post: PostType; rect: DOMRect; distance: number } | null = null;
+            const elements = Array.from(
+                document.querySelectorAll<HTMLElement>('[data-store-feed-post]'),
+            );
+            for (const element of elements) {
+                const rect = element.getBoundingClientRect();
+                if (rect.bottom <= 0 || rect.top >= window.innerHeight) continue;
+                const postId = element.dataset.storeFeedPost;
+                const post = postId ? postMapRef.current.get(postId) : undefined;
+                if (!post) continue;
+                const distance = Math.abs(rect.top + rect.height / 2 - viewportCenter);
+                if (!best || distance < best.distance) best = { post, rect, distance };
+            }
+
+            if (!best || best.post.postId === activePostIdRef.current) return;
+            activePostIdRef.current = best.post.postId;
+            setActivePostId(best.post.postId);
+            stackHandlerRef.current(best.post.relatedStacks, best.post.postId, {
+                top: best.rect.top + window.scrollY,
+                height: best.rect.height,
+            });
+        };
+
+        const initialFrame = requestAnimationFrame(evaluate);
+        const onScroll = () => {
+            if (scrollTimer) clearTimeout(scrollTimer);
+            scrollTimer = setTimeout(evaluate, 50);
+        };
+        window.addEventListener('scroll', onScroll, { passive: true });
+        return () => {
+            cancelAnimationFrame(initialFrame);
+            if (scrollTimer) clearTimeout(scrollTimer);
+            window.removeEventListener('scroll', onScroll);
+        };
+    }, [hydrated, source, setActivePostId]);
+
     // Mirror the apiUrl path's manual-selection bookkeeping so clicking a post
     // both highlights it and (when relatedStacks exist) drives the aside.
     const lastUserActivateRef = useRef<number>(0);
@@ -722,6 +784,7 @@ const StoreFeed: React.FC<PostListProps & { source: FeedSource }> = ({
                 <div
                     key={post.postId}
                     data-post-id={post.postId}
+                    data-store-feed-post={post.postId}
                 >
                     <Post
                         id={post.postId}
@@ -758,6 +821,9 @@ const StoreFeed: React.FC<PostListProps & { source: FeedSource }> = ({
                             setActivePostId(id);
                         }}
                         initialCard={post.previewCard || null}
+                        focusRelations={post.focusRelations}
+                        replyingToAccount={post.replyingToAccount}
+                        appearance={source === 'home' ? 'timeline' : 'card'}
                     />
                 </div>
             ))}

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -832,6 +832,10 @@ interface PostProps {
   /** Count of displayed replies linked to a span union — merged into the
    *  focused post's dwell tooltip on the thread view (honest two-pane counts). */
   replyCountForSpans?: (ranges: Array<{ fs: number; fe: number }>) => number;
+  /** Timeline cards form one continuous stream; card is the default everywhere else. */
+  appearance?: 'card' | 'timeline';
+  /** Parent account handle displayed as reply provenance in timeline views. */
+  replyingToAccount?: string | null;
 }
 
 function Post({
@@ -862,6 +866,8 @@ function Post({
   activeClusterTopic = null,
   relatedCountForSpans,
   replyCountForSpans,
+  appearance = 'card',
+  replyingToAccount = null,
 }: PostProps) {
   const router = useRouter();
   const [cardHeight, setCardHeight] = useState(0);
@@ -891,6 +897,7 @@ function Post({
   const isTextExpandedRef = useRef(isTextExpanded);
   isTextExpandedRef.current = isTextExpanded;
   const [hovered, setHovered] = useState(false);
+  const isTimeline = appearance === 'timeline';
 
   const [previewCards, setPreviewCards] = useState<PreviewCard[]>(initialCard ? [initialCard] : []);
   const [tempRelatedStacks, setTempRelatedStacks] = useState<any[]>(relatedStacks);
@@ -1244,7 +1251,7 @@ function Post({
   };
 
   return (
-    <div style={{ position: 'relative', marginBottom: '1rem'}}>
+    <div style={{ position: 'relative', marginBottom: isTimeline ? 0 : '1rem'}}>
       <Paper
         ref={paperRef}
         data-testid="post"
@@ -1253,16 +1260,19 @@ function Post({
         style={{
           position: 'relative',
           width: "100%",
-          backgroundColor: '#fff',
+          backgroundColor: isTimeline && hovered ? '#fbfcff' : '#fff',
           zIndex: 5,
-          borderRadius: '10px',
-          border: isActive ? '2px solid rgb(156, 184, 255)' : '2px solid #e7e7e7',
-          boxShadow: isActive ? 'rgba(0, 0, 0, 0.18) 0px 12px 24px, rgba(0, 0, 0, 0.12) 0px 6px 12px' : 'none',
-          transform: isActive ? 'translateY(-2px)' : 'none',
+          borderRadius: isTimeline ? 0 : '10px',
+          border: isTimeline ? 'none' : (isActive ? '2px solid rgb(156, 184, 255)' : '2px solid #e7e7e7'),
+          borderBottom: isTimeline ? '1px solid #e3e2dc' : undefined,
+          boxShadow: isTimeline
+            ? (isActive ? 'inset 3px 0 0 #5a71a8' : 'none')
+            : (isActive ? 'rgba(0, 0, 0, 0.18) 0px 12px 24px, rgba(0, 0, 0, 0.12) 0px 6px 12px' : 'none'),
+          transform: !isTimeline && isActive ? 'translateY(-2px)' : 'none',
           // Border switches instantly (not transitioned) so the active outline
           // can't be caught mid-fade showing the inactive colour during scroll
           // re-renders (R-FEED-5). Elevation/lift still animate.
-          transition: 'box-shadow 150ms ease, transform 150ms ease',
+          transition: 'background-color 120ms ease, box-shadow 150ms ease, transform 150ms ease',
           paddingLeft: '1rem',
           paddingRight: '1rem',
           paddingTop: '1rem',
@@ -1346,6 +1356,21 @@ function Post({
             )}
           </Group>
         </div>
+
+        {replyingToAccount && (
+          <Text
+            data-testid="reply-context"
+            size="xs"
+            style={{
+              paddingLeft: `${BODY_INDENT_PX}px`,
+              marginTop: '2px',
+              marginBottom: '3px',
+              color: '#6b7280',
+            }}
+          >
+            Replying to <span style={{ color: '#4f669d', fontWeight: 600 }}>@{replyingToAccount.split('@')[0]}</span>
+          </Text>
+        )}
 
         <div
           // X-style: the body + media indent to align under the USERNAME, past the

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -1260,8 +1260,11 @@ function Post({
           backgroundColor: isTimeline && hovered ? '#fbfcff' : '#fff',
           zIndex: 5,
           borderRadius: isTimeline ? 0 : '10px',
-          border: isTimeline ? 'none' : (isActive ? '2px solid rgb(156, 184, 255)' : '2px solid #e7e7e7'),
-          borderBottom: isTimeline ? '1px solid #e3e2dc' : undefined,
+          borderStyle: 'solid',
+          borderWidth: isTimeline ? '0 0 1px' : '2px',
+          borderColor: isTimeline
+            ? '#e3e2dc'
+            : (isActive ? 'rgb(156, 184, 255)' : '#e7e7e7'),
           boxShadow: isTimeline
             ? (isActive ? 'inset 3px 0 0 #5a71a8' : 'none')
             : (isActive ? 'rgba(0, 0, 0, 0.18) 0px 12px 24px, rgba(0, 0, 0, 0.12) 0px 6px 12px' : 'none'),

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -1046,14 +1046,12 @@ function Post({
     setLikeCount((c) => Math.max(0, c + (wasLiked ? -1 : 1)));
 
     try {
-      // Persists to the local store (flips liked[] + favourites_count) and returns
-      // { ok: true, value: <new liked state> }. ok is always true in local mode,
-      // so this just confirms the optimistic update; the revert path is retained
-      // for the future swap back to REST.
+      // Persists to Mastodon when authenticated and to the local JSON store in
+      // demo mode, then confirms or reverts the optimistic state.
       const result = await toggleFavourite(id, wasLiked);
       if (!mountedRef.current) return;
       if (result.ok) {
-        // Confirm against the store's authoritative new state.
+        // Confirm against the active data source's authoritative state.
         setLiked(result.value);
         showUndoableAction({
           title: result.value ? 'Post liked' : 'Like removed',
@@ -1099,9 +1097,8 @@ function Post({
     setBookmarkedState(!wasBookmarked);
 
     try {
-      // Persists to the local store (flips bookmarked[]) and returns
-      // { ok: true, value: <new bookmarked state> }. ok is always true in local
-      // mode; the revert path is retained for the future swap back to REST.
+      // Persists to Mastodon when authenticated and to the local JSON store in
+      // demo mode, then confirms or reverts the optimistic state.
       const result = await toggleBookmark(id, wasBookmarked);
       if (!mountedRef.current) return;
       if (result.ok) {

--- a/src/components/Posts/Post.tsx
+++ b/src/components/Posts/Post.tsx
@@ -933,6 +933,13 @@ function Post({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, favourited, bookmarked, favouritesCount]);
 
+  // Reply counts can change after a local reply or a background Mastodon
+  // refresh. Keep the stateful action row aligned with the latest parent prop;
+  // previously it permanently retained the value from the first render.
+  useEffect(() => {
+    setReplyCount(repliesCount);
+  }, [id, repliesCount]);
+
   useEffect(() => {
     const element = textRef.current;
     if (!element) return;

--- a/src/components/Posts/Posts.tsx
+++ b/src/components/Posts/Posts.tsx
@@ -5,7 +5,7 @@ import PostList from '../PostList';
 import { useRelatedStacks } from "../../app/(shell)/related-stacks-context";
 import { useAccessToken } from '../../utils/useAccessToken';
 
-export default function Posts({ apiUrl, loadStackInfo, showSubmitAndSearch, showLoadMore = false, source, }: { apiUrl?: string, loadStackInfo: boolean, showSubmitAndSearch: boolean, showLoadMore?: boolean; source?: "home" | "bookmarks" | "liked"; }) {
+export default function Posts({ apiUrl, loadStackInfo, showSubmitAndSearch, showLoadMore = false, source, includeFollowedDemo = false, }: { apiUrl?: string, loadStackInfo: boolean, showSubmitAndSearch: boolean, showLoadMore?: boolean; source?: "home" | "bookmarks" | "liked"; includeFollowedDemo?: boolean; }) {
     const { token: accessToken, ready } = useAccessToken();
     const [activePostId, setActivePostId] = useState<string | null>(null);
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -53,6 +53,7 @@ export default function Posts({ apiUrl, loadStackInfo, showSubmitAndSearch, show
                     activePostId={activePostId}
                     setActivePostId={setActivePostId}
                     showLoadMore={showLoadMore}
+                    includeFollowedDemo={includeFollowedDemo}
                 />
             </div>
             {/* Related stacks are now rendered in AppShell.Aside via context */}

--- a/src/components/Posts/Posts.tsx
+++ b/src/components/Posts/Posts.tsx
@@ -1,20 +1,15 @@
 "use client";
-import React, { useEffect, useState, useRef } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import React, { useCallback, useEffect, useState } from 'react';
 import { SubmitPost } from '../SubmitPost/SubmitPost';
-import SearchBar from '../SearchBar/SearchBar';
-import RelatedStacks from '../RelatedStacks';
 import PostList from '../PostList';
 import { useRelatedStacks } from "../../app/(shell)/related-stacks-context";
 import { useAccessToken } from '../../utils/useAccessToken';
-import { getMockRelatedStacks } from '../../utils/mockPostResolver';
 
 export default function Posts({ apiUrl, loadStackInfo, showSubmitAndSearch, showLoadMore = false, source, }: { apiUrl?: string, loadStackInfo: boolean, showSubmitAndSearch: boolean, showLoadMore?: boolean; source?: "home" | "bookmarks" | "liked"; }) {
     const { token: accessToken, ready } = useAccessToken();
     const [activePostId, setActivePostId] = useState<string | null>(null);
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [isExpandModalOpen, setIsExpandModalOpen] = useState(false);
-    const [previousPostId, setPreviousPostId] = useState<string | null>(null);
 
     const { setFromPost, activePostId: asideActivePostId, relatedStacks: asideStacks, clear } = useRelatedStacks();
 
@@ -22,29 +17,24 @@ export default function Posts({ apiUrl, loadStackInfo, showSubmitAndSearch, show
     // over from a previous focus so it never shows orphaned (no highlighted post).
     useEffect(() => { clear(); }, [clear]);
 
-    const handleStackIconClick = (incomingRelatedStacks: any[], postId: string, _position: { top: number, height: number }) => {
+    const handleStackIconClick = useCallback((incomingRelatedStacks: any[], postId: string, _position: { top: number, height: number }) => {
         const togglingOff = postId === asideActivePostId && Array.isArray(asideStacks) && asideStacks.length > 0;
-        // Store-feed posts (home/bookmarks/liked) carry no inline related stacks;
-        // fall back to the mock dataset so the related panel still populates.
-        const stacksToPublish =
-            Array.isArray(incomingRelatedStacks) && incomingRelatedStacks.length > 0
-                ? incomingRelatedStacks
-                : (getMockRelatedStacks(postId) || []);
+        // Publish only the relation payload carried by the post adapter. This is
+        // the same contract a real timeline/related-post API will satisfy and
+        // avoids a demo-only resolver silently inventing data for empty posts.
+        const stacksToPublish = Array.isArray(incomingRelatedStacks) ? incomingRelatedStacks : [];
         setFromPost(stacksToPublish, postId);
-        setPreviousPostId(activePostId);
         setActivePostId(togglingOff ? null : postId);
         setIsExpandModalOpen(false);
-    };
+    }, [activePostId, asideActivePostId, asideStacks, setFromPost]);
 
-
-    const shouldUpdate = activePostId !== previousPostId;
     return (
-        <div style={{ position: 'relative' }}>
+        <div style={{ position: 'relative' }} data-home-timeline={source === 'home' ? 'true' : undefined}>
             <div>
                 {showSubmitAndSearch && (
-                    <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '2rem' }}>
+                    <div style={{ display: 'flex', justifyContent: 'center', marginBottom: source === 'home' ? 0 : '2rem' }}>
                         <div style={{ width: '100%' }}>
-                            <SubmitPost />
+                            <SubmitPost appearance={source === 'home' ? 'timeline' : 'card'} />
                         </div>
                     </div>
                 )}

--- a/src/components/Posts/Posts.tsx
+++ b/src/components/Posts/Posts.tsx
@@ -29,12 +29,15 @@ export default function Posts({ apiUrl, loadStackInfo, showSubmitAndSearch, show
     }, [activePostId, asideActivePostId, asideStacks, setFromPost]);
 
     return (
-        <div style={{ position: 'relative' }} data-home-timeline={source === 'home' ? 'true' : undefined}>
+        <div
+            style={{ position: 'relative' }}
+            data-home-timeline={source === 'home' || apiUrl?.includes('/timelines/home') ? 'true' : undefined}
+        >
             <div>
                 {showSubmitAndSearch && (
-                    <div style={{ display: 'flex', justifyContent: 'center', marginBottom: source === 'home' ? 0 : '2rem' }}>
+                    <div style={{ display: 'flex', justifyContent: 'center', marginBottom: source === 'home' || apiUrl?.includes('/timelines/home') ? 0 : '2rem' }}>
                         <div style={{ width: '100%' }}>
-                            <SubmitPost appearance={source === 'home' ? 'timeline' : 'card'} />
+                            <SubmitPost appearance={source === 'home' || apiUrl?.includes('/timelines/home') ? 'timeline' : 'card'} />
                         </div>
                     </div>
                 )}

--- a/src/components/RelatedStacks.css
+++ b/src/components/RelatedStacks.css
@@ -92,3 +92,150 @@
     background: #f4f1e8;
     border-color: #9ca8bf;
   }
+
+  /* Contextual AI edits borrow the visual grammar of document track changes:
+     red strike-through for removed language, green underline for additions. */
+  .ai-edit-disclosure {
+    position: relative;
+    display: inline-flex;
+    margin: 0 0 7px;
+    z-index: 8;
+  }
+
+  .ai-edit-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-height: 24px;
+    padding: 3px 7px;
+    color: #4c3f78;
+    background: #f3f0ff;
+    border: 1px solid #c9c1e8;
+    border-radius: 5px;
+    font: inherit;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    cursor: help;
+  }
+
+  .ai-edit-badge:hover,
+  .ai-edit-badge:focus-visible,
+  .ai-edit-badge[aria-expanded="true"] {
+    color: #35265f;
+    background: #e9e3ff;
+    border-color: #9f93cf;
+    outline: none;
+  }
+
+  .ai-edit-badge:focus-visible {
+    box-shadow: 0 0 0 3px rgba(117, 96, 176, 0.2);
+  }
+
+  .ai-edit-popover {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    width: min(310px, calc(100cqw - 72px));
+    min-width: 0;
+    padding: 11px 12px 10px;
+    color: #263044;
+    background: #fffefb;
+    border: 1px solid #b8bec9;
+    border-radius: 7px;
+    box-shadow: 0 14px 32px rgba(28, 43, 74, 0.18), 0 2px 8px rgba(28, 43, 74, 0.1);
+    cursor: default;
+  }
+
+  .ai-edit-popover::before {
+    content: "";
+    position: absolute;
+    top: -5px;
+    left: 16px;
+    width: 8px;
+    height: 8px;
+    background: #fffefb;
+    border-top: 1px solid #b8bec9;
+    border-left: 1px solid #b8bec9;
+    transform: rotate(45deg);
+  }
+
+  .ai-edit-popover-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 5px;
+    color: #30384a;
+    font-size: 11px;
+    font-weight: 800;
+  }
+
+  .ai-edit-legend {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: #6b7280;
+    font-size: 10px;
+    font-weight: 600;
+  }
+
+  .ai-edit-legend i {
+    display: inline-block;
+    width: 9px;
+    height: 3px;
+    border-radius: 2px;
+  }
+
+  .ai-edit-legend-delete { background: #d96b6b; }
+  .ai-edit-legend-insert { background: #4a9b68; }
+
+  .ai-edit-summary,
+  .ai-edit-diff,
+  .ai-edit-original-note {
+    margin: 0;
+  }
+
+  .ai-edit-summary {
+    margin-bottom: 8px;
+    color: #626b7b;
+    font-size: 11px;
+    line-height: 1.4;
+  }
+
+  .ai-edit-diff {
+    max-height: 122px;
+    overflow: auto;
+    color: #30384a;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 11.5px;
+    line-height: 1.55;
+  }
+
+  .ai-edit-diff del {
+    color: #8f2f35;
+    background: #fde5e5;
+    text-decoration-color: #b83c45;
+    text-decoration-thickness: 1.5px;
+  }
+
+  .ai-edit-diff ins {
+    color: #17613a;
+    background: #ddf5e6;
+    text-decoration-color: #2d8955;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 2px;
+  }
+
+  .ai-edit-original-note {
+    margin-top: 8px;
+    padding-top: 7px;
+    color: #70798a;
+    border-top: 1px solid #e1e4e9;
+    font-size: 10px;
+    line-height: 1.35;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ai-edit-badge { transition: none; }
+  }

--- a/src/components/RelatedStacks.css
+++ b/src/components/RelatedStacks.css
@@ -96,10 +96,8 @@
   /* Contextual AI edits borrow the visual grammar of document track changes:
      red strike-through for removed language, green underline for additions. */
   .ai-edit-disclosure {
-    position: relative;
     display: inline-flex;
     margin: 0 0 7px;
-    z-index: 8;
   }
 
   .ai-edit-badge {
@@ -116,12 +114,12 @@
     font-size: 10px;
     font-weight: 700;
     letter-spacing: 0.01em;
-    cursor: help;
+    cursor: default;
   }
 
   .ai-edit-badge:hover,
   .ai-edit-badge:focus-visible,
-  .ai-edit-badge[aria-expanded="true"] {
+  .ai-edit-badge[aria-pressed="true"] {
     color: #35265f;
     background: #e9e3ff;
     border-color: #9f93cf;
@@ -132,94 +130,45 @@
     box-shadow: 0 0 0 3px rgba(117, 96, 176, 0.2);
   }
 
-  .ai-edit-popover {
-    position: absolute;
-    top: calc(100% + 6px);
-    left: 0;
-    width: min(310px, calc(100cqw - 72px));
-    min-width: 0;
-    padding: 11px 12px 10px;
-    color: #263044;
-    background: #fffefb;
-    border: 1px solid #b8bec9;
-    border-radius: 7px;
-    box-shadow: 0 14px 32px rgba(28, 43, 74, 0.18), 0 2px 8px rgba(28, 43, 74, 0.1);
-    cursor: default;
+  /* The original text remains in normal flow and permanently owns the card's
+     geometry. The tracked-edit layer occupies the exact same rectangle, so
+     switching it on can never reflow or resize the related-post card. */
+  .ai-edit-text-stage {
+    position: relative;
+    margin: 0 0 0.4rem;
   }
 
-  .ai-edit-popover::before {
-    content: "";
-    position: absolute;
-    top: -5px;
-    left: 16px;
-    width: 8px;
-    height: 8px;
-    background: #fffefb;
-    border-top: 1px solid #b8bec9;
-    border-left: 1px solid #b8bec9;
-    transform: rotate(45deg);
-  }
-
-  .ai-edit-popover-heading {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 5px;
-    color: #30384a;
-    font-size: 11px;
-    font-weight: 800;
-  }
-
-  .ai-edit-legend {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    color: #6b7280;
-    font-size: 10px;
-    font-weight: 600;
-  }
-
-  .ai-edit-legend i {
-    display: inline-block;
-    width: 9px;
-    height: 3px;
-    border-radius: 2px;
-  }
-
-  .ai-edit-legend-delete { background: #d96b6b; }
-  .ai-edit-legend-insert { background: #4a9b68; }
-
-  .ai-edit-summary,
-  .ai-edit-diff,
-  .ai-edit-original-note {
+  .ai-edit-original-text,
+  .ai-edit-inline-text {
     margin: 0;
+    transition: opacity 90ms ease;
   }
 
-  .ai-edit-summary {
-    margin-bottom: 8px;
-    color: #626b7b;
-    font-size: 11px;
-    line-height: 1.4;
+  .ai-edit-inline-text {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
   }
 
-  .ai-edit-diff {
-    max-height: 122px;
-    overflow: auto;
-    color: #30384a;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    font-size: 11.5px;
-    line-height: 1.55;
+  .ai-edit-text-stage.is-active .ai-edit-original-text {
+    opacity: 0;
+    pointer-events: none;
   }
 
-  .ai-edit-diff del {
+  .ai-edit-text-stage.is-active .ai-edit-inline-text {
+    opacity: 1;
+  }
+
+  .ai-edit-inline-text del {
     color: #8f2f35;
     background: #fde5e5;
     text-decoration-color: #b83c45;
     text-decoration-thickness: 1.5px;
   }
 
-  .ai-edit-diff ins {
+  .ai-edit-inline-text ins {
     color: #17613a;
     background: #ddf5e6;
     text-decoration-color: #2d8955;
@@ -227,15 +176,20 @@
     text-underline-offset: 2px;
   }
 
-  .ai-edit-original-note {
-    margin-top: 8px;
-    padding-top: 7px;
-    color: #70798a;
-    border-top: 1px solid #e1e4e9;
-    font-size: 10px;
-    line-height: 1.35;
+  .ai-edit-sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .ai-edit-badge { transition: none; }
+    .ai-edit-badge,
+    .ai-edit-original-text,
+    .ai-edit-inline-text { transition: none; }
   }

--- a/src/components/RelatedStacks.css
+++ b/src/components/RelatedStacks.css
@@ -130,15 +130,15 @@
     box-shadow: 0 0 0 3px rgba(117, 96, 176, 0.2);
   }
 
-  /* The original text remains in normal flow and permanently owns the card's
-     geometry. The tracked-edit layer occupies the exact same rectangle, so
-     switching it on can never reflow or resize the related-post card. */
+  /* The edited/published text remains in normal flow and permanently owns the
+     card's geometry. The tracked-edit layer occupies the exact same rectangle,
+     so revealing provenance can never resize the related-post card. */
   .ai-edit-text-stage {
     position: relative;
     margin: 0 0 0.4rem;
   }
 
-  .ai-edit-original-text,
+  .ai-edit-edited-text,
   .ai-edit-inline-text {
     margin: 0;
     transition: opacity 90ms ease;
@@ -152,7 +152,7 @@
     pointer-events: none;
   }
 
-  .ai-edit-text-stage.is-active .ai-edit-original-text {
+  .ai-edit-text-stage.is-active .ai-edit-edited-text {
     opacity: 0;
     pointer-events: none;
   }
@@ -190,6 +190,6 @@
 
   @media (prefers-reduced-motion: reduce) {
     .ai-edit-badge,
-    .ai-edit-original-text,
+    .ai-edit-edited-text,
     .ai-edit-inline-text { transition: none; }
   }

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -19,6 +19,7 @@ import type { Relation } from '../types/PostType';
 import { showTooltip, hideTooltip, type TooltipColors } from './HoverTooltip';
 import { showUndoableAction } from '../utils/actionNotifications';
 import AiModifiedDisclosure from './AiModifiedDisclosure';
+import { createWordDiffExcerpt } from '../utils/wordDiff.mjs';
 import './RelatedStacks.css';
 
 interface PostType {
@@ -856,6 +857,18 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
   // Per-card expanded state, keyed by stackId
   const [expandedCards, setExpandedCards] = useState<Record<string, boolean>>({});
   const [visibleCardCount, setVisibleCardCount] = useState(RELATED_PAGE_SIZE);
+  const [activeAiEditPostId, setActiveAiEditPostId] = useState<string | null>(null);
+  const aiDiffByPostId = useMemo(() => {
+    const diffs = new Map<string, ReturnType<typeof createWordDiffExcerpt>>();
+    for (const stack of relatedStacks) {
+      const rewrite = stack.topPost.rewrite;
+      if (!rewrite?.significant || !rewrite.content) continue;
+      const original = (stack.topPost.content || '').replace(/<[^>]*>/g, '');
+      const revised = rewrite.content.replace(/<[^>]*>/g, '');
+      diffs.set(stack.topPost.id, createWordDiffExcerpt(original, revised, 55));
+    }
+    return diffs;
+  }, [relatedStacks]);
 
   const isFavourited = (postId: string, initial: boolean) =>
     favouritedOverride[postId] !== undefined ? favouritedOverride[postId] : initial;
@@ -1910,6 +1923,8 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
           const isHighlighted = !!highlightPostId && stack.topPost.id === highlightPostId;
           const colors = getCategoryColors(stack.rel);
           const isExpanded = !!expandedCards[stack.stackId];
+          const aiDiff = aiDiffByPostId.get(stack.topPost.id);
+          const isAiEditActive = activeAiEditPostId === stack.topPost.id && !!aiDiff;
 
           // Strip HTML so the text matches the relations' PLAIN-text offsets.
           // The mock resolver wraps card content as `<p>…</p>`, which both leaks
@@ -2588,9 +2603,11 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                   {/* D3: shortest common related text label — only when span filter is active */}
                   {stack.topPost.rewrite?.significant && stack.topPost.rewrite.content && (
                     <AiModifiedDisclosure
-                      originalContent={plainContent}
-                      rewrittenContent={stack.topPost.rewrite.content.replace(/<[^>]*>/g, '')}
+                      active={isAiEditActive}
                       editSummary={stack.topPost.rewrite.editSummary}
+                      onActiveChange={(active) => {
+                        setActiveAiEditPostId(active ? stack.topPost.id : null);
+                      }}
                     />
                   )}
 
@@ -2610,11 +2627,38 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                       </Text>
                     </div>
                   )}
-                  <Text component="p" size="sm" lh={1.55} c="#011445" style={{ margin: '0 0 0.4rem 0' }}>
-                    {hasPrefix && <span style={{ color: '#94a3b8', userSelect: 'none' }}>…</span>}
-                    {contentNodes}
-                    {hasSuffix && !isExpanded && <span style={{ color: '#94a3b8', userSelect: 'none' }}>…</span>}
-                  </Text>
+                  <div className={`ai-edit-text-stage${isAiEditActive ? ' is-active' : ''}`}>
+                    <Text
+                      component="p"
+                      size="sm"
+                      lh={1.55}
+                      c="#011445"
+                      className="ai-edit-original-text"
+                      aria-hidden={isAiEditActive}
+                    >
+                      {hasPrefix && <span style={{ color: '#94a3b8', userSelect: 'none' }}>…</span>}
+                      {contentNodes}
+                      {hasSuffix && !isExpanded && <span style={{ color: '#94a3b8', userSelect: 'none' }}>…</span>}
+                    </Text>
+                    {aiDiff && (
+                      <Text
+                        component="p"
+                        size="sm"
+                        lh={1.55}
+                        c="#011445"
+                        className="ai-edit-inline-text"
+                        data-ai-inline-diff
+                        aria-hidden={!isAiEditActive}
+                        aria-label={stack.topPost.rewrite.editSummary || 'AI changes shown in this post'}
+                      >
+                        {aiDiff.map((chunk, chunkIndex) => {
+                          if (chunk.kind === 'delete') return <del key={chunkIndex}>{chunk.text}</del>;
+                          if (chunk.kind === 'insert') return <ins key={chunkIndex}>{chunk.text}</ins>;
+                          return <React.Fragment key={chunkIndex}>{chunk.text}</React.Fragment>;
+                        })}
+                      </Text>
+                    )}
+                  </div>
 
                   {/* Read more / See less */}
                   {(isTruncated || isExpanded) && (

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -19,7 +19,7 @@ import type { Relation } from '../types/PostType';
 import { showTooltip, hideTooltip, type TooltipColors } from './HoverTooltip';
 import { showUndoableAction } from '../utils/actionNotifications';
 import AiModifiedDisclosure from './AiModifiedDisclosure';
-import { createWordDiffExcerpt } from '../utils/wordDiff.mjs';
+import { createAlignedWordDiffWindow } from '../utils/wordDiff.mjs';
 import './RelatedStacks.css';
 
 interface PostType {
@@ -677,22 +677,27 @@ function buildMultiHighlightNodes(
 const WINDOW_CHARS = 140;
 
 /** Window content around the first relation's content range. Returns adjusted relations with shifted offsets. */
-function windowContent(plain: string, relations: Relation[] | undefined, expanded: boolean): {
+function windowContent(
+  plain: string,
+  relations: Relation[] | undefined,
+  expanded: boolean,
+  preferredBounds?: { start: number; end: number },
+): {
   text: string; adjustedRelations: Relation[] | undefined; hasPrefix: boolean; hasSuffix: boolean;
 } {
-  if (!relations || relations.length === 0) {
-    return { text: plain, adjustedRelations: relations, hasPrefix: false, hasSuffix: false };
-  }
   const totalChars = WINDOW_CHARS * 2;
   if (expanded || plain.length <= totalChars) {
     return { text: plain, adjustedRelations: relations, hasPrefix: false, hasSuffix: false };
   }
-  const first = relations[0];
-  const center = Math.floor((first.contentStart + first.contentEnd) / 2);
-  const start = Math.max(0, center - WINDOW_CHARS);
-  const end = Math.min(plain.length, center + WINDOW_CHARS);
+  if ((!relations || relations.length === 0) && !preferredBounds) {
+    return { text: plain, adjustedRelations: relations, hasPrefix: false, hasSuffix: false };
+  }
+  const first = relations?.[0];
+  const center = first ? Math.floor((first.contentStart + first.contentEnd) / 2) : WINDOW_CHARS;
+  const start = preferredBounds?.start ?? Math.max(0, center - WINDOW_CHARS);
+  const end = preferredBounds?.end ?? Math.min(plain.length, center + WINDOW_CHARS);
   const text = plain.slice(start, end);
-  const adjustedRelations = relations.map((r, i) => ({
+  const adjustedRelations = relations?.map((r, i) => ({
     ...r,
     __idx: i, // preserve original index so rangeIndex survives the filter below
     contentStart: Math.max(0, r.contentStart - start),
@@ -859,13 +864,19 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
   const [visibleCardCount, setVisibleCardCount] = useState(RELATED_PAGE_SIZE);
   const [activeAiEditPostId, setActiveAiEditPostId] = useState<string | null>(null);
   const aiDiffByPostId = useMemo(() => {
-    const diffs = new Map<string, ReturnType<typeof createWordDiffExcerpt>>();
+    const diffs = new Map<string, {
+      collapsed: ReturnType<typeof createAlignedWordDiffWindow>;
+      expanded: ReturnType<typeof createAlignedWordDiffWindow>;
+    }>();
     for (const stack of relatedStacks) {
       const rewrite = stack.topPost.rewrite;
       if (!rewrite?.significant || !rewrite.content) continue;
       const original = (stack.topPost.content || '').replace(/<[^>]*>/g, '');
       const revised = rewrite.content.replace(/<[^>]*>/g, '');
-      diffs.set(stack.topPost.id, createWordDiffExcerpt(original, revised, 55));
+      diffs.set(stack.topPost.id, {
+        collapsed: createAlignedWordDiffWindow(original, revised, WINDOW_CHARS * 2),
+        expanded: createAlignedWordDiffWindow(original, revised, original.length),
+      });
     }
     return diffs;
   }, [relatedStacks]);
@@ -1923,7 +1934,8 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
           const isHighlighted = !!highlightPostId && stack.topPost.id === highlightPostId;
           const colors = getCategoryColors(stack.rel);
           const isExpanded = !!expandedCards[stack.stackId];
-          const aiDiff = aiDiffByPostId.get(stack.topPost.id);
+          const aiDiffSet = aiDiffByPostId.get(stack.topPost.id);
+          const aiDiff = aiDiffSet ? (isExpanded ? aiDiffSet.expanded : aiDiffSet.collapsed) : undefined;
           const isAiEditActive = activeAiEditPostId === stack.topPost.id && !!aiDiff;
 
           // Strip HTML so the text matches the relations' PLAIN-text offsets.
@@ -1935,7 +1947,14 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
 
           // Smart windowing: show only the highlighted portion unless expanded
           const { text: visibleText, adjustedRelations, hasPrefix, hasSuffix } =
-            windowContent(plainContent, rels, isExpanded);
+            windowContent(
+              plainContent,
+              rels,
+              isExpanded,
+              aiDiff && !isExpanded
+                ? { start: aiDiff.originalStart, end: aiDiff.originalEnd }
+                : undefined,
+            );
           const isTruncated = hasPrefix || hasSuffix;
 
           // Calculate indent depth by walking the anchor chain. Per-level indent
@@ -2651,11 +2670,13 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                         aria-hidden={!isAiEditActive}
                         aria-label={stack.topPost.rewrite.editSummary || 'AI changes shown in this post'}
                       >
-                        {aiDiff.map((chunk, chunkIndex) => {
+                        {aiDiff.hasPrefix && <span style={{ color: '#94a3b8', userSelect: 'none' }}>…</span>}
+                        {aiDiff.chunks.map((chunk, chunkIndex) => {
                           if (chunk.kind === 'delete') return <del key={chunkIndex}>{chunk.text}</del>;
                           if (chunk.kind === 'insert') return <ins key={chunkIndex}>{chunk.text}</ins>;
                           return <React.Fragment key={chunkIndex}>{chunk.text}</React.Fragment>;
                         })}
+                        {aiDiff.hasSuffix && !isExpanded && <span style={{ color: '#94a3b8', userSelect: 'none' }}>…</span>}
                       </Text>
                     )}
                   </div>

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -19,7 +19,7 @@ import type { Relation } from '../types/PostType';
 import { showTooltip, hideTooltip, type TooltipColors } from './HoverTooltip';
 import { showUndoableAction } from '../utils/actionNotifications';
 import AiModifiedDisclosure from './AiModifiedDisclosure';
-import { createAlignedWordDiffWindow } from '../utils/wordDiff.mjs';
+import { createAlignedWordDiffWindow, createWordDiff } from '../utils/wordDiff.mjs';
 import './RelatedStacks.css';
 
 interface PostType {
@@ -676,6 +676,65 @@ function buildMultiHighlightNodes(
 
 const WINDOW_CHARS = 140;
 
+/** Map an original-text boundary into the revised text. Start boundaries sit
+ * after an insertion at that exact point; end boundaries sit before it, so an
+ * insertion between two adjacent annotated ranges is not claimed by both. */
+function mapRewriteBoundary(
+  chunks: ReturnType<typeof createWordDiff>,
+  offset: number,
+  edge: 'start' | 'end',
+): number {
+  let originalOffset = 0;
+  let revisedOffset = 0;
+  for (const chunk of chunks) {
+    if (chunk.kind === 'insert') {
+      if (originalOffset === offset && edge === 'end') return revisedOffset;
+      revisedOffset += chunk.text.length;
+      continue;
+    }
+    const nextOriginalOffset = originalOffset + chunk.text.length;
+    if (offset < nextOriginalOffset) {
+      return chunk.kind === 'equal'
+        ? revisedOffset + (offset - originalOffset)
+        : revisedOffset;
+    }
+    originalOffset = nextOriginalOffset;
+    if (chunk.kind === 'equal') revisedOffset += chunk.text.length;
+  }
+  return revisedOffset;
+}
+
+/** Preserve relation highlighting after a contextual rewrite changes offsets. */
+function remapRelationsToRewrite(
+  original: string,
+  revised: string,
+  relations: Relation[] | undefined,
+): Relation[] | undefined {
+  if (!relations || original === revised) return relations;
+  const chunks = createWordDiff(original, revised);
+  const remapRange = (start: number, end: number) => {
+    const nextStart = mapRewriteBoundary(chunks, start, 'start');
+    let nextEnd = mapRewriteBoundary(chunks, end, 'end');
+    // If a relation was exactly the replaced phrase, include its replacement
+    // instead of collapsing its highlight to a zero-width range.
+    if (nextEnd <= nextStart && end > start) {
+      nextEnd = mapRewriteBoundary(chunks, end, 'start');
+    }
+    return { start: nextStart, end: Math.max(nextStart, nextEnd) };
+  };
+  return relations.map((relation) => {
+    const content = remapRange(relation.contentStart, relation.contentEnd);
+    const comment = remapRange(relation.contentCommentStart, relation.contentCommentEnd);
+    return {
+      ...relation,
+      contentStart: content.start,
+      contentEnd: content.end,
+      contentCommentStart: comment.start,
+      contentCommentEnd: comment.end,
+    };
+  });
+}
+
 /** Window content around the first relation's content range. Returns adjusted relations with shifted offsets. */
 function windowContent(
   plain: string,
@@ -867,6 +926,8 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
     const diffs = new Map<string, {
       collapsed: ReturnType<typeof createAlignedWordDiffWindow>;
       expanded: ReturnType<typeof createAlignedWordDiffWindow>;
+      revisedContent: string;
+      revisedRelations: Relation[] | undefined;
     }>();
     for (const stack of relatedStacks) {
       const rewrite = stack.topPost.rewrite;
@@ -876,6 +937,8 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
       diffs.set(stack.topPost.id, {
         collapsed: createAlignedWordDiffWindow(original, revised, WINDOW_CHARS * 2),
         expanded: createAlignedWordDiffWindow(original, revised, original.length),
+        revisedContent: revised,
+        revisedRelations: remapRelationsToRewrite(original, revised, stack.topPost.relations),
       });
     }
     return diffs;
@@ -1944,15 +2007,19 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
           // the focus post already strips before highlighting, so mirror that.
           const plainContent = (stack.topPost.content || '').replace(/<[^>]*>/g, '');
           const rels = stack.topPost.relations;
+          // Contextual rewrites are the published/default card text. The
+          // original survives only inside the hover/focus track-changes layer.
+          const visibleContent = aiDiffSet?.revisedContent ?? plainContent;
+          const visibleRelations = aiDiffSet?.revisedRelations ?? rels;
 
           // Smart windowing: show only the highlighted portion unless expanded
           const { text: visibleText, adjustedRelations, hasPrefix, hasSuffix } =
             windowContent(
-              plainContent,
-              rels,
+              visibleContent,
+              visibleRelations,
               isExpanded,
               aiDiff && !isExpanded
-                ? { start: aiDiff.originalStart, end: aiDiff.originalEnd }
+                ? { start: aiDiff.revisedStart, end: aiDiff.revisedEnd }
                 : undefined,
             );
           const isTruncated = hasPrefix || hasSuffix;
@@ -2652,7 +2719,8 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                       size="sm"
                       lh={1.55}
                       c="#011445"
-                      className="ai-edit-original-text"
+                      className="ai-edit-edited-text"
+                      data-ai-edited-default
                       aria-hidden={isAiEditActive}
                     >
                       {hasPrefix && <span style={{ color: '#94a3b8', userSelect: 'none' }}>…</span>}

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -20,6 +20,7 @@ import { showTooltip, hideTooltip, type TooltipColors } from './HoverTooltip';
 import { showUndoableAction } from '../utils/actionNotifications';
 import AiModifiedDisclosure from './AiModifiedDisclosure';
 import { createAlignedWordDiffWindow, createWordDiff } from '../utils/wordDiff.mjs';
+import { useHydrated, useLocalStore } from '../utils/localStore';
 import './RelatedStacks.css';
 
 interface PostType {
@@ -803,6 +804,12 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
   // forgot to thread the sourcePostId prop (which is what produced the "share
   // opens the related post instead of the pairing" bug).
   const { activePostId: ctxActivePostId } = useRelatedStacks();
+  const localHydrated = useHydrated();
+  const localPosts = useLocalStore((snapshot) => snapshot.posts);
+  const localFocusId = sourcePostId ?? ctxActivePostId;
+  const useLocalReplyCounts = localHydrated && !!localFocusId && !!localPosts[localFocusId];
+  const displayedReplyCount = (postId: string, sourceCount: number) =>
+    useLocalReplyCounts ? localPosts[postId]?.replies_count ?? sourceCount : sourceCount;
   const paperRefs = useRef<(HTMLDivElement | null)[]>([]);
   // Debounce hover activation. Hovering a card cross-highlights the (possibly
   // long) focus post, which re-parses its HTML + reflows (~300ms). Firing that
@@ -2770,7 +2777,7 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                 <Divider style={{ marginTop: '0.5rem', marginLeft: '1rem', marginRight: '1rem' }} />
                 <div style={{ paddingLeft: '1rem', paddingRight: '1rem' }}>
                   <Group style={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <InteractionControl icon={<IconMessageCircle size={20} />} label={stack.topPost.replies_count} ariaLabel="Replies"
+                    <InteractionControl icon={<IconMessageCircle size={20} />} label={displayedReplyCount(stack.topPost.id, stack.topPost.replies_count)} ariaLabel="Replies"
                       onClick={() => handleNavigate(stack.topPost.id, stack.stackId)} />
                     <InteractionControl
                       icon={isFavourited(stack.topPost.id, stack.topPost.favourited) ? <IconHeartFilled size={20} /> : <IconHeart size={20} />}

--- a/src/components/RelatedStacks.tsx
+++ b/src/components/RelatedStacks.tsx
@@ -18,6 +18,7 @@ import { reorderForAnchor } from '../utils/reorderForAnchor';
 import type { Relation } from '../types/PostType';
 import { showTooltip, hideTooltip, type TooltipColors } from './HoverTooltip';
 import { showUndoableAction } from '../utils/actionNotifications';
+import AiModifiedDisclosure from './AiModifiedDisclosure';
 import './RelatedStacks.css';
 
 interface PostType {
@@ -35,7 +36,7 @@ interface PostType {
     username?: string;
   };
   content_rewritten: string;
-  rewrite: { content: string; significant: boolean };
+  rewrite: { content: string; significant: boolean; editSummary?: string };
   /** Offset-based relations between this post and the focus post */
   relations?: Relation[];
 }
@@ -2585,6 +2586,14 @@ const RelatedStacks: React.FC<RelatedStacksProps> = ({ relatedStacks, cardWidth 
                   style={{ paddingLeft: '54px', paddingRight: '1rem', cursor: 'pointer' }}
                 >
                   {/* D3: shortest common related text label — only when span filter is active */}
+                  {stack.topPost.rewrite?.significant && stack.topPost.rewrite.content && (
+                    <AiModifiedDisclosure
+                      originalContent={plainContent}
+                      rewrittenContent={stack.topPost.rewrite.content.replace(/<[^>]*>/g, '')}
+                      editSummary={stack.topPost.rewrite.editSummary}
+                    />
+                  )}
+
                   {shortestCommonText !== null && (
                     <div style={{
                       display: 'inline-flex', alignItems: 'center',

--- a/src/components/SubmitPost/SubmitPost.module.css
+++ b/src/components/SubmitPost/SubmitPost.module.css
@@ -11,6 +11,14 @@
   box-shadow: 0 8px 22px rgba(20, 33, 61, 0.07);
 }
 
+.timeline {
+  margin-bottom: 0;
+  border: 0;
+  border-bottom: 1px solid #deddd6;
+  border-radius: 0;
+  box-shadow: none;
+}
+
 .threadRail {
   display: grid;
   grid-template-columns: repeat(4, 1fr);

--- a/src/components/SubmitPost/SubmitPost.module.css
+++ b/src/components/SubmitPost/SubmitPost.module.css
@@ -80,6 +80,27 @@
   color: #697386;
 }
 
+.composerMeta {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.characterCount {
+  min-width: 2.2rem;
+  padding-left: 0.65rem;
+  color: #747d8d;
+  text-align: right;
+  border-left: 1px solid rgba(20, 33, 61, 0.14);
+  font-variant-numeric: tabular-nums;
+}
+
+.characterCount[data-near-limit='true'] {
+  color: #a9493d;
+  font-weight: 700;
+}
+
 .button {
   min-width: 76px;
   height: 36px;

--- a/src/components/SubmitPost/SubmitPost.tsx
+++ b/src/components/SubmitPost/SubmitPost.tsx
@@ -7,7 +7,7 @@ import { useRelatedStacks } from '../../app/(shell)/related-stacks-context';
 import axios from 'axios';
 import classes from './SubmitPost.module.css';
 
-export function SubmitPost() {
+export function SubmitPost({ appearance = 'card' }: { appearance?: 'card' | 'timeline' }) {
   // Local current user — reactive so the avatar reflects store identity.
   const currentUser = useLocalStore(() => getMe());
   // Publish live writing-feedback to the aside (rendered by the feed @aside slot).
@@ -112,7 +112,10 @@ export function SubmitPost() {
   };
 
   return (
-    <section className={classes.composer} aria-label="Create a post">
+    <section
+      className={`${classes.composer} ${appearance === 'timeline' ? classes.timeline : ''}`}
+      aria-label="Create a post"
+    >
       <div className={classes.threadRail} aria-hidden="true">
         <span /><span /><span /><span />
       </div>

--- a/src/components/SubmitPost/SubmitPost.tsx
+++ b/src/components/SubmitPost/SubmitPost.tsx
@@ -4,12 +4,21 @@ import { Avatar, Button, Text, Textarea } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { getMe, createPost, useLocalStore } from '../../utils/localStore';
 import { useRelatedStacks } from '../../app/(shell)/related-stacks-context';
+import {
+  createMastodonStatus,
+  MASTODON_STATUS_MAX_LENGTH,
+  publishCreatedMastodonStatus,
+  type MastodonAccount,
+} from '../../utils/mastodonApi';
+import { useAccessToken } from '../../utils/useAccessToken';
 import axios from 'axios';
 import classes from './SubmitPost.module.css';
 
 export function SubmitPost({ appearance = 'card' }: { appearance?: 'card' | 'timeline' }) {
   // Local current user — reactive so the avatar reflects store identity.
   const currentUser = useLocalStore(() => getMe());
+  const { token: accessToken } = useAccessToken();
+  const [mastodonUser, setMastodonUser] = useState<MastodonAccount | null>(null);
   // Publish live writing-feedback to the aside (rendered by the feed @aside slot).
   const { setComposerFeedback } = useRelatedStacks();
   const [postText, setPostText] = useState('');
@@ -18,6 +27,19 @@ export function SubmitPost({ appearance = 'card' }: { appearance?: 'card' | 'tim
   const [feedbackLoading, setFeedbackLoading] = useState(false);
   const draftIdRef = useRef(`draft-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const feedbackReqIdRef = useRef(0);
+
+  useEffect(() => {
+    if (!accessToken) {
+      setMastodonUser(null);
+      return;
+    }
+    try {
+      const stored = localStorage.getItem('currentUser');
+      setMastodonUser(stored ? JSON.parse(stored) as MastodonAccount : null);
+    } catch {
+      setMastodonUser(null);
+    }
+  }, [accessToken]);
 
   const requestFeedback = useCallback(async (text: string, requestId: number) => {
     setFeedbackLoading(true);
@@ -71,9 +93,10 @@ export function SubmitPost({ appearance = 'card' }: { appearance?: 'card' | 'tim
     void requestFeedback(text, requestId);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (submitting) return;
-    if (!postText.trim()) {
+    const text = postText.trim();
+    if (!text) {
       notifications.show({
         title: 'Error',
         message: 'Please enter some text before posting.',
@@ -81,15 +104,27 @@ export function SubmitPost({ appearance = 'card' }: { appearance?: 'card' | 'tim
       });
       return;
     }
+    if (text.length > MASTODON_STATUS_MAX_LENGTH) {
+      notifications.show({
+        title: 'Post is too long',
+        message: `Shorten it to ${MASTODON_STATUS_MAX_LENGTH} characters before posting.`,
+        color: 'red',
+      });
+      return;
+    }
 
     setSubmitting(true);
     try {
-      // Local mode: persist the post to the store. It surfaces at the top of
-      // Home immediately (the store is reactive).
-      createPost(postText.trim());
+      if (accessToken) {
+        const status = await createMastodonStatus(accessToken, text);
+        publishCreatedMastodonStatus(status);
+      } else {
+        // JSON demo mode remains local and reactive.
+        createPost(text);
+      }
       notifications.show({
         title: 'Success',
-        message: 'Post created successfully.',
+        message: accessToken ? 'Posted to Stacky.' : 'Post created successfully.',
         color: 'green',
       });
       setPostText(''); // Clear the composer after posting.
@@ -102,14 +137,17 @@ export function SubmitPost({ appearance = 'card' }: { appearance?: 'card' | 'tim
     } catch (error) {
       console.error('Error creating post:', error);
       notifications.show({
-        title: 'Error',
-        message: 'Failed to create post. Please try again later.',
+        title: 'Post was not published',
+        message: error instanceof Error ? error.message : 'Please try again later.',
         color: 'red',
       });
     } finally {
       setSubmitting(false);
     }
   };
+
+  const visibleUser = accessToken ? mastodonUser : currentUser;
+  const charactersRemaining = MASTODON_STATUS_MAX_LENGTH - postText.length;
 
   return (
     <section
@@ -122,8 +160,8 @@ export function SubmitPost({ appearance = 'card' }: { appearance?: 'card' | 'tim
 
       <div className={classes.composerBody}>
         <div className={classes.avatarArea}>
-        {currentUser ? (
-          <Avatar src={currentUser.avatar} alt={currentUser.display_name || 'Your profile'} radius="xl" size={42} />
+        {visibleUser ? (
+          <Avatar src={visibleUser.avatar} alt={visibleUser.display_name || 'Your profile'} radius="xl" size={42} />
         ) : (
           <Avatar alt="Your profile" radius="xl" size={42} />
         )}
@@ -139,6 +177,7 @@ export function SubmitPost({ appearance = 'card' }: { appearance?: 'card' | 'tim
           minRows={3}
           maxRows={9}
           resize="none"
+          maxLength={MASTODON_STATUS_MAX_LENGTH}
           value={postText}
           onChange={(event) => setPostText(event.currentTarget.value)}
           className={classes.textarea}
@@ -161,10 +200,15 @@ export function SubmitPost({ appearance = 'card' }: { appearance?: 'card' | 'tim
           )}
 
           <div className={classes.buttonArea}>
-            <Text size="xs" className={classes.feedbackHint}>
-              {feedbackLoading ? 'Checking your draft…' : 'AI feedback appears as you write'}
-            </Text>
-            <Button className={classes.button} onClick={handleSubmit} loading={submitting} disabled={submitting}>
+            <div className={classes.composerMeta}>
+              <Text size="xs" className={classes.feedbackHint}>
+                {feedbackLoading ? 'Checking your draft…' : 'AI feedback appears as you write'}
+              </Text>
+              <Text size="xs" className={classes.characterCount} data-near-limit={charactersRemaining <= 50 || undefined}>
+                {charactersRemaining}
+              </Text>
+            </div>
+            <Button className={classes.button} onClick={() => void handleSubmit()} loading={submitting} disabled={submitting || !postText.trim()}>
               Post
             </Button>
           </div>

--- a/src/data/contextualAiRewrites.ts
+++ b/src/data/contextualAiRewrites.ts
@@ -1,0 +1,87 @@
+import type { ListyInjectionEntry, RelatedPostMock } from "../types/PostType";
+
+export type ContextualAiRewrite = {
+  content: string;
+  significant: boolean;
+  editSummary?: string;
+};
+
+type RewriteInstruction = {
+  from: string;
+  to: string;
+  editSummary: string;
+};
+
+/**
+ * Demo-only examples of the contextual clarification a future enrichment
+ * service can return. The key includes both posts because a response can need a
+ * different clarification depending on which focus post it is paired with.
+ */
+const REWRITE_INSTRUCTIONS: Record<string, RewriteInstruction> = {
+  "143195604:149288649": {
+    from: "I am glad to see a long form article on this topic.",
+    to: "On U.S. automakers falling behind China's EV industry, I am glad to see a long-form article on this topic.",
+    editSummary: "Names the auto-industry context that was implicit in the original reply.",
+  },
+  "143200921:152047717": {
+    from: "This should be framed as support for engineering work as opposed to new scientific breakthroughs.",
+    to: "In response to the argument that incumbent automakers struggle with disruptive EV technology, this should be framed as support for engineering work rather than new scientific breakthroughs.",
+    editSummary: "Connects the engineering argument to the focus post's disruption theme.",
+  },
+  "149289024:149289332": {
+    from: "Watch YouTube videos on China's new EVs, or the top 10 EVs in China. It's mind-blowing.",
+    to: "For evidence that the future auto market is electric and software-driven, watch YouTube videos on China's new EVs, or the top 10 EVs in China. It's mind-blowing.",
+    editSummary: "Makes the evidence-to-claim connection explicit.",
+  },
+  "149289030:152047229": {
+    from: "One reads this and sees decades of American foolishness and greed leading to our fall from top tier research and manufacturing.",
+    to: "Seen through the lens of short-term Wall Street incentives, one reads this and sees decades of American foolishness and greed leading to our fall from top-tier research and manufacturing.",
+    editSummary: "Adds the short-term incentive frame supplied by the focus post.",
+  },
+  "152047717:152053690": {
+    from: "I reported this story when I was in China for President Trump's visit in May.",
+    to: "As a concrete example of engineering progress in batteries, I reported this story when I was in China for President Trump's visit in May.",
+    editSummary: "Clarifies why the first-hand report supports the engineering claim.",
+  },
+  "152053690:143196877": {
+    from: "I work in sustainability for a leading European global brand that has 1000+ suppliers across the world.",
+    to: "To connect China's battery-factory lead with supply-chain practice, I work in sustainability for a leading European global brand that has 1000+ suppliers across the world.",
+    editSummary: "Makes the supply-chain connection visible before the supporting example.",
+  },
+};
+
+export function contextualAiRewrite(
+  focusPostId: string,
+  relatedPostId: string,
+  originalContent: string,
+  fallback?: RelatedPostMock["rewrite"],
+): ContextualAiRewrite {
+  const instruction = REWRITE_INSTRUCTIONS[`${focusPostId}:${relatedPostId}`];
+  if (!instruction) {
+    return {
+      content: fallback?.content ?? originalContent,
+      significant: fallback?.significant ?? false,
+      editSummary: fallback?.editSummary,
+    };
+  }
+
+  const content = originalContent.replace(instruction.from, instruction.to);
+  if (content === originalContent) {
+    // Fixture drift should fail safely: never claim an edit when the source
+    // phrase no longer matches the curated post.
+    return { content: originalContent, significant: false };
+  }
+
+  return { content, significant: true, editSummary: instruction.editSummary };
+}
+
+/** Adds backend-shaped enrichment metadata without mutating the JSON fixture. */
+export function withContextualAiRewrites(entry: ListyInjectionEntry): ListyInjectionEntry {
+  return {
+    ...entry,
+    relatedPosts: entry.relatedPosts.map((post) => ({
+      ...post,
+      rewrite: contextualAiRewrite(entry.focusPost.id, post.id, post.content, post.rewrite),
+    })),
+  };
+}

--- a/src/data/contextualAiRewrites.ts
+++ b/src/data/contextualAiRewrites.ts
@@ -45,8 +45,8 @@ const REWRITE_INSTRUCTIONS: Record<string, RewriteInstruction> = {
   },
   "152053690:143196877": {
     from: "I work in sustainability for a leading European global brand that has 1000+ suppliers across the world.",
-    to: "To connect China's battery-factory lead with supply-chain practice, I work in sustainability for a leading European global brand that has 1000+ suppliers across the world.",
-    editSummary: "Makes the supply-chain connection visible before the supporting example.",
+    to: "To connect China's battery-factory lead with supply-chain practice, I work on sustainability for a major European brand that has 1000+ suppliers across the world.",
+    editSummary: "Makes the supply-chain connection explicit and tightens the wording of the supporting example.",
   },
 };
 

--- a/src/services/demoApiClient.ts
+++ b/src/services/demoApiClient.ts
@@ -1,0 +1,95 @@
+import type { ListyInjectionEntry } from "../types/PostType";
+
+export type TimelineStats = {
+  posts: number;
+  participants: number;
+  responses: number;
+};
+
+export type TimelinePage = {
+  items: ListyInjectionEntry[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  stats: TimelineStats;
+  meta: { simulated: boolean; delayMs: number; generatedAt: string };
+};
+
+type CacheEntry = { value: TimelinePage; expiresAt: number };
+
+const PAGE_SIZE = 2;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 20;
+const pageCache = new Map<string, CacheEntry>();
+const inFlight = new Map<string, Promise<TimelinePage>>();
+
+function apiBaseUrl(): string {
+  // A live backend can expose the same typed contract and be selected without
+  // changing page components. The bundled demo defaults to the local route.
+  return (process.env.NEXT_PUBLIC_STACKY_DATA_API_URL || "/api/demo").replace(/\/$/, "");
+}
+
+function pruneCache() {
+  const now = Date.now();
+  for (const [key, entry] of Array.from(pageCache.entries())) {
+    if (entry.expiresAt <= now) pageCache.delete(key);
+  }
+  while (pageCache.size > MAX_CACHE_ENTRIES) {
+    const oldest = pageCache.keys().next().value;
+    if (oldest === undefined) break;
+    pageCache.delete(oldest);
+  }
+}
+
+function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(new DOMException("Request aborted", "AbortError"));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new DOMException("Request aborted", "AbortError"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener("abort", onAbort));
+  });
+}
+
+/**
+ * Typed, cached frontend boundary for the simulated backend. Requests for the
+ * same page share one fetch; callers can still cancel their own subscription.
+ */
+export function getChineseEvTimelinePage(
+  cursor: string | null,
+  options: { signal?: AbortSignal } = {},
+): Promise<TimelinePage> {
+  pruneCache();
+  const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+  if (cursor) params.set("cursor", cursor);
+  const url = `${apiBaseUrl()}/timelines/chinese-evs?${params}`;
+
+  const cached = pageCache.get(url);
+  if (cached && cached.expiresAt > Date.now()) {
+    pageCache.delete(url);
+    pageCache.set(url, cached); // LRU touch
+    return abortable(Promise.resolve(cached.value), options.signal);
+  }
+
+  let request = inFlight.get(url);
+  if (!request) {
+    request = fetch(url, { headers: { Accept: "application/json" }, cache: "no-store" })
+      .then(async (response) => {
+        if (!response.ok) {
+          const body = await response.json().catch(() => null);
+          throw new Error(body?.error || `Timeline request failed (${response.status})`);
+        }
+        return response.json() as Promise<TimelinePage>;
+      })
+      .then((page) => {
+        pageCache.set(url, { value: page, expiresAt: Date.now() + CACHE_TTL_MS });
+        pruneCache();
+        return page;
+      })
+      .finally(() => inFlight.delete(url));
+    inFlight.set(url, request);
+  }
+
+  return abortable(request, options.signal);
+}
+
+export const DEMO_TIMELINE_PAGE_SIZE = PAGE_SIZE;

--- a/src/types/PostType.tsx
+++ b/src/types/PostType.tsx
@@ -32,6 +32,12 @@ export interface PostType {
     replies_count: number;
     relatedStacks: any[];
     previewCard?: PreviewCardType | null;
+    /** Thread parent supplied by the timeline/status payload. */
+    inReplyToId?: string | null;
+    /** Parent account handle, resolved by the data adapter for X-style reply context. */
+    replyingToAccount?: string | null;
+    /** Offset annotations connecting this post to its related responses. */
+    focusRelations?: Relation[];
 }
 
 // ─── Listy Injection mock data types ────────────────────────────────────────

--- a/src/types/PostType.tsx
+++ b/src/types/PostType.tsx
@@ -117,6 +117,8 @@ export interface RelatedPostMock {
   rewrite?: {
     content: string;
     significant: boolean;
+    /** Plain-language reason the contextual edit was made. */
+    editSummary?: string;
   };
 }
 

--- a/src/utils/cursorPagination.d.mts
+++ b/src/utils/cursorPagination.d.mts
@@ -1,0 +1,6 @@
+export function encodeCursor(lastId: string): string | null;
+export function decodeCursor(cursor: string | null | undefined): string | null;
+export function paginateByCursor<T>(
+  items: T[],
+  options: { cursor?: string | null; limit: number; idOf: (item: T) => string },
+): { items: T[]; nextCursor: string | null; hasMore: boolean };

--- a/src/utils/cursorPagination.mjs
+++ b/src/utils/cursorPagination.mjs
@@ -1,0 +1,43 @@
+const CURSOR_VERSION = 1;
+
+export function encodeCursor(lastId) {
+  if (!lastId) return null;
+  return Buffer.from(JSON.stringify({ v: CURSOR_VERSION, after: String(lastId) }), "utf8").toString("base64url");
+}
+
+export function decodeCursor(cursor) {
+  if (!cursor) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+  } catch {
+    throw new Error("Invalid pagination cursor");
+  }
+  if (parsed?.v !== CURSOR_VERSION || typeof parsed.after !== "string" || !parsed.after) {
+    throw new Error("Invalid pagination cursor");
+  }
+  return parsed.after;
+}
+
+/** Stable keyset pagination. A cursor points after an item id, never at an array offset. */
+export function paginateByCursor(items, { cursor = null, limit, idOf }) {
+  if (!Number.isInteger(limit) || limit < 1) throw new Error("Pagination limit must be a positive integer");
+
+  const afterId = decodeCursor(cursor);
+  let start = 0;
+  if (afterId !== null) {
+    const anchorIndex = items.findIndex((item) => String(idOf(item)) === afterId);
+    if (anchorIndex < 0) throw new Error("Pagination cursor is no longer available");
+    start = anchorIndex + 1;
+  }
+
+  const pageItems = items.slice(start, start + limit);
+  const hasMore = start + pageItems.length < items.length;
+  const lastItem = pageItems[pageItems.length - 1];
+
+  return {
+    items: pageItems,
+    nextCursor: hasMore && lastItem ? encodeCursor(idOf(lastItem)) : null,
+    hasMore,
+  };
+}

--- a/src/utils/localStore.ts
+++ b/src/utils/localStore.ts
@@ -557,6 +557,23 @@ export function getHomeFeed(): Post[] {
 }
 
 /**
+ * JSON-backed posts authored by accounts the participant explicitly followed.
+ *
+ * Authenticated Home uses this as a temporary supplemental source beside the
+ * real Mastodon timeline. Once the curated corpus is imported into Mastodon,
+ * the same UI can rely on the server timeline and remove this adapter.
+ */
+export function getFollowedDemoFeed(): Post[] {
+  return memoized("followedDemo", () => {
+    const followed = new Set(state.following);
+    if (followed.size === 0) return [];
+    return Object.values(state.posts)
+      .filter((post) => followed.has(post.account.acct))
+      .sort(byNewest);
+  });
+}
+
+/**
  * Bookmarked posts, newest first.
  *
  * REST: GET /api/v1/bookmarks
@@ -760,8 +777,8 @@ export function toggleFollow(acct: string): { following: boolean } {
 
 /**
  * Distinct authors of the hashtag's posts — everyone whose post is in the feed,
- * excluding the local user. Backs the "Follow hashtag" action, which surfaces the
- * whole conversation on Home by following all of them.
+ * excluding the local user. Backs the "Follow demo feed" action, which surfaces
+ * the whole conversation on Home by following all of them.
  */
 export function getHashtagAuthors(): string[] {
   return memoized("hashtagAuthors", () => {

--- a/src/utils/localStore.ts
+++ b/src/utils/localStore.ts
@@ -36,7 +36,9 @@ import type {
   ListyInjectionEntry,
   FocusPostMock,
   RelatedPostMock,
+  Relation,
 } from "../types/PostType";
+import { getMockFocusRelations, getMockRelatedStacks } from "./mockPostResolver";
 
 // ─── Exported data shapes ────────────────────────────────────────────────────
 
@@ -94,6 +96,8 @@ export interface Post {
   media_attachments: any[];
   /** Aside-format related stacks for this post (see mockPostResolver.getMockRelatedStacks). */
   relatedStacks: any[];
+  /** Offset annotations connecting this post to its related responses. */
+  focusRelations: Relation[];
   /** Parent post id for thread hierarchy; null for roots. */
   in_reply_to_id?: string | null;
 }
@@ -163,6 +167,7 @@ function mockToPost(p: FocusPostMock | RelatedPostMock): Post {
     bookmarked: p.bookmarked,
     media_attachments: [],
     relatedStacks: [],
+    focusRelations: [],
     in_reply_to_id: p.inReplyToId ?? null,
   };
 }
@@ -250,6 +255,22 @@ function seedState(meOverride?: Account): LocalState {
     for (const rp of e.relatedPosts ?? []) addPost(rp);
   }
 
+  // Keep the demo store backend-shaped: focus posts carry their own related
+  // response payload and annotation offsets. Consumers should never need to
+  // know which fixture produced a post or perform a second hidden resolver
+  // lookup just to decide whether the related pane exists.
+  for (const e of entries) {
+    const post = posts[e.focusPost.id];
+    if (!post) continue;
+    const relatedStacks = getMockRelatedStacks(e.focusPost.id);
+    posts[e.focusPost.id] = {
+      ...post,
+      stackCount: relatedStacks.length || null,
+      relatedStacks,
+      focusRelations: getMockFocusRelations(e.focusPost.id),
+    };
+  }
+
   // Seed accounts from FakeUsers too (they have no posts, but should resolve).
   for (const u of fakeUsers) {
     const acct = u.email?.split("@")[0] || u.accountId;
@@ -312,8 +333,35 @@ function load(): LocalState {
     const parsed = JSON.parse(raw) as LocalState;
     // Defensive: ensure all top-level keys exist (forward-compat with older blobs).
     const seed = seedState();
+    const persistedPosts = parsed.posts ?? {};
+    const posts: Record<string, Post> = { ...seed.posts, ...persistedPosts };
+
+    // Migrate existing v1 browser data without discarding likes, bookmarks, or
+    // user-created posts. Older snapshots intentionally stored empty relation
+    // arrays, so restore only the seeded read-only enrichment fields here.
+    for (const [id, seededPost] of Object.entries(seed.posts)) {
+      const persistedPost = persistedPosts[id];
+      if (!persistedPost) continue;
+      posts[id] = {
+        ...seededPost,
+        ...persistedPost,
+        relatedStacks:
+          persistedPost.relatedStacks?.length > 0
+            ? persistedPost.relatedStacks
+            : seededPost.relatedStacks,
+        focusRelations:
+          persistedPost.focusRelations?.length > 0
+            ? persistedPost.focusRelations
+            : seededPost.focusRelations,
+        stackCount:
+          persistedPost.relatedStacks?.length > 0
+            ? persistedPost.stackCount
+            : seededPost.stackCount,
+      };
+    }
+
     return {
-      posts: parsed.posts ?? seed.posts,
+      posts,
       accounts: parsed.accounts ?? seed.accounts,
       liked: parsed.liked ?? [],
       bookmarked: parsed.bookmarked ?? [],
@@ -489,8 +537,21 @@ function memoized<T>(key: string, compute: () => T): T {
 export function getHomeFeed(): Post[] {
   return memoized("home", () => {
     const sources = new Set<string>([state.me.acct, ...state.following]);
-    return Object.values(state.posts)
-      .filter((p) => sources.has(p.account.acct))
+    const personal = Object.values(state.posts).filter((p) => sources.has(p.account.acct));
+
+    // A fresh local profile still needs a meaningful Home to evaluate. This is
+    // the simulated equivalent of a backend "For you" blend: three focus posts
+    // with annotated related responses, interleaved with three ordinary replies
+    // that deliberately have no related payload. Following and self-authored
+    // posts merge into the same chronological timeline without duplicates.
+    const starterIds = [
+      "152053690", "152052643", "152047717",
+      "149294079", "149289030", "143203257",
+    ];
+    const starter = starterIds
+      .map((id) => state.posts[id])
+      .filter((post): post is Post => !!post);
+    return Array.from(new Map([...personal, ...starter].map((post) => [post.id, post])).values())
       .sort(byNewest);
   });
 }
@@ -574,6 +635,7 @@ export function createPost(text: string): Post {
     bookmarked: false,
     media_attachments: [],
     relatedStacks: [],
+    focusRelations: [],
     in_reply_to_id: null,
   };
   mutate((draft) => {
@@ -608,6 +670,7 @@ export function addComment(postId: string, text: string): Comment {
     bookmarked: false,
     media_attachments: [],
     relatedStacks: [],
+    focusRelations: [],
     in_reply_to_id: postId,
   };
   mutate((draft) => {

--- a/src/utils/localStore.ts
+++ b/src/utils/localStore.ts
@@ -567,8 +567,13 @@ export function getFollowedDemoFeed(): Post[] {
   return memoized("followedDemo", () => {
     const followed = new Set(state.following);
     if (followed.size === 0) return [];
+    // Match the actual /ChineseEVs timeline contract: its feed contains focus
+    // posts, while ancestors, replies, and related responses belong inside the
+    // focus/detail experience. Returning every stored record here buried focus
+    // posts beneath newer standalone replies that correctly had no related pane.
+    const focusPostIds = new Set(entries.map((entry) => entry.focusPost.id));
     return Object.values(state.posts)
-      .filter((post) => followed.has(post.account.acct))
+      .filter((post) => focusPostIds.has(post.id) && followed.has(post.account.acct))
       .sort(byNewest);
   });
 }

--- a/src/utils/localStore.ts
+++ b/src/utils/localStore.ts
@@ -38,7 +38,8 @@ import type {
   RelatedPostMock,
   Relation,
 } from "../types/PostType";
-import { getMockFocusRelations, getMockRelatedStacks } from "./mockPostResolver";
+import { getMockFocusRelations, getMockRelatedStacks, getMockReplyCount } from "./mockPostResolver";
+import { resolveReplyCount } from "./replyCount.mjs";
 
 // ─── Exported data shapes ────────────────────────────────────────────────────
 
@@ -159,7 +160,7 @@ function mockToPost(p: FocusPostMock | RelatedPostMock): Post {
       acct: p.account.acct,
       avatar: p.account.avatar || DEFAULT_AVATAR,
     },
-    replies_count: p.replies_count,
+    replies_count: getMockReplyCount(p.id),
     created_at: p.created_at,
     stackCount: null,
     favourites_count: p.favourites_count,
@@ -334,6 +335,7 @@ function load(): LocalState {
     // Defensive: ensure all top-level keys exist (forward-compat with older blobs).
     const seed = seedState();
     const persistedPosts = parsed.posts ?? {};
+    const persistedComments = parsed.comments ?? {};
     const posts: Record<string, Post> = { ...seed.posts, ...persistedPosts };
 
     // Migrate existing v1 browser data without discarding likes, bookmarks, or
@@ -346,6 +348,11 @@ function load(): LocalState {
       posts[id] = {
         ...seededPost,
         ...persistedPost,
+        replies_count: resolveReplyCount(
+          seededPost.replies_count,
+          0,
+          (persistedComments[id] ?? []).filter((comment) => comment.in_reply_to_id === id).length,
+        ),
         relatedStacks: seededPost.relatedStacks,
         focusRelations: seededPost.focusRelations,
         stackCount: seededPost.stackCount,
@@ -358,7 +365,7 @@ function load(): LocalState {
       liked: parsed.liked ?? [],
       bookmarked: parsed.bookmarked ?? [],
       following: parsed.following ?? [],
-      comments: parsed.comments ?? {},
+      comments: persistedComments,
       me: parsed.me ?? seed.me,
     };
   } catch {

--- a/src/utils/localStore.ts
+++ b/src/utils/localStore.ts
@@ -337,26 +337,18 @@ function load(): LocalState {
     const posts: Record<string, Post> = { ...seed.posts, ...persistedPosts };
 
     // Migrate existing v1 browser data without discarding likes, bookmarks, or
-    // user-created posts. Older snapshots intentionally stored empty relation
-    // arrays, so restore only the seeded read-only enrichment fields here.
+    // user-created posts. Related stacks, annotations, and contextual rewrites
+    // are read-only fixture enrichment, so always refresh those fields from the
+    // latest seed instead of pinning a participant to a stale demo payload.
     for (const [id, seededPost] of Object.entries(seed.posts)) {
       const persistedPost = persistedPosts[id];
       if (!persistedPost) continue;
       posts[id] = {
         ...seededPost,
         ...persistedPost,
-        relatedStacks:
-          persistedPost.relatedStacks?.length > 0
-            ? persistedPost.relatedStacks
-            : seededPost.relatedStacks,
-        focusRelations:
-          persistedPost.focusRelations?.length > 0
-            ? persistedPost.focusRelations
-            : seededPost.focusRelations,
-        stackCount:
-          persistedPost.relatedStacks?.length > 0
-            ? persistedPost.stackCount
-            : seededPost.stackCount,
+        relatedStacks: seededPost.relatedStacks,
+        focusRelations: seededPost.focusRelations,
+        stackCount: seededPost.stackCount,
       };
     }
 

--- a/src/utils/mastoActions.ts
+++ b/src/utils/mastoActions.ts
@@ -1,4 +1,8 @@
-import { toggleLike as storeToggleLike, toggleBookmark as storeToggleBookmark } from './localStore';
+import {
+  getPost as getStorePost,
+  toggleLike as storeToggleLike,
+  toggleBookmark as storeToggleBookmark,
+} from './localStore';
 import axios from 'axios';
 import { MASTODON_INSTANCE_URL } from './mastodonApi';
 
@@ -33,6 +37,9 @@ function getAccessToken(): string | null {
 export type ToggleResult = { ok: boolean; value: boolean };
 
 export async function toggleFavourite(postId: string, currentlyFavourited: boolean): Promise<ToggleResult> {
+  // Curated/demo posts remain JSON-backed during the migration. Their ids do
+  // not exist in Mastodon yet, even when the viewer is authenticated.
+  if (getStorePost(postId)) return storeToggleLike(postId);
   const token = getAccessToken();
   if (!token) return storeToggleLike(postId);
   try {
@@ -51,6 +58,7 @@ export async function toggleFavourite(postId: string, currentlyFavourited: boole
 }
 
 export async function toggleBookmark(postId: string, currentlyBookmarked: boolean): Promise<ToggleResult> {
+  if (getStorePost(postId)) return storeToggleBookmark(postId);
   const token = getAccessToken();
   if (!token) return storeToggleBookmark(postId);
   try {

--- a/src/utils/mastoActions.ts
+++ b/src/utils/mastoActions.ts
@@ -1,4 +1,6 @@
 import { toggleLike as storeToggleLike, toggleBookmark as storeToggleBookmark } from './localStore';
+import axios from 'axios';
+import { MASTODON_INSTANCE_URL } from './mastodonApi';
 
 // ─── Local (no-backend) mode ──────────────────────────────────────────────────
 //
@@ -7,25 +9,20 @@ import { toggleLike as storeToggleLike, toggleBookmark as storeToggleBookmark } 
 // owns the source of truth for liked/bookmarked state plus each post's
 // `favourited` flag and `favourites_count`, and persists across reloads.
 //
-// The original axios/REST bodies are preserved in comments below; swapping back
-// to a live backend is a mechanical edit of THIS FILE — restore the commented
-// implementations and remove the store delegation.
-//
+// When an OAuth token is present these helpers persist the interaction to
+// Mastodon. Without a token they preserve the JSON demo's local behavior.
 // NOTE: the store's toggle functions ignore the `currentlyFavourited` /
 // `currentlyBookmarked` argument (they derive the new state from persisted
 // state), but we keep the parameters to preserve the exported signature used by
 // callers such as RelatedStacks.tsx and Post.tsx.
 
-// import axios from 'axios';
-//
-// const MastodonInstanceUrl = 'https://beta.stacky.social';
-//
-// const REQUEST_TIMEOUT_MS = 10000;
-//
-// function getAccessToken(): string | null {
-//   if (typeof window === 'undefined') return null;
-//   return localStorage.getItem('accessToken');
-// }
+const REQUEST_TIMEOUT_MS = 10000;
+
+function getAccessToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  const token = localStorage.getItem('accessToken');
+  return token && token !== 'null' && token !== 'undefined' ? token : null;
+}
 
 /**
  * Result of a toggle action.
@@ -36,47 +33,37 @@ import { toggleLike as storeToggleLike, toggleBookmark as storeToggleBookmark } 
 export type ToggleResult = { ok: boolean; value: boolean };
 
 export async function toggleFavourite(postId: string, currentlyFavourited: boolean): Promise<ToggleResult> {
-  // Local mode: delegate to the store, which flips liked[] and the post's
-  // favourited + favourites_count, and returns { ok: true, value: <new state> }.
-  return storeToggleLike(postId);
-
-  // ── REST implementation (restore when swapping to a live backend) ──
-  // const token = getAccessToken();
-  // if (!token) return { ok: false, value: currentlyFavourited };
-  // try {
-  //   const endpoint = currentlyFavourited
-  //     ? `${MastodonInstanceUrl}/api/v1/statuses/${postId}/unfavourite`
-  //     : `${MastodonInstanceUrl}/api/v1/statuses/${postId}/favourite`;
-  //   await axios.post(endpoint, {}, {
-  //     headers: { Authorization: `Bearer ${token}` },
-  //     timeout: REQUEST_TIMEOUT_MS,
-  //   });
-  //   return { ok: true, value: !currentlyFavourited };
-  // } catch (error) {
-  //   console.error('toggleFavourite failed:', error);
-  //   return { ok: false, value: currentlyFavourited };
-  // }
+  const token = getAccessToken();
+  if (!token) return storeToggleLike(postId);
+  try {
+    const endpoint = currentlyFavourited
+      ? `${MASTODON_INSTANCE_URL}/api/v1/statuses/${postId}/unfavourite`
+      : `${MASTODON_INSTANCE_URL}/api/v1/statuses/${postId}/favourite`;
+    const response = await axios.post(endpoint, {}, {
+      headers: { Authorization: `Bearer ${token}` },
+      timeout: REQUEST_TIMEOUT_MS,
+    });
+    return { ok: true, value: Boolean(response.data?.favourited) };
+  } catch (error) {
+    console.error('toggleFavourite failed:', error);
+    return { ok: false, value: currentlyFavourited };
+  }
 }
 
 export async function toggleBookmark(postId: string, currentlyBookmarked: boolean): Promise<ToggleResult> {
-  // Local mode: delegate to the store, which flips bookmarked[] and the post's
-  // bookmarked flag, and returns { ok: true, value: <new state> }.
-  return storeToggleBookmark(postId);
-
-  // ── REST implementation (restore when swapping to a live backend) ──
-  // const token = getAccessToken();
-  // if (!token) return { ok: false, value: currentlyBookmarked };
-  // try {
-  //   const endpoint = currentlyBookmarked
-  //     ? `${MastodonInstanceUrl}/api/v1/statuses/${postId}/unbookmark`
-  //     : `${MastodonInstanceUrl}/api/v1/statuses/${postId}/bookmark`;
-  //   await axios.post(endpoint, {}, {
-  //     headers: { Authorization: `Bearer ${token}` },
-  //     timeout: REQUEST_TIMEOUT_MS,
-  //   });
-  //   return { ok: true, value: !currentlyBookmarked };
-  // } catch (error) {
-  //   console.error('toggleBookmark failed:', error);
-  //   return { ok: false, value: currentlyBookmarked };
-  // }
+  const token = getAccessToken();
+  if (!token) return storeToggleBookmark(postId);
+  try {
+    const endpoint = currentlyBookmarked
+      ? `${MASTODON_INSTANCE_URL}/api/v1/statuses/${postId}/unbookmark`
+      : `${MASTODON_INSTANCE_URL}/api/v1/statuses/${postId}/bookmark`;
+    const response = await axios.post(endpoint, {}, {
+      headers: { Authorization: `Bearer ${token}` },
+      timeout: REQUEST_TIMEOUT_MS,
+    });
+    return { ok: true, value: Boolean(response.data?.bookmarked) };
+  } catch (error) {
+    console.error('toggleBookmark failed:', error);
+    return { ok: false, value: currentlyBookmarked };
+  }
 }

--- a/src/utils/mastodonApi.ts
+++ b/src/utils/mastodonApi.ts
@@ -1,0 +1,65 @@
+export const MASTODON_INSTANCE_URL = (
+  process.env.NEXT_PUBLIC_MASTODON_INSTANCE_URL || 'https://beta.stacky.social'
+).replace(/\/$/, '');
+
+export const RELATED_POSTS_API_URL = (
+  process.env.NEXT_PUBLIC_RELATED_POSTS_API_URL || 'https://beta.stacky.social:3002'
+).replace(/\/$/, '');
+
+export const MASTODON_STATUS_CREATED_EVENT = 'crossweave:mastodon-status-created';
+export const MASTODON_STATUS_MAX_LENGTH = 500;
+
+export interface MastodonAccount {
+  id: string;
+  username: string;
+  acct: string;
+  display_name: string;
+  avatar: string;
+  [key: string]: unknown;
+}
+
+export interface MastodonStatus {
+  id: string;
+  content: string;
+  created_at: string;
+  account: MastodonAccount;
+  replies_count: number;
+  favourites_count: number;
+  favourited: boolean;
+  bookmarked: boolean;
+  media_attachments: Array<{ url: string }>;
+  card?: {
+    title: string;
+    description: string;
+    image?: string | null;
+    url: string;
+  } | null;
+  [key: string]: unknown;
+}
+
+export async function createMastodonStatus(
+  accessToken: string,
+  status: string,
+): Promise<MastodonStatus> {
+  const response = await fetch(`${MASTODON_INSTANCE_URL}/api/v1/statuses`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ status }),
+  });
+
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = data && typeof data.error === 'string'
+      ? data.error
+      : 'Mastodon could not publish this post.';
+    throw new Error(message);
+  }
+  return data as MastodonStatus;
+}
+
+export function publishCreatedMastodonStatus(status: MastodonStatus): void {
+  window.dispatchEvent(new CustomEvent(MASTODON_STATUS_CREATED_EVENT, { detail: status }));
+}

--- a/src/utils/mastodonPagination.d.mts
+++ b/src/utils/mastodonPagination.d.mts
@@ -1,0 +1,1 @@
+export function nextMaxIdFromLink(linkHeader: string | null | undefined): string | null;

--- a/src/utils/mastodonPagination.mjs
+++ b/src/utils/mastodonPagination.mjs
@@ -1,0 +1,18 @@
+/**
+ * Extract Mastodon's opaque next-page max_id from an RFC 8288 Link header.
+ * Returns null when the timeline has no next relation.
+ */
+export function nextMaxIdFromLink(linkHeader) {
+  if (!linkHeader || typeof linkHeader !== 'string') return null;
+  for (const part of linkHeader.split(',')) {
+    if (!/;\s*rel=(?:"next"|next)(?:;|\s|$)/i.test(part)) continue;
+    const match = part.match(/<([^>]+)>/);
+    if (!match) continue;
+    try {
+      return new URL(match[1]).searchParams.get('max_id');
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}

--- a/src/utils/mockPostResolver.ts
+++ b/src/utils/mockPostResolver.ts
@@ -3,6 +3,7 @@
 import mockData from "../app/FakeData/listy-injection.json";
 import { firstTypeRelations } from "./relationFirstType.mjs";
 import { contextualAiRewrite } from "../data/contextualAiRewrites";
+import { resolveReplyCount } from "./replyCount.mjs";
 import type {
   ListyInjectionData,
   ListyInjectionEntry,
@@ -48,7 +49,7 @@ function toMockPostType(p: FocusPostMock | RelatedPostMock, relatedStacks: any[]
     // post: synthesized ancestors (the NYT article headlines) are written with
     // replies_count 0 by the converter, but their children — the focus posts —
     // are right here in the fixture, so the headline card read "0 replies".
-    replies_count: Math.max(p.replies_count ?? 0, (childrenByParent.get(p.id) ?? []).length),
+    replies_count: getMockReplyCount(p.id),
     created_at: p.created_at,
     stackCount,
     favourites_count: p.favourites_count,
@@ -120,6 +121,15 @@ export function getMockPost(id: string): MockPostType | null {
   if (!post) return null;
   const stacks = getMockRelatedStacks(id);
   return toMockPostType(post, stacks, stacks.length || null);
+}
+
+/** Source/Mastodon count, repaired only by explicit thread edges in the fixture. */
+export function getMockReplyCount(id: string): number {
+  const post = allPostsById.get(id);
+  return resolveReplyCount(
+    post?.replies_count ?? 0,
+    (childrenByParent.get(id) ?? []).length,
+  );
 }
 
 /** Plain text of the post — for useUrlSync ?fs= hydration. */

--- a/src/utils/mockPostResolver.ts
+++ b/src/utils/mockPostResolver.ts
@@ -2,6 +2,7 @@
 
 import mockData from "../app/FakeData/listy-injection.json";
 import { firstTypeRelations } from "./relationFirstType.mjs";
+import { contextualAiRewrite } from "../data/contextualAiRewrites";
 import type {
   ListyInjectionData,
   ListyInjectionEntry,
@@ -214,7 +215,7 @@ export function getMockRelatedStacks(id: string): any[] {
             acct: p.account.acct,
           },
           content_rewritten: "",
-          rewrite: { content: p.rewrite?.content ?? p.content, significant: p.rewrite?.significant ?? false },
+          rewrite: contextualAiRewrite(id, p.id, p.content, p.rewrite),
           relations: firstTypeRelations(p.relations),
         },
       }));
@@ -237,7 +238,7 @@ export function getMockRelatedStacks(id: string): any[] {
         acct: rp.account.acct,
       },
       content_rewritten: "",
-      rewrite: { content: rp.rewrite?.content ?? rp.content, significant: rp.rewrite?.significant ?? false },
+      rewrite: contextualAiRewrite(id, rp.id, rp.content, rp.rewrite),
       relations: firstTypeRelations(rp.relations),
     },
   }));

--- a/src/utils/replyCount.d.mts
+++ b/src/utils/replyCount.d.mts
@@ -1,0 +1,5 @@
+export function resolveReplyCount(
+  sourceCount: number,
+  knownDirectReplies?: number,
+  localReplies?: number,
+): number;

--- a/src/utils/replyCount.mjs
+++ b/src/utils/replyCount.mjs
@@ -1,0 +1,15 @@
+/**
+ * Resolve the number shown beside the reply action.
+ *
+ * The backend/source count is authoritative because the demo only carries a
+ * curated subset of each conversation. Known direct thread children may repair
+ * an obviously low synthetic count, and locally-created direct replies are then
+ * added exactly once. Related-post membership is deliberately not an input.
+ */
+export function resolveReplyCount(sourceCount, knownDirectReplies = 0, localReplies = 0) {
+  const safeInteger = (value) =>
+    Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+
+  return Math.max(safeInteger(sourceCount), safeInteger(knownDirectReplies))
+    + safeInteger(localReplies);
+}

--- a/src/utils/wordDiff.d.mts
+++ b/src/utils/wordDiff.d.mts
@@ -1,2 +1,15 @@
 export type WordDiffChunk = { kind: "equal" | "insert" | "delete"; text: string };
 export function createWordDiffExcerpt(original: string, revised: string, maxTokens?: number): WordDiffChunk[];
+export type AlignedWordDiffWindow = {
+  originalText: string;
+  chunks: WordDiffChunk[];
+  originalStart: number;
+  originalEnd: number;
+  hasPrefix: boolean;
+  hasSuffix: boolean;
+};
+export function createAlignedWordDiffWindow(
+  original: string,
+  revised: string,
+  maxOriginalChars?: number,
+): AlignedWordDiffWindow;

--- a/src/utils/wordDiff.d.mts
+++ b/src/utils/wordDiff.d.mts
@@ -1,10 +1,14 @@
 export type WordDiffChunk = { kind: "equal" | "insert" | "delete"; text: string };
+export function createWordDiff(original: string, revised: string): WordDiffChunk[];
 export function createWordDiffExcerpt(original: string, revised: string, maxTokens?: number): WordDiffChunk[];
 export type AlignedWordDiffWindow = {
   originalText: string;
+  revisedText: string;
   chunks: WordDiffChunk[];
   originalStart: number;
   originalEnd: number;
+  revisedStart: number;
+  revisedEnd: number;
   hasPrefix: boolean;
   hasSuffix: boolean;
 };

--- a/src/utils/wordDiff.d.mts
+++ b/src/utils/wordDiff.d.mts
@@ -1,0 +1,2 @@
+export type WordDiffChunk = { kind: "equal" | "insert" | "delete"; text: string };
+export function createWordDiffExcerpt(original: string, revised: string, maxTokens?: number): WordDiffChunk[];

--- a/src/utils/wordDiff.mjs
+++ b/src/utils/wordDiff.mjs
@@ -1,0 +1,60 @@
+function tokenize(text) {
+  return text.match(/\s+|[\p{L}\p{N}]+(?:['’\-][\p{L}\p{N}]+)*|[^\s]/gu) ?? [];
+}
+
+function compact(parts) {
+  const chunks = [];
+  for (const part of parts) {
+    const previous = chunks[chunks.length - 1];
+    if (previous?.kind === part.kind) previous.text += part.text;
+    else chunks.push({ ...part });
+  }
+  return chunks;
+}
+
+/** Word-level LCS diff with surrounding context, suitable for a track-changes preview. */
+export function createWordDiffExcerpt(original, revised, maxTokens = 100) {
+  const before = tokenize(original);
+  const after = tokenize(revised);
+  const rows = Array.from({ length: before.length + 1 }, () => new Uint16Array(after.length + 1));
+
+  for (let i = before.length - 1; i >= 0; i--) {
+    for (let j = after.length - 1; j >= 0; j--) {
+      rows[i][j] = before[i] === after[j]
+        ? rows[i + 1][j + 1] + 1
+        : Math.max(rows[i + 1][j], rows[i][j + 1]);
+    }
+  }
+
+  const parts = [];
+  let i = 0;
+  let j = 0;
+  while (i < before.length && j < after.length) {
+    if (before[i] === after[j]) {
+      parts.push({ kind: "equal", text: before[i] });
+      i++;
+      j++;
+    } else if (rows[i + 1][j] >= rows[i][j + 1]) {
+      parts.push({ kind: "delete", text: before[i++] });
+    } else {
+      parts.push({ kind: "insert", text: after[j++] });
+    }
+  }
+  while (i < before.length) parts.push({ kind: "delete", text: before[i++] });
+  while (j < after.length) parts.push({ kind: "insert", text: after[j++] });
+
+  const firstChange = parts.findIndex((part) => part.kind !== "equal");
+  let lastChange = -1;
+  for (let index = parts.length - 1; index >= 0; index--) {
+    if (parts[index].kind !== "equal") { lastChange = index; break; }
+  }
+  if (firstChange < 0) return [{ kind: "equal", text: revised }];
+
+  const context = Math.max(12, Math.floor(maxTokens / 3));
+  const start = Math.max(0, firstChange - context);
+  const end = Math.min(parts.length, Math.max(lastChange + context + 1, start + maxTokens));
+  const excerpt = parts.slice(start, Math.min(end, start + maxTokens));
+  if (start > 0) excerpt.unshift({ kind: "equal", text: "… " });
+  if (end < parts.length || start + maxTokens < parts.length) excerpt.push({ kind: "equal", text: " …" });
+  return compact(excerpt);
+}

--- a/src/utils/wordDiff.mjs
+++ b/src/utils/wordDiff.mjs
@@ -12,8 +12,8 @@ function compact(parts) {
   return chunks;
 }
 
-/** Word-level LCS diff with surrounding context, suitable for a track-changes preview. */
-export function createWordDiffExcerpt(original, revised, maxTokens = 100) {
+/** Complete word-level LCS diff. The non-delete chunks reconstruct `revised`. */
+export function createWordDiff(original, revised) {
   const before = tokenize(original);
   const after = tokenize(revised);
   const rows = Array.from({ length: before.length + 1 }, () => new Uint16Array(after.length + 1));
@@ -43,6 +43,13 @@ export function createWordDiffExcerpt(original, revised, maxTokens = 100) {
   while (i < before.length) parts.push({ kind: "delete", text: before[i++] });
   while (j < after.length) parts.push({ kind: "insert", text: after[j++] });
 
+  return compact(parts);
+}
+
+/** Word-level LCS diff with surrounding context, suitable for a track-changes preview. */
+export function createWordDiffExcerpt(original, revised, maxTokens = 100) {
+  const parts = createWordDiff(original, revised);
+
   const firstChange = parts.findIndex((part) => part.kind !== "equal");
   let lastChange = -1;
   for (let index = parts.length - 1; index >= 0; index--) {
@@ -69,9 +76,12 @@ export function createAlignedWordDiffWindow(original, revised, maxOriginalChars 
     const originalEnd = Math.min(original.length, maxOriginalChars);
     return {
       originalText: original.slice(0, originalEnd),
+      revisedText: revised.slice(0, originalEnd),
       chunks: [{ kind: "equal", text: revised.slice(0, originalEnd) }],
       originalStart: 0,
       originalEnd,
+      revisedStart: 0,
+      revisedEnd: originalEnd,
       hasPrefix: false,
       hasSuffix: originalEnd < original.length,
     };
@@ -119,9 +129,12 @@ export function createAlignedWordDiffWindow(original, revised, maxOriginalChars 
 
   return {
     originalText,
+    revisedText,
     chunks: createWordDiffExcerpt(originalText, revisedText, tokenBudget),
     originalStart,
     originalEnd,
+    revisedStart,
+    revisedEnd,
     hasPrefix: originalStart > 0,
     hasSuffix: originalEnd < original.length,
   };

--- a/src/utils/wordDiff.mjs
+++ b/src/utils/wordDiff.mjs
@@ -58,3 +58,71 @@ export function createWordDiffExcerpt(original, revised, maxTokens = 100) {
   if (end < parts.length || start + maxTokens < parts.length) excerpt.push({ kind: "equal", text: " …" });
   return compact(excerpt);
 }
+
+/**
+ * Returns original and tracked-edit slices covering the same semantic window.
+ * Deleted text remains in the tracked layer and insertions are additive, so the
+ * tracked layer can never contain less reading material than the original.
+ */
+export function createAlignedWordDiffWindow(original, revised, maxOriginalChars = 280) {
+  if (original === revised) {
+    const originalEnd = Math.min(original.length, maxOriginalChars);
+    return {
+      originalText: original.slice(0, originalEnd),
+      chunks: [{ kind: "equal", text: revised.slice(0, originalEnd) }],
+      originalStart: 0,
+      originalEnd,
+      hasPrefix: false,
+      hasSuffix: originalEnd < original.length,
+    };
+  }
+
+  let changeStart = 0;
+  while (
+    changeStart < original.length
+    && changeStart < revised.length
+    && original[changeStart] === revised[changeStart]
+  ) changeStart++;
+
+  let sharedSuffix = 0;
+  while (
+    sharedSuffix < original.length - changeStart
+    && sharedSuffix < revised.length - changeStart
+    && original[original.length - sharedSuffix - 1] === revised[revised.length - sharedSuffix - 1]
+  ) sharedSuffix++;
+
+  const originalChangeEnd = original.length - sharedSuffix;
+  const revisedChangeEnd = revised.length - sharedSuffix;
+  const changedOriginalChars = Math.max(0, originalChangeEnd - changeStart);
+  const contextBudget = Math.max(0, maxOriginalChars - changedOriginalChars);
+  let originalStart = Math.max(0, changeStart - Math.floor(contextBudget / 3));
+  let originalEnd = Math.min(
+    original.length,
+    Math.max(originalChangeEnd, originalStart + maxOriginalChars),
+  );
+
+  if (originalEnd - originalStart < maxOriginalChars && originalStart > 0) {
+    originalStart = Math.max(0, originalEnd - maxOriginalChars);
+  }
+
+  // The window begins in the unchanged prefix and ends in the unchanged
+  // suffix. Shift its revised end by the edit delta to preserve the same
+  // semantic endpoint rather than cutting the new text short.
+  const revisedStart = originalStart;
+  const revisedEnd = Math.min(
+    revised.length,
+    originalEnd + (revisedChangeEnd - originalChangeEnd),
+  );
+  const originalText = original.slice(originalStart, originalEnd);
+  const revisedText = revised.slice(revisedStart, revisedEnd);
+  const tokenBudget = Math.max(100, (originalText.length + revisedText.length) * 2);
+
+  return {
+    originalText,
+    chunks: createWordDiffExcerpt(originalText, revisedText, tokenBudget),
+    originalStart,
+    originalEnd,
+    hasPrefix: originalStart > 0,
+    hasSuffix: originalEnd < original.length,
+  };
+}

--- a/tests/unit/cursorPagination.test.mjs
+++ b/tests/unit/cursorPagination.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { decodeCursor, paginateByCursor } from "../../src/utils/cursorPagination.mjs";
+
+const items = ["a", "b", "c", "d", "e"].map((id) => ({ id }));
+
+test("cursor pagination returns stable keyset pages without duplicates", () => {
+  const first = paginateByCursor(items, { limit: 2, idOf: (item) => item.id });
+  const second = paginateByCursor(items, { cursor: first.nextCursor, limit: 2, idOf: (item) => item.id });
+  const third = paginateByCursor(items, { cursor: second.nextCursor, limit: 2, idOf: (item) => item.id });
+
+  assert.deepEqual(first.items.map((item) => item.id), ["a", "b"]);
+  assert.deepEqual(second.items.map((item) => item.id), ["c", "d"]);
+  assert.deepEqual(third.items.map((item) => item.id), ["e"]);
+  assert.equal(third.nextCursor, null);
+  assert.equal(decodeCursor(first.nextCursor), "b");
+});
+
+test("cursor pagination rejects malformed and stale cursors", () => {
+  assert.throws(
+    () => paginateByCursor(items, { cursor: "not-a-cursor", limit: 2, idOf: (item) => item.id }),
+    /Invalid pagination cursor/,
+  );
+});

--- a/tests/unit/mastodonPagination.test.mjs
+++ b/tests/unit/mastodonPagination.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { nextMaxIdFromLink } from '../../src/utils/mastodonPagination.mjs';
+
+test('reads the next Mastodon max_id without confusing it with the previous page', () => {
+  const link = '<https://beta.stacky.social/api/v1/timelines/home?max_id=101>; rel="next", '
+    + '<https://beta.stacky.social/api/v1/timelines/home?min_id=202>; rel="prev"';
+  assert.equal(nextMaxIdFromLink(link), '101');
+});
+
+test('treats a missing next relation as the end of the timeline', () => {
+  assert.equal(nextMaxIdFromLink('<https://example.test?min_id=202>; rel="prev"'), null);
+  assert.equal(nextMaxIdFromLink(undefined), null);
+  assert.equal(nextMaxIdFromLink('not a link header'), null);
+});

--- a/tests/unit/replyCount.test.mjs
+++ b/tests/unit/replyCount.test.mjs
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveReplyCount } from "../../src/utils/replyCount.mjs";
+
+test("keeps the authoritative source count when the curated thread is partial", () => {
+  assert.equal(resolveReplyCount(20, 4), 20);
+});
+
+test("repairs a synthetic source count when more direct replies are known", () => {
+  assert.equal(resolveReplyCount(0, 2), 2);
+});
+
+test("adds each local direct reply once", () => {
+  assert.equal(resolveReplyCount(20, 4, 1), 21);
+  assert.equal(resolveReplyCount(20, 4, 2), 22);
+});
+
+test("normalizes invalid and negative counts", () => {
+  assert.equal(resolveReplyCount(Number.NaN, -3, 1), 1);
+});

--- a/tests/unit/wordDiff.test.mjs
+++ b/tests/unit/wordDiff.test.mjs
@@ -1,6 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createAlignedWordDiffWindow, createWordDiffExcerpt } from "../../src/utils/wordDiff.mjs";
+import { createAlignedWordDiffWindow, createWordDiff, createWordDiffExcerpt } from "../../src/utils/wordDiff.mjs";
+
+test("complete diff reconstructs both original and edited text", () => {
+  const original = "The old wording stays concise.";
+  const revised = "The clearer AI wording stays concise.";
+  const diff = createWordDiff(original, revised);
+  assert.equal(diff.filter((chunk) => chunk.kind !== "insert").map((chunk) => chunk.text).join(""), original);
+  assert.equal(diff.filter((chunk) => chunk.kind !== "delete").map((chunk) => chunk.text).join(""), revised);
+});
 
 test("word diff exposes inserted and removed language", () => {
   const diff = createWordDiffExcerpt(

--- a/tests/unit/wordDiff.test.mjs
+++ b/tests/unit/wordDiff.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createWordDiffExcerpt } from "../../src/utils/wordDiff.mjs";
+
+test("word diff exposes inserted and removed language", () => {
+  const diff = createWordDiffExcerpt(
+    "This supports new science.",
+    "In the EV context, this supports engineering progress.",
+  );
+
+  assert.ok(diff.some((chunk) => chunk.kind === "delete" && chunk.text.includes("new")));
+  assert.ok(diff.some((chunk) => chunk.kind === "insert" && chunk.text.includes("engineering")));
+});
+
+test("word diff preserves unchanged text", () => {
+  assert.deepEqual(createWordDiffExcerpt("No changes", "No changes"), [
+    { kind: "equal", text: "No changes" },
+  ]);
+});

--- a/tests/unit/wordDiff.test.mjs
+++ b/tests/unit/wordDiff.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createWordDiffExcerpt } from "../../src/utils/wordDiff.mjs";
+import { createAlignedWordDiffWindow, createWordDiffExcerpt } from "../../src/utils/wordDiff.mjs";
 
 test("word diff exposes inserted and removed language", () => {
   const diff = createWordDiffExcerpt(
@@ -16,4 +16,28 @@ test("word diff preserves unchanged text", () => {
   assert.deepEqual(createWordDiffExcerpt("No changes", "No changes"), [
     { kind: "equal", text: "No changes" },
   ]);
+});
+
+test("aligned diff keeps the same semantic text window and enough context", () => {
+  const original = "I am glad to see a long form article on this topic. "
+    + "I feel that the collective strategic decision by American automakers will shape the market. "
+    + "Battery technology will keep improving over the next decade.";
+  const revised = "On U.S. automakers falling behind China's EV industry, "
+    + original.replace("long form", "long-form");
+  const window = createAlignedWordDiffWindow(original, revised, 120);
+  const trackedOriginal = window.chunks
+    .filter((chunk) => chunk.kind !== "insert")
+    .map((chunk) => chunk.text)
+    .join("");
+  const trackedRevised = window.chunks
+    .filter((chunk) => chunk.kind !== "delete")
+    .map((chunk) => chunk.text)
+    .join("");
+
+  assert.equal(window.originalText, original.slice(window.originalStart, window.originalEnd));
+  assert.equal(trackedOriginal, window.originalText);
+  assert.ok(trackedRevised.startsWith("On U.S. automakers"));
+  assert.ok(window.chunks.some((chunk) => chunk.kind === "delete"));
+  assert.ok(window.chunks.some((chunk) => chunk.kind === "insert"));
+  assert.ok(trackedOriginal.length >= 120);
 });


### PR DESCRIPTION
## Summary
- route the Chinese EV demo through a typed simulated API with delay, cursor pagination, request deduplication, caching, skeletons, retries, and near-viewport prefetching
- show contextual AI-edited wording as the compact card's default, then reveal green additions and red struck deletions in place on badge hover/focus; Michael's demo now includes a contextual addition, two replacements, and a standalone removal while full posts remain canonical and card geometry stays fixed
- redesign account entry around Stacky sign-in, account creation, and an explicit no-account JSON demo
- use one compact icon-only Log out action for both Mastodon accounts and JSON-demo participants while preserving each mode's cleanup behavior
- move OAuth code exchange and token revocation behind same-origin server routes with state validation and a server-only client-secret migration path
- load authenticated home, liked, and bookmark feeds from Mastodon; publish posts and persist likes/bookmarks to Mastodon while retaining the local demo path
- blend explicitly followed JSON focus posts into authenticated Home, preserve their related-post panels and local interactions, and match the demo feed's cream card gutters until the curated corpus is imported into Mastodon
- refresh read-only demo relations, annotations, and AI rewrites from the latest fixture for existing sessions without discarding participant likes, bookmarks, follows, or authored posts
- keep Mastodon/source reply totals authoritative, repair only counts disproved by explicit direct thread children, add local replies exactly once, and never fold related-post membership into comment totals
- parse Mastodon Link cursors, prevent duplicate pagination requests, render timelines before optional relation hydration, and resolve missing relations to a stable empty panel
- document the Mastodon fork audit, live-backend migration path, curated import safeguards, and a formative usability study

## Verification
- `pnpm test:unit` (110 passed)
- `pnpm lint` (passes with pre-existing warnings)
- `pnpm build`
- 17 affected Playwright scenarios passed in focused Chromium runs, including OAuth callback, JSON fallback, authenticated demo follows, live-feed loading, post creation, pagination, likes, bookmarks, and local study flows
- live browser handoff verified against `beta.stacky.social/auth/sign_in` and `/auth/sign_up`
- desktop and 390px mobile visual/usability review; mobile sign-in is visible in the first viewport, edited wording is visible before hover, and Michael's measured AI card remains exactly 343.42 × 353.95 px while three green insertions and three red struck deletions are revealed
- focused header review confirmed the icon-only Log out control has no visible text, retains a 34 × 34 px target and accessible name, and clears local study state correctly
- 9 focused Home/local Playwright scenarios passed, including stale persisted-count repair and a local reply that increments once and remains correct after reload
- live Home audit confirmed Ana's source total remains 20 despite four curated thread descendants and 103 related posts; related cards retain independent reply totals and the browser console is clean
- full-suite audit exposed existing timing-sensitive failures in unrelated highlight/navigation stress specs under five-worker contention; affected backend and study flows pass serially

No backend files were changed.
